### PR TITLE
FIX: Store the repr of each scan arg, not the object itself.

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -478,7 +478,7 @@ class RunEngine:
         if hasattr(plan, '_fields'):
             scan_args = {}
             for field in plan._fields:
-                scan_args[field] = getattr(plan, field)
+                scan_args[field] = repr(getattr(plan, field))
             metadata['scan_args'] = scan_args
 
         self._metadata_per_call = metadata


### PR DESCRIPTION
Bug caught today at HXN, when `register_mds` tried to call `copy.deepcopy` on an `EpicsMotor` instance. It should be been the repr of of that instance.