### PR TITLE
Look for metadata in md attribute of plan passed to RE

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -495,7 +495,10 @@ class RunEngine:
                 scan_args[field] = repr(getattr(plan, field))
             metadata['scan_args'] = scan_args
 
-        self._metadata_per_call = metadata
+        if hasattr(plan, 'md'):
+            self._metadata_per_call.update(plan.md)
+        # If kwargs to __call__ collide with plan.md, kwargs win.
+        self._metadata_per_call.update(metadata)
 
         self.state = 'running'
         gen = iter(plan)  # no-op on generators; needed for classes

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -464,9 +464,9 @@ class RunEngine:
 
         # Register temporary subscriptions. Save tokens to unsubscribe later.
         subs = normalize_subs_input(subs)
-        try:
+        if hasattr(plan, 'subs'):
             scan_subs = normalize_subs_input(plan.subs)
-        except AttributeError:
+        else:
             scan_subs = {}
         self._clear_call_cache()
         for name, funcs in itertools.chain(subs.items(), scan_subs.items()):


### PR DESCRIPTION
Like subscriptions, metadata can come from:

* kwargs to `RE.__call__` for metadata
* a special attribute of the plan passed to `RE.__call__`
* a Msg, wherein metadata can be determined after the call has begun

Unlike subscriptions, we don't need a new type of command to pass in metadata in a Msg. It is always good enough to put it in the 'open_run' Msg: we can't do it any later than that (it has to get into the RunStart) and it doesn't help to set it any earlier than that.