### PR TITLE
API: LivePlot will use current fig, axes by default.

### DIFF
--- a/bluesky/callbacks.py
+++ b/bluesky/callbacks.py
@@ -150,7 +150,7 @@ class LivePlot(CallbackBase):
     def __init__(self, y, x=None, legend_keys=None, xlim=None, ylim=None,
                  **kwargs):
         super().__init__()
-        fig, ax = plt.subplots()
+        fig, ax = plt.gcf(), plt.gca()
         if legend_keys is None:
             legend_keys = []
         self.legend_keys = ['scan_id'] + legend_keys


### PR DESCRIPTION
The old behavior was creating a new figure for each scan. The new behavior is using matplotlib's "current figure." Either behavior has disadvantages, but this choice makes it *possible* to plot multiple scans together. And of course it is still possible to plot scans separately -- just create a new figure in matplotlib.

Recall that we used to do it this way, which is why we show a legend with the scan ID.

The biggest downside with this new approach is that scans with different quantities with different dimensions can end up plotted together if users fail to create a fresh figure. But trying to be heuristically guess when users should have created a new figure sounds really hard to do simply or with reliable correctness.