### PR TITLE
API: Expose doc names as strings, not enum values.

### DIFF
--- a/bluesky/callbacks.py
+++ b/bluesky/callbacks.py
@@ -71,7 +71,7 @@ class CallbackCounter:
     # Wrap itertools.count in something we can use as a callback.
     def __init__(self):
         self.counter = count()
-        self(None)  # Start counting at 1.
+        self(None, 'start')  # Start counting at 1.
 
     def __call__(self, name, doc):
         self.value = next(self.counter)

--- a/bluesky/callbacks.py
+++ b/bluesky/callbacks.py
@@ -71,7 +71,7 @@ class CallbackCounter:
     # Wrap itertools.count in something we can use as a callback.
     def __init__(self):
         self.counter = count()
-        self(None, 'start')  # Start counting at 1.
+        self(None, {})  # Pass a fake doc to prime the counter (start at 1).
 
     def __call__(self, name, doc):
         self.value = next(self.counter)

--- a/bluesky/callbacks.py
+++ b/bluesky/callbacks.py
@@ -51,7 +51,7 @@ class CallbackBase(object):
 
     def __call__(self, name, doc):
         "Dispatch to methods expecting particular doc types."
-        return getattr(self, name.name)(doc)
+        return getattr(self, name)(doc)
 
     def event(self, doc):
         logger.debug("CallbackBase: I'm an event with doc = {}".format(doc))

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1020,7 +1020,7 @@ class Dispatcher:
         self._token_mapping = dict()
 
     def process(self, name, doc):
-        self.cb_registry.process(name, name, doc)
+        self.cb_registry.process(name, name.name, doc)
 
     def subscribe(self, name, func):
         """

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -170,6 +170,8 @@ class RunEngine:
             skipped
         logbook
             callable accepting a message and an optional dict
+        ignore_callback_exceptions
+            boolean, True by default
 
         Methods
         -------
@@ -244,6 +246,7 @@ class RunEngine:
 
         # public dispatcher for callbacks processed on the main thread
         self.dispatcher = Dispatcher()
+        self.ignore_callback_exceptions = True
         self.event_timeout = 0.1
         self.subscribe = self.dispatcher.subscribe
         self.unsubscribe = self.dispatcher.unsubscribe
@@ -294,6 +297,14 @@ class RunEngine:
     @property
     def resumable(self):
         return self._msg_cache is not None
+
+    @property
+    def ignore_callback_exceptions(self):
+        return not self.dispatcher.halt_on_exception
+
+    @ignore_callback_exceptions.setter
+    def ignore_callback_exceptions(self, val):
+        self.dispatcher.halt_on_exception = not val
 
     def register_command(self, name, func):
         """
@@ -1015,7 +1026,7 @@ class Dispatcher:
 
     def __init__(self):
         self.cb_registry = CallbackRegistry(allowed_sigs=DocumentNames,
-                                            halt_on_exception=True)
+                                            halt_on_exception=False)
         self._counter = count()
         self._token_mapping = dict()
 

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -995,7 +995,7 @@ class RunEngine:
     def emit(self, name, doc):
         "Process blocking callbacks and schedule non-blocking callbacks."
         jsonschema.validate(doc, schemas[name])
-        self._scan_cb_registry.process(name, name, doc)
+        self._scan_cb_registry.process(name, name.name, doc)
         if name != DocumentNames.event:
             self.dispatcher.process(name, doc)
             logger.info("Emitting %s document: %r", name.name, doc)

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -12,7 +12,7 @@ import tempfile
 RE = setup_test_run_engine()
 
 
-def exception_raiser(doc):
+def exception_raiser(name, doc):
     raise Exception("Hey look it's an exception that better not kill the "
                     "scan!!")
 

--- a/bluesky/tests/test_documents.py
+++ b/bluesky/tests/test_documents.py
@@ -8,7 +8,7 @@ RE = setup_test_run_engine()
 
 
 def test_custom_metadata():
-    def assert_lion(doc):
+    def assert_lion(name, doc):
         assert_in('animal', doc)
         assert_equal(doc['animal'], 'lion')
 

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -288,7 +288,7 @@ def test_suspend():
 
     out = []
 
-    def ev_cb(ev):
+    def ev_cb(name, ev):
         out.append(ev)
     # trigger the suspend right after the check point
     loop.call_later(.1, local_suspend)

--- a/bluesky/tests/test_scans.py
+++ b/bluesky/tests/test_scans.py
@@ -31,7 +31,7 @@ def traj_checker(scan, expected_traj):
 def multi_traj_checker(scan, expected_data):
     actual_data = []
 
-    def collect_data(event):
+    def collect_data(name, event):
         actual_data.append(event['data'])
 
     RE(scan, subs={'event': collect_data})


### PR DESCRIPTION
Internally, we pass around document names (start, stop, event, descriptor) as values of an Enum, `DocumentTypes`. This is for strictness and probably a minor performance boost. But we should not expose this to the users via subscriptions; we should expose the string names.