### PR TITLE
Simple (SPEC-like) scans are more customizable

### DIFF
--- a/bluesky/broker_callbacks.py
+++ b/bluesky/broker_callbacks.py
@@ -1,7 +1,7 @@
-from dataportal import DataBroker as db
+from dataportal import DataBroker as db, get_events
 import filestore
 import filestore.api as fsapi
-from metadatastore.commands import find_event_descriptors, find_run_starts
+from metadatastore.commands import run_start_given_uid, descriptors_by_start
 import matplotlib.pyplot as plt
 from xray_vision.backend.mpl.cross_section_2d import CrossSection
 from .callbacks import CallbackBase
@@ -71,11 +71,11 @@ def post_run(callback):
     """
     def f(name, stop_doc):
         uid = stop_doc['run_start']
-        start, = find_run_starts(uid=uid)
-        descriptors = find_event_descriptors(run_start=uid)
+        start = run_start_given_uid(uid)
+        descriptors = descriptors_by_start(uid)
         # For convenience, I'll rely on the broker to get Events.
         header = db[uid]
-        events = db.fetch_events(header)
+        events = get_events(header)
         callback.start(start)
         for d in descriptors:
             callback.descriptor(d)

--- a/bluesky/scans.py
+++ b/bluesky/scans.py
@@ -555,6 +555,8 @@ class Center(ScanBase):
         return self.initial_center + self.RANGE_LIMIT * self.initial_width
 
     def _gen(self):
+        # We checked in the __init__ that this import works.
+        from lmfit.models import GaussianModel, LinearModel
         # For thread safety (paranoia) make copies of stuff
         dets = self.detectors
         target_field = self.target_field

--- a/bluesky/simple_scans.py
+++ b/bluesky/simple_scans.py
@@ -31,7 +31,7 @@ from bluesky.standard_config import gs
 class _PrimitiveScan:
 
     def __init__(self):
-        self.params = list(signature(self._scan_class).parameters.keys())
+        self.params = list(signature(self.scan_class).parameters.keys())
 
     def __call__(self, *args, subs=None, **kwargs):
         scan_kwargs = dict()
@@ -47,7 +47,7 @@ class _PrimitiveScan:
                                  "the RunEngine arguments. Use different "
                                  "names. Avoid: {0}".format(RE_params))
 
-        self.scan = self._scan_class(gs.DETS, *args, **scan_kwargs)
+        self.scan = self.scan_class(gs.DETS, *args, **scan_kwargs)
         if subs is None:
             subs = self.subs
         # Any remainging kwargs go the RE. To be safe, no args are passed
@@ -148,7 +148,7 @@ class _HardcodedMotorStepScan(_PrimitiveScan):
 
 class Count(_PrimitiveScan):
     "ct"
-    _scan_class = scans.Count
+    scan_class = scans.Count
 
     def __call__(self, time=None, subs=None, **kwargs):
         if subs is None:
@@ -165,32 +165,32 @@ class Count(_PrimitiveScan):
 
 class AbsScan(_StepScan):
     "ascan"
-    _scan_class = scans.AbsScan
+    scan_class = scans.AbsScan
 
 
 class OuterProductAbsScan(_OuterProductScan):
     "mesh"
-    _scan_class = scans.OuterProductAbsScan
+    scan_class = scans.OuterProductAbsScan
 
 
 class InnerProductAbsScan(_InnerProductScan):
     "a2scan, a3scan, etc."
-    _scan_class = scans.InnerProductAbsScan
+    scan_class = scans.InnerProductAbsScan
 
 
 class DeltaScan(_StepScan):
     "dscan (also known as lup)"
-    _scan_class = scans.DeltaScan
+    scan_class = scans.DeltaScan
 
 
 class InnerProductDeltaScan(_InnerProductScan):
     "d2scan, d3scan, etc."
-    _scan_class = scans.InnerProductDeltaScan
+    scan_class = scans.InnerProductDeltaScan
 
 
 class ThetaTwoThetaScan(_InnerProductScan):
     "th2th"
-    _scan_class = scans.InnerProductDeltaScan
+    scan_class = scans.InnerProductDeltaScan
 
     def __call__(self, start, finish, intervals, time=None, **kwargs):
         TTH_MOTOR = gs.TTH_MOTOR
@@ -224,12 +224,12 @@ class _TemperatureScan(_HardcodedMotorStepScan):
 
 class AbsTemperatureScan(_TemperatureScan):
     "tscan"
-    _scan_class = scans.AbsScan
+    scan_class = scans.AbsScan
 
 
 class DeltaTemperatureScan(_TemperatureScan):
     "dtscan"
-    _scan_class = scans.DeltaScan
+    scan_class = scans.DeltaScan
 
 
 ### Basic Reciprocal Space Scans (p. 147) ###
@@ -237,7 +237,7 @@ class DeltaTemperatureScan(_TemperatureScan):
 
 class HScan(_HardcodedMotorStepScan):
     "hscan"
-    _scan_class = scans.AbsScan
+    scan_class = scans.AbsScan
 
     @property
     def _motor(self):
@@ -247,7 +247,7 @@ class HScan(_HardcodedMotorStepScan):
 
 class KScan(_HardcodedMotorStepScan):
     "kscan"
-    _scan_class = scans.AbsScan
+    scan_class = scans.AbsScan
 
     @property
     def _motor(self):
@@ -257,7 +257,7 @@ class KScan(_HardcodedMotorStepScan):
 
 class LScan(_HardcodedMotorStepScan):
     "lscan"
-    _scan_class = scans.AbsScan
+    scan_class = scans.AbsScan
 
     @property
     def _motor(self):
@@ -267,7 +267,7 @@ class LScan(_HardcodedMotorStepScan):
 
 class OuterProductHKLScan(_PrimitiveScan):
     "hklmesh"
-    _scan_class = scans.OuterProductAbsScan
+    scan_class = scans.OuterProductAbsScan
 
     def __call__(self, Q1, start1, finish1, intervals1, Q2, start2, finish2,
                  intervals2, time=None, **kwargs):
@@ -292,7 +292,7 @@ class OuterProductHKLScan(_PrimitiveScan):
 
 class InnerProductHKLScan(_PrimitiveScan):
     "hklscan"
-    _scan_class = scans.InnerProductAbsScan
+    scan_class = scans.InnerProductAbsScan
 
     def __call__(self, start_h, finish_h, start_k, finish_k, start_l,
                  finish_l, intervals, time=None, **kwargs):
@@ -319,7 +319,7 @@ class InnerProductHKLScan(_PrimitiveScan):
 
 class Tweak(_PrimitiveScan):
     "tw"
-    _scan_class = scans.Tweak
+    scan_class = scans.Tweak
 
     def __call__(motor, step, **kwargs):
         from bluesky.standard_config import gs

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -1,4 +1,5 @@
 from nose.tools import assert_equal, assert_raises
+from nose import SkipTest
 from bluesky.run_engine import Msg
 from bluesky.examples import (motor, det, stepscan)
 from bluesky.scans import AdaptiveAbsScan
@@ -67,6 +68,16 @@ def test_unknown_cb_raises():
     assert_raises(KeyError, RE.subscribe, 'not a thing', f)
     # CallbackRegistry catches this case (different error).
     assert_raises(ValueError, RE._register_scan_callback, 'not a thing', f)
+
+
+def test_post_run():
+    try:
+        import dataportal
+    except ImportError:
+        raise SkipTest('requires dataportal')
+    from bluesky.broker_callbacks import post_run
+    RE(stepscan(det, motor), subs=post_run(LiveTable()))
+
 
 
 @contextlib.contextmanager

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -313,7 +313,7 @@ class ExtendedList(list):
 
 
 def normalize_subs_input(subs):
-    "Accept a callable, a list, or a dict. Normalize to a dict."
+    "Accept a callable, a list, or a dict. Normalize to a dict of lists."
     if subs is None:
         return {}
     if hasattr(subs, 'items'):


### PR DESCRIPTION
In current master, the subscriptions attached to the simple scans are hard-coded. Customizing them is tricky because they inspect the scan to automatically do things like use `motor` attribute as the x axis in `LivePlot`.

This introduces two new user-modifiable attributes: `.subs`, which works the same way as usual, and `.sub_factories`, which expects a *function that accepts a scan instance and returns a callback*. It's the job of the function to inspect the scan and pass the right arguments to, for example, `LivePlot`. A collection of these "sub factories" is included in the PR. See for example `plot_first_motor`.

I don't imagine that users will be writing very many "sub factories," but they are crucial to providing the magical scan inspection in a way that lets users add and remove other subs (like peak stats) at will.