### PR TITLE
WIP: serving Documents over sockets

### DIFF
--- a/bluesky/broker_callbacks.py
+++ b/bluesky/broker_callbacks.py
@@ -69,7 +69,7 @@ def post_run(callback):
     |         1  |  14:02:32.099807  |          5.00  |          1.00  |
     +------------+-------------------+----------------+----------------+
     """
-    def f(stop_doc):
+    def f(name, stop_doc):
         uid = stop_doc['run_start']
         start, = find_run_starts(uid=uid)
         descriptors = find_event_descriptors(run_start=uid)

--- a/bluesky/callbacks.py
+++ b/bluesky/callbacks.py
@@ -50,11 +50,9 @@ class CallbackBase(object):
     def __init__(self):
         super().__init__()
 
-    def __call__(self, doc):
-        """Inspect the document, infer its type, and dispatch it."""
-        doc_name = doc_type(doc)
-        doc_func = getattr(self, doc_name)
-        doc_func(doc)
+    def __call__(self, name, doc):
+        "Dispatch to methods expecting particular doc types."
+        return getattr(self, name)(doc)
 
     def event(self, doc):
         logger.debug("CallbackBase: I'm an event with doc = {}".format(doc))
@@ -76,11 +74,11 @@ class CallbackCounter:
         self.counter = count()
         self(None)  # Start counting at 1.
 
-    def __call__(self, doc):
+    def __call__(self, name, doc):
         self.value = next(self.counter)
 
 
-def print_metadata(doc):
+def print_metadata(name, doc):
     "Print all fields except uid and time."
     for field, value in sorted(doc.items()):
         # uid is returned by the RunEngine, and time is self-evident
@@ -107,7 +105,7 @@ def collector(field, output):
     func : function
         expects one argument, an Event dictionary
     """
-    def f(event):
+    def f(name, event):
         output.append(event['data'][field])
 
     return f

--- a/bluesky/doc_server.py
+++ b/bluesky/doc_server.py
@@ -1,0 +1,32 @@
+from jsonsocket import Client, Server
+from bluesky.run_engine import Dispatcher
+
+
+class DocumentClient:
+
+    def __init__(self, host, port):
+        self.client = Client()
+        self.client.connect(host, port)
+        self.dispatcher = Dispatcher()
+        self.subscribe = self.dispatcher.subscribe
+
+    def __call__(self):
+        while True:
+            response = self.client.recv()
+            (name, doc), = response.items()
+            self.dispatcher.process(name, doc)
+
+    def __del__(self):
+        self.client.close()
+
+
+class DocumentServer:
+
+    def __init__(self, host, port):
+        self.server = Server()
+
+    def __call__(self, name, doc):
+        self.server.send({name: doc})
+
+    def __del__(self):
+        self.server.close()

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -986,7 +986,7 @@ class RunEngine:
     def emit(self, name, doc):
         "Process blocking callbacks and schedule non-blocking callbacks."
         jsonschema.validate(doc, schemas[name])
-        self._scan_cb_registry.process(name, doc)
+        self._scan_cb_registry.process(name, name, doc)
         if name != DocumentNames.event:
             self.dispatcher.process(name, doc)
             logger.info("Emitting %s document: %r", name.name, doc)
@@ -1011,7 +1011,7 @@ class Dispatcher:
         self._token_mapping = dict()
 
     def process(self, name, doc):
-        self.cb_registry.process(name, doc)
+        self.cb_registry.process(name, name, doc)
 
     def subscribe(self, name, func):
         """

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -61,7 +61,7 @@ def test_subscribe_msg():
 
 
 def test_unknown_cb_raises():
-    def f(doc):
+    def f(name, doc):
         pass
     # Dispatches catches this case.
     assert_raises(KeyError, RE.subscribe, 'not a thing', f)

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -161,7 +161,7 @@ def test_simple_scan_saving():
     yield run, simple_scan_saving, det, motor
 
 
-def print_event_time(doc):
+def print_event_time(name, doc):
     print('===== EVENT TIME:', doc['time'], '=====')
 
 
@@ -240,14 +240,14 @@ def _md(md):
 
 
 def validate_dict_cb(key, val):
-    def callback(doc):
+    def callback(name, doc):
         assert_in(key, doc)
         assert_equal(doc[key], val)
     return callback
 
 
 def validate_dict_cb_opposite(key):
-    def callback(doc):
+    def callback(name, doc):
         assert_not_in(key, doc)
     return callback
 
@@ -412,7 +412,7 @@ def test_seqnum_nonrepeated():
 
     seq_nums = []
 
-    def f(doc):
+    def f(name, doc):
         seq_nums.append(doc['seq_num'])
 
     RE(gen(), {'event': f})


### PR DESCRIPTION
This allows any of our callbacks to run on a separate machine, receiving a stream of Documents via a socket.

This is very much a work in progress, shared prematurely so that @ericdill can take a look. It relies on [my python-3-compatible branch on jsonsocket](https://github.com/danielballan/jsonsocket/tree/py3-compat).