### PR TITLE
REF: Move qt_kicker into separate module.

### DIFF
--- a/bluesky/callbacks.py
+++ b/bluesky/callbacks.py
@@ -3,12 +3,9 @@ Useful callbacks for the Run Engine
 """
 import sys
 from itertools import count
-import asyncio
 import warnings
 from prettytable import PrettyTable
 
-import matplotlib.backends.backend_qt5
-from matplotlib.backends.backend_qt5 import _create_qApp
 import matplotlib.pyplot as plt
 
 from datetime import datetime
@@ -16,33 +13,6 @@ import numpy as np
 
 import logging
 logger = logging.getLogger(__name__)
-
-
-_create_qApp()
-qApp = matplotlib.backends.backend_qt5.qApp
-
-from matplotlib._pylab_helpers import Gcf
-
-try:
-    _draw_all = Gcf.draw_all  # mpl version >= 1.5
-except AttributeError:
-    # slower, but backward-compatible
-    def _draw_all():
-        for f_mgr in Gcf.get_all_fig_managers():
-            f_mgr.canvas.draw_idle()
-
-
-def _qt_kicker():
-    # The RunEngine Event Loop interferes with the qt event loop. Here we
-    # kick it to keep it going.
-    _draw_all()
-
-    qApp.processEvents()
-    loop.call_later(0.1, _qt_kicker)
-
-
-loop = asyncio.get_event_loop()
-loop.call_soon(_qt_kicker)
 
 
 class CallbackBase(object):

--- a/bluesky/qt_kicker.py
+++ b/bluesky/qt_kicker.py
@@ -1,0 +1,35 @@
+"""
+A utility that, once imported, kicks the qt event loop at regular
+intervals. This lets qt and asyncio peacefully coexist, and it is 
+necessary for matplotlib < 1.5.0.
+"""
+import asyncio
+import matplotlib.backends.backend_qt5
+from matplotlib.backends.backend_qt5 import _create_qApp
+
+
+_create_qApp()
+qApp = matplotlib.backends.backend_qt5.qApp
+
+from matplotlib._pylab_helpers import Gcf
+
+try:
+    _draw_all = Gcf.draw_all  # mpl version >= 1.5
+except AttributeError:
+    # slower, but backward-compatible
+    def _draw_all():
+        for f_mgr in Gcf.get_all_fig_managers():
+            f_mgr.canvas.draw_idle()
+
+
+def _qt_kicker():
+    # The RunEngine Event Loop interferes with the qt event loop. Here we
+    # kick it to keep it going.
+    _draw_all()
+
+    qApp.processEvents()
+    loop.call_later(0.1, _qt_kicker)
+
+
+loop = asyncio.get_event_loop()
+loop.call_soon(_qt_kicker)


### PR DESCRIPTION
This code was bundled into callbacks.py, and it breaks the import if mpl is not using qt. This PR moves it into separate module. If the user is (1) using qt and (2) running mpl < 1.5, they need to import this module in order for LivePlot to work properly. Once we are in a post-1.5 world, this is vestigial and can eventually be removed completely.