### PR TITLE
ENH: mds bulk events integration

### DIFF
--- a/bluesky/callbacks.py
+++ b/bluesky/callbacks.py
@@ -54,16 +54,19 @@ class CallbackBase(object):
         return getattr(self, name)(doc)
 
     def event(self, doc):
-        logger.debug("CallbackBase: I'm an event with doc = {}".format(doc))
+        logger.debug("CallbackBase: I'm an event with doc = %r", doc)
+
+    def bulk_events(self, doc):
+        logger.debug("CallbackBase: I'm an event with a big doc")
 
     def descriptor(self, doc):
-        logger.debug("CallbackBase: I'm a descriptor with doc = {}".format(doc))
+        logger.debug("CallbackBase: I'm a descriptor with doc = %r", doc)
 
     def start(self, doc):
-        logger.debug("CallbackBase: I'm a start with doc = {}".format(doc))
+        logger.debug("CallbackBase: I'm a start with doc = %r", doc)
 
     def stop(self, doc):
-        logger.debug("CallbackBase: I'm a stop with doc = {}".format(doc))
+        logger.debug("CallbackBase: I'm a stop with doc = %r", doc)
 
 
 class CallbackCounter:

--- a/bluesky/register_mds.py
+++ b/bluesky/register_mds.py
@@ -20,7 +20,7 @@ known_run_start_keys = ['time', 'scan_id', 'beamline_id', 'uid', 'owner',
                         'group', 'project']
 
 
-def _insert_runstart(name, doc):
+def _insert_run_start(name, doc):
     """Add a beamline config that, for now, only knows the time."""
     # Move dynamic keys into 'custom' for MDS API.
     # We should change this in MDS to save the time of copying here:
@@ -32,7 +32,7 @@ def _insert_runstart(name, doc):
             except KeyError:
                 doc['custom'] = {}
             doc['custom'][key] = doc.pop(key)
-    return mds.insert_runstart(**doc)
+    return mds.insert_run_start(**doc)
 
 
 def _insert_bulk_events(name, doc):
@@ -45,8 +45,8 @@ insert_funcs = {DocumentNames.event: _make_insert_func(mds.insert_event),
                 DocumentNames.bulk_events: _insert_bulk_events,
                 DocumentNames.descriptor: _make_insert_func(
                     mds.insert_descriptor),
-                DocumentNames.start: _insert_runstart,  # see above
-                DocumentNames.stop: _make_insert_func(mds.insert_runstop)}
+                DocumentNames.start: _insert_run_start,  # see above
+                DocumentNames.stop: _make_insert_func(mds.insert_run_stop)}
 
 
 def register_mds(runengine):

--- a/bluesky/register_mds.py
+++ b/bluesky/register_mds.py
@@ -1,14 +1,11 @@
 import metadatastore.api as mds
+from metadatastore.commands import bulk_insert_events
 import copy
 import time as ttime
 from bluesky.run_engine import DocumentNames
 
 
 __all__ = ['register_mds']
-
-
-def _make_blc():
-    return mds.insert_beamline_config({}, time=ttime.time())
 
 
 # For why this function is necessary, see
@@ -19,13 +16,12 @@ def _make_insert_func(func):
     return inserter
 
 
-known_run_start_keys = ['time', 'scan_id', 'beamline_id', 'beamline_config',
-                        'uid', 'owner', 'group', 'project']
+known_run_start_keys = ['time', 'scan_id', 'beamline_id', 'uid', 'owner',
+                        'group', 'project']
 
 
 def _insert_run_start(name, doc):
-    "Add a beamline config that, for now, only knows the time."
-    doc['beamline_config'] = _make_blc()
+    """Add a beamline config that, for now, only knows the time."""
     # Move dynamic keys into 'custom' for MDS API.
     # We should change this in MDS to save the time of copying here:
     doc = copy.deepcopy(doc)
@@ -39,7 +35,14 @@ def _insert_run_start(name, doc):
     return mds.insert_run_start(**doc)
 
 
+def _insert_bulk_events(name, doc):
+    "Add a beamline config that, for now, only knows the time."
+    for desc_uid, events in doc.items():
+        bulk_insert_events(desc_uid, events)
+
+
 insert_funcs = {DocumentNames.event: _make_insert_func(mds.insert_event),
+                DocumentNames.bulk_events: _insert_bulk_events,
                 DocumentNames.descriptor: _make_insert_func(
                     mds.insert_event_descriptor),
                 DocumentNames.start: _insert_run_start,  # see above

--- a/bluesky/register_mds.py
+++ b/bluesky/register_mds.py
@@ -20,7 +20,7 @@ known_run_start_keys = ['time', 'scan_id', 'beamline_id', 'uid', 'owner',
                         'group', 'project']
 
 
-def _insert_run_start(name, doc):
+def _insert_runstart(name, doc):
     """Add a beamline config that, for now, only knows the time."""
     # Move dynamic keys into 'custom' for MDS API.
     # We should change this in MDS to save the time of copying here:
@@ -32,7 +32,7 @@ def _insert_run_start(name, doc):
             except KeyError:
                 doc['custom'] = {}
             doc['custom'][key] = doc.pop(key)
-    return mds.insert_run_start(**doc)
+    return mds.insert_runstart(**doc)
 
 
 def _insert_bulk_events(name, doc):
@@ -44,9 +44,9 @@ def _insert_bulk_events(name, doc):
 insert_funcs = {DocumentNames.event: _make_insert_func(mds.insert_event),
                 DocumentNames.bulk_events: _insert_bulk_events,
                 DocumentNames.descriptor: _make_insert_func(
-                    mds.insert_event_descriptor),
-                DocumentNames.start: _insert_run_start,  # see above
-                DocumentNames.stop: _make_insert_func(mds.insert_run_stop)}
+                    mds.insert_descriptor),
+                DocumentNames.start: _insert_runstart,  # see above
+                DocumentNames.stop: _make_insert_func(mds.insert_runstop)}
 
 
 def register_mds(runengine):

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -886,7 +886,6 @@ class RunEngine:
 
             bulk_data[descriptor_uid] = []
 
-        emit_events = msg.kwargs.pop('emit_events', False)
         for ev in obj.collect():
             objs_read = frozenset(ev['data'])
             seq_num = next(self._sequence_counters[objs_read])
@@ -902,9 +901,6 @@ class RunEngine:
             ev['uid'] = event_uid
 
             bulk_data[descriptor_uid].append(ev)
-            if emit_events:
-                yield from self.emit(DocumentNames.event, ev)
-                self.debug("Emitted Event:\n%s" % ev)
 
         yield from self.emit(DocumentNames.bulk_events, bulk_data)
         self.debug("Emitted bulk events")

--- a/bluesky/schema/bulk_events.json
+++ b/bluesky/schema/bulk_events.json
@@ -1,0 +1,49 @@
+{
+    "patternProperties": {
+        "^.*$": {
+            "type": "array",
+            "items": {
+                "type": "object",
+
+                "properties": {
+                    "data": {
+                        "type": "object",
+                        "description": "The actual measument data"
+                    },
+                    "timestamps": {
+                        "type": "object",
+                        "description": "The timestamps of the individual measument data"
+                    },
+                    "descriptor": {
+                        "type": "string",
+                        "description": "UID to point back to Descriptor for this event stream"
+                    },
+                    "seq_num": {
+                        "type": "integer",
+                        "description": "Sequence number to identify the location of this Event in the Event stream"
+                    },
+                    "time": {
+                        "type": "number",
+                        "description": "The event time.  This maybe different than the timestamps on each of the data entries"
+                    },
+                    "uid": {
+                        "type": "string",
+                        "description": "Globally unique identifier for this Event"
+                    }
+                },
+                "required": [
+                    "uid",
+                    "data",
+                    "timestamps",
+                    "time",
+                    "descriptor",
+                    "seq_num"
+                ],
+                "additionalProperties": false,
+                "type": "object",
+                "title": "event",
+                "description": "Document to record a quanta of collected data"
+            }
+        }
+    }
+}

--- a/bluesky/tests/test_hardware_checklist.py
+++ b/bluesky/tests/test_hardware_checklist.py
@@ -2,21 +2,30 @@ import uuid
 import nose
 from bluesky.testing.noseclasses import KnownFailureTest
 from nose.tools import assert_raises
+import time
 from bluesky.hardware_checklist import *
 
 
 def test_connect_mds_mongodb():
     try:
-        import metadatastore
+        from metadatastore.utils.testing import mds_setup, mds_teardown
+        import metadatastore.commands as mdsc
     except ImportError:
         raise nose.SkipTest
-    from metadatastore.utils.testing import mds_setup, mds_teardown
-    from metadatastore.commands import insert_beamline_config
+
     try:
         mds_setup()
         # Until we insert something, the db is not actually created.
-        bc = insert_beamline_config({}, time=0., uid=str(uuid.uuid4()))
+
+        mdsc.insert_runstart(scan_id=3022013,
+                             beamline_id='testbed',
+                             owner='tester',
+                             group='awesome-devs',
+                             project='Nikea',
+                             time=time.time(),
+                             uid=str(uuid.uuid4()))
         connect_mds_mongodb()
+
     except:
         raise
     finally:
@@ -48,7 +57,8 @@ def test_check_storage():
 
 def test_connect_channelarchiver():
     # Just test failure, not success.
-    assert_raises(RuntimeError, connect_channelarchiver, 'http://bnl.gov/asfoijewapfoia')
+    assert_raises(RuntimeError, connect_channelarchiver,
+                  'http://bnl.gov/asfoijewapfoia')
 
 
 def test_connect_pv():

--- a/bluesky/tests/test_hardware_checklist.py
+++ b/bluesky/tests/test_hardware_checklist.py
@@ -17,7 +17,7 @@ def test_connect_mds_mongodb():
         mds_setup()
         # Until we insert something, the db is not actually created.
 
-        mdsc.insert_runstart(scan_id=3022013,
+        mdsc.insert_run_start(scan_id=3022013,
                              beamline_id='testbed',
                              owner='tester',
                              group='awesome-devs',


### PR DESCRIPTION
I spent a bit of time to see how bulk events from `collect` could be passed around, and here's what I came up with:

* Added a new document name `"bulk_events"` 
    * It's a dictionary that's keyed on `descriptor_uid`, with lists of events as values
    * It's verified with jsonschema (thanks @arkilic for the input)
* Individual events are by default not emitted, unless `emit_events` is set in the `collect` message (as in `Msg('collect', flyer, emit_events=True)`)

Feel free to reject it outright - I honestly have no clue how you intended to implement this. 

In any case, it works on my end and allows me to run tests. The speed-up is significant: 5000 events are stored in 3.5 seconds, giving an estimate of 45 seconds for our larger 65k event scans. I don't think that's an unreasonable number.