### PR TITLE
ENH: Add PeakStats callback

### DIFF
--- a/bluesky/callbacks.py
+++ b/bluesky/callbacks.py
@@ -3,6 +3,7 @@ Useful callbacks for the Run Engine
 """
 import sys
 from itertools import count
+from collections import deque
 import warnings
 from prettytable import PrettyTable
 
@@ -383,3 +384,34 @@ def _get_obj_fields(fields):
                                  "'describe' method that return a dict.")
             string_fields.extend(field_list)
     return string_fields
+
+
+class CollectThenCompute(CallbackBase):
+
+    def __init__(self):
+        self._start_doc = None
+        self._stop_doc = None
+        self._events = deque()
+        self._descriptors = deque()
+
+    def start(self, doc):
+        self._start_doc = doc
+
+    def descriptor(self, doc):
+        self._descriptors.append(doc)
+
+    def event(self, doc):
+        self._events.append(event)
+
+    def stop(self, doc):
+        self._stop_doc = doc
+        self.compute()
+
+    def reset(self):
+        self._start_doc = None
+        self._stop_doc = None
+        self._events.clear()
+        self._descriptors.clear()
+
+    def compute(self):
+        raise NotImplementedError("This method must be defined by a subclass.")

--- a/bluesky/callbacks.py
+++ b/bluesky/callbacks.py
@@ -401,7 +401,7 @@ class CollectThenCompute(CallbackBase):
         self._descriptors.append(doc)
 
     def event(self, doc):
-        self._events.append(event)
+        self._events.append(doc)
 
     def stop(self, doc):
         self._stop_doc = doc

--- a/bluesky/scientific_callbacks.py
+++ b/bluesky/scientific_callbacks.py
@@ -61,12 +61,12 @@ class PeakStats(CollectThenCompute):
                 y.append(_y)
         x = np.array(x)
         y = np.array(y)
+        self.x_data = x
+        self.y_data = y
         # Compute x value at min and max of y
         self.max = x[np.argmax(y)]
         self.min = x[np.argmin(y)]
-        self.com = np.interp(center_of_mass(y), x, y)
-        self.x_data = x
-        self.y_data = y
+        self.com = np.interp(center_of_mass(y), np.arange(len(x)), x)
 
 
 def plot_peak_stats(peak_stats, ax=None):

--- a/bluesky/scientific_callbacks.py
+++ b/bluesky/scientific_callbacks.py
@@ -1,0 +1,83 @@
+import numpy as np
+from scipy.ndimage import center_of_mass
+from bluesky.callbacks import CollectThenCompute
+
+
+class PeakStats(CollectThenCompute):
+
+    def __init__(self, x, y):
+        """
+        Compute peak statsitics after a run finishes.
+
+        Results are stored in the attributes.
+
+        Parameters
+        ----------
+        x : string
+            field name for the x variable (e.g., a motor)
+        y : string
+            field name for the y variable (e.g., a detector)
+
+        Attributes
+        ----------
+        com : center of mass
+        cen : TBD
+        max : x location of y maximum
+        min : x location of y minimum
+        """
+        self.x = x
+        self.y = y
+        self.com = None
+        self.cen = None
+        self.max = None
+        self.min = None
+        super().__init__()
+
+    def compute(self):
+        "This method is called at run-stop time by the superclass."
+        x = []
+        y = []
+        for event in self._events:
+            try:
+                x.append(event['data'][self.x])
+            except KeyError:
+                pass
+            try:
+                y.append(event['data'][self.y])
+            except KeyError:
+                pass
+        x = np.array(x)
+        y = np.array(y)
+        # Compute x value at min and max of y
+        self.min = x[np.argmax(y)]
+        self.max = x[np.argmin(y)]
+        self.com = np.interp(center_of_mass(y), x, y)
+        self.x_data = x
+        self.y_data = y
+
+
+def plot_peak_stats(ax, peak_stats):
+    """
+    Plot data and various peak statistics.
+
+    Parameters
+    ----------
+    ax : matplotlib.Axes
+    peak_stats : PeakStats
+
+    Returns
+    -------
+    arts : dict
+        dictionary of matplotlib Artist objects, for further styling
+    """
+    ps = peak_stats  # for brevity
+    if ax is None:
+        fig, ax = plt.subplots()
+    # Plot points, vertical lines, and a legend. Collect Artist objs to return.
+    points, = ax.plot(ps.x_data, ps.y_data, 'o')
+    vlines = []
+    for attr in ['cen', 'com', 'max', 'min']:
+        vlines.append(ax.axvline(getattr(ps, attr), label=attr))
+    legend = ax.legend(loc='best')
+    arts = {'points': points, 'vlines': vlines, 'legend': legend}
+    return arts

--- a/bluesky/scientific_callbacks.py
+++ b/bluesky/scientific_callbacks.py
@@ -55,8 +55,8 @@ class PeakStats(CollectThenCompute):
         x = np.array(x)
         y = np.array(y)
         # Compute x value at min and max of y
-        self.min = x[np.argmax(y)]
-        self.max = x[np.argmin(y)]
+        self.max = x[np.argmax(y)]
+        self.min = x[np.argmin(y)]
         self.com = np.interp(center_of_mass(y), x, y)
         self.x_data = x
         self.y_data = y

--- a/bluesky/scientific_callbacks.py
+++ b/bluesky/scientific_callbacks.py
@@ -1,4 +1,6 @@
 import numpy as np
+from cycler import cycler
+import matplotlib.pyplot as plt
 from scipy.ndimage import center_of_mass
 from bluesky.callbacks import CollectThenCompute
 
@@ -67,14 +69,14 @@ class PeakStats(CollectThenCompute):
         self.y_data = y
 
 
-def plot_peak_stats(ax, peak_stats):
+def plot_peak_stats(peak_stats, ax=None):
     """
     Plot data and various peak statistics.
 
     Parameters
     ----------
-    ax : matplotlib.Axes
     peak_stats : PeakStats
+    ax : matplotlib.Axes, optional
 
     Returns
     -------
@@ -87,8 +89,12 @@ def plot_peak_stats(ax, peak_stats):
     # Plot points, vertical lines, and a legend. Collect Artist objs to return.
     points, = ax.plot(ps.x_data, ps.y_data, 'o')
     vlines = []
-    for attr in ['cen', 'com', 'max', 'min']:
-        vlines.append(ax.axvline(getattr(ps, attr), label=attr))
+    styles = cycler('color', list('krgb'))
+    for style, attr in zip(styles, ['cen', 'com', 'max', 'min']):
+        val = getattr(ps, attr)
+        if val is None:
+            continue
+        vlines.append(ax.axvline(val, label=attr, **style))
     legend = ax.legend(loc='best')
     arts = {'points': points, 'vlines': vlines, 'legend': legend}
     return arts

--- a/bluesky/scientific_callbacks.py
+++ b/bluesky/scientific_callbacks.py
@@ -33,6 +33,12 @@ class PeakStats(CollectThenCompute):
         self.min = None
         super().__init__()
 
+    def __getitem__(self, key):
+        if key in ['com', 'cen', 'max', 'min']:
+            return getattr(self, key)
+        else:
+            raise KeyError
+
     def compute(self):
         "This method is called at run-stop time by the superclass."
         x = []

--- a/bluesky/scientific_callbacks.py
+++ b/bluesky/scientific_callbacks.py
@@ -18,6 +18,11 @@ class PeakStats(CollectThenCompute):
         y : string
             field name for the y variable (e.g., a detector)
 
+        Note
+        ----
+        It is assumed that the two fields, x and y, are recorded in the same
+        Event stream.
+
         Attributes
         ----------
         com : center of mass
@@ -45,13 +50,13 @@ class PeakStats(CollectThenCompute):
         y = []
         for event in self._events:
             try:
-                x.append(event['data'][self.x])
+                _x = event['data'][self.x]
+                _y = event['data'][self.y]
             except KeyError:
                 pass
-            try:
-                y.append(event['data'][self.y])
-            except KeyError:
-                pass
+            else:
+                x.append(_x)
+                y.append(_y)
         x = np.array(x)
         y = np.array(y)
         # Compute x value at min and max of y


### PR DESCRIPTION
This adds a class for computing peak stats. It works like this:

```
ps = PeakStats(motor, det)
RE(ascan, subs=ps)  # or, in the simple SPEC-like API, ascan(motor, start, stop, interval, subs=ps)
```

When the scan finishes, the statistics are automatically computed, and the results are available via attributes of `ps`. So far, center-of-mass (`ps.com`) and min and max (`ps.min`, `ps.max`) are implemented. I need guidance from @cmazzoli or @ambarb on exactly how `cen` is supposed to work.

Since the pattern, "compute some things when a scan finishes" is likely to come up again, I implemented `PeakStats` on a base class `CollectThenCompute` which is more general. I'm interested in thoughts from non-CSX-ers on whether this is the right generalization. Notice that this does not use databroker; we have the `post_run` callback for that.