### PR TITLE
Prohibit duplicates in gs.DETS and during event bundling

### DIFF
--- a/bluesky/global_state.py
+++ b/bluesky/global_state.py
@@ -58,8 +58,10 @@ class ReadableList(TraitType):
                 validate_readable(det)
             except TypeError:
                 self.error(obj, value)
+        # Read the scary line below as "flatten data key names"
+        data_keys = list(itertools.chain.from_iterable(
+                             [list(det.describe().keys()) for det in value]))
         # The data keys taken together must be unique.
-        data_keys = itertools.chain([obj.describe() for det in value])
         if len(set(data_keys)) < len(data_keys):
             self.error(obj, value)
         return value

--- a/bluesky/global_state.py
+++ b/bluesky/global_state.py
@@ -3,6 +3,7 @@ This module creates a singleton object to store settings such as which
 RunEngine and detectors the simple scan interface should invoke.
 """
 from traitlets import HasTraits, TraitType, Unicode, List, Float
+import itertools
 from collections import Iterable
 from bluesky.run_engine import RunEngine
 
@@ -57,6 +58,10 @@ class ReadableList(TraitType):
                 validate_readable(det)
             except TypeError:
                 self.error(obj, value)
+        # The data keys taken together must be unique.
+        data_keys = itertools.chain([obj.describe() for det in value])
+        if len(set(data_keys)) < len(data_keys):
+            self.error(obj, value)
         return value
 
 

--- a/bluesky/global_state.py
+++ b/bluesky/global_state.py
@@ -18,7 +18,7 @@ class RunEngineTraitType(TraitType):
 
     def validate(self, obj, value):
         if not isinstance(value, RunEngine):
-            self.error(obj, vluae)
+            self.error(obj, value)
         return value
 
 
@@ -28,7 +28,7 @@ class Readable(TraitType):
 
     def validate(self, obj, value):
         try:
-            validate_detector(value)
+            validate_readable(value)
         except TypeError:
             self.error(obj, value)
         return value
@@ -45,7 +45,7 @@ class Movable(TraitType):
         return value
 
 
-class DetectorList(TraitType):
+class ReadableList(TraitType):
 
     info_text = 'a list or iterable of Readable (detector-like) objects'
 
@@ -54,21 +54,22 @@ class DetectorList(TraitType):
             self.error(obj, value)
         for det in value:
             try:
-                validate_detector(det)
+                validate_readable(det)
             except TypeError:
                 self.error(obj, value)
         return value
 
 
-def validate_detector(det):
+def validate_readable(det):
     if isinstance(det, str):
         raise TypeError("{0} is a string, not a Readable object "
                         "(Do not use quotes)".format(det))
     required_methods = ['read', 'trigger']
     for method in required_methods:
         if not hasattr(det, method):
-            raise TypeError("{0} is not a detector; it does not have "
-                            "a '{1}' method'".format(det, method))
+            raise TypeError("{0} is not a Readable (detector-like) object; "
+                            "it does not have a "
+                            "'{1}' method'".format(det, method))
 
 
 def validate_movable(movable):
@@ -78,14 +79,15 @@ def validate_movable(movable):
     required_methods = ['read', 'set']
     for method in required_methods:
         if not hasattr(movable, method):
-            raise TypeError("{0} is not a Movable; it does not have "
+            raise TypeError("{0} is not a Movable (positioner-like) object; "
+                            "it does not have "
                             "a '{1}' method'".format(det, method))
 
 
 class GlobalState(HasTraits):
     "A bucket of validated global state used by the simple scan API"
     RE = RunEngineTraitType()
-    DETS = DetectorList()
+    DETS = ReadableList()
     MASTER_DET = Readable()
     MASTER_DET_FIELD = Unicode()
     H_MOTOR = Readable()

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -739,7 +739,7 @@ class RunEngine:
             keys = data_keys.keys()  # that is, field names
             for known_obj, known_data_keys in self._describe_cache.items():
                 known_keys = known_data_keys.keys()  # that is, field names
-                if len(set(known_keys) & set(keys)) > 0:
+                if set(known_keys) & set(keys):
                     raise ValueError("Data keys (field names) from {0!r} "
                                      "collide with those from {1!r}"
                                      "".format(obj, known_obj))

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -742,7 +742,7 @@ class RunEngine:
                 if len(set(known_keys) & set(keys)) > 0:
                     raise ValueError("Data keys (field names) from {0!r} "
                                      "collide with those from {1!r}"
-                                     "".format(obj, old_obj))
+                                     "".format(obj, known_obj))
             self._describe_cache[obj] = data_keys
         ret = obj.read(*msg.args, **msg.kwargs)
         self._read_cache.append(ret)

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -734,7 +734,16 @@ class RunEngine:
         obj = msg.obj
         self._objs_read.append(obj)
         if obj not in self._describe_cache:
-            self._describe_cache[obj] = obj.describe()
+            # Validate that there is no data key name collision.
+            data_keys = obj.describe()
+            keys = data_keys.keys()  # that is, field names
+            for known_obj, known_data_keys in self._describe_cache.items():
+                known_keys = known_data_keys.keys()  # that is, field names
+                if len(set(known_keys) & set(keys)) > 0:
+                    raise ValueError("Data keys (field names) from {0!r} "
+                                     "collide with those from {1!r}"
+                                     "".format(obj, old_obj))
+            self._describe_cache[obj] = data_keys
         ret = obj.read(*msg.args, **msg.kwargs)
         self._read_cache.append(ret)
         return ret

--- a/bluesky/tests/test_simple_api.py
+++ b/bluesky/tests/test_simple_api.py
@@ -1,12 +1,15 @@
+from nose.tools import assert_raises
+from traitlets import TraitError
 from bluesky.global_state import gs
 from bluesky.examples import motor, motor1, motor2, det
 from bluesky.spec_api import (ct, ascan, a2scan, a3scan, dscan, d2scan, d3scan,
                               mesh, tscan, dtscan, th2th)
-                             
 
 
 def test_basic_usage():
     gs.DETS = [det]
+    with assert_raises(TraitError):
+        gs.DETS = [det, det]  # no duplicate data keys
     gs.TEMP_CONTROLLER = motor
     gs.TH_MOTOR = motor1
     gs.TTH_MOTOR = motor2


### PR DESCRIPTION
We can do this elsewhere as well (in the RunEngine, perhaps also in the scan `detectors` setters) but this is a start.