### PR TITLE
API/MNT: make qt_kicker not install on import

### DIFF
--- a/bluesky/qt_kicker.py
+++ b/bluesky/qt_kicker.py
@@ -1,35 +1,45 @@
-"""
-A utility that, once imported, kicks the qt event loop at regular
-intervals. This lets qt and asyncio peacefully coexist, and it is 
-necessary for matplotlib < 1.5.0.
-"""
-import asyncio
-import matplotlib.backends.backend_qt5
-from matplotlib.backends.backend_qt5 import _create_qApp
+import sys
+
+_INSTALLED = None
 
 
-_create_qApp()
-qApp = matplotlib.backends.backend_qt5.qApp
+def install_qt_kicker():
+    """Install a periodic callback to integrate qt and asyncio event loops
 
-from matplotlib._pylab_helpers import Gcf
+    If a version of the qt bindings are not already imported, this function
+    will do nothing.
 
-try:
-    _draw_all = Gcf.draw_all  # mpl version >= 1.5
-except AttributeError:
-    # slower, but backward-compatible
-    def _draw_all():
-        for f_mgr in Gcf.get_all_fig_managers():
-            f_mgr.canvas.draw_idle()
+    It is safe to call this function multiple times.
+    """
 
+    global _INSTALLED
+    if _INSTALLED is not None:
+        return
+    if not any(p in sys.modules for p in ['PyQt4', 'pyside', 'PyQt5']):
+        return
+    import asyncio
+    import matplotlib.backends.backend_qt5
+    from matplotlib.backends.backend_qt5 import _create_qApp
+    from matplotlib._pylab_helpers import Gcf
 
-def _qt_kicker():
-    # The RunEngine Event Loop interferes with the qt event loop. Here we
-    # kick it to keep it going.
-    _draw_all()
+    _create_qApp()
+    qApp = matplotlib.backends.backend_qt5.qApp
 
-    qApp.processEvents()
-    loop.call_later(0.1, _qt_kicker)
+    try:
+        _draw_all = Gcf.draw_all  # mpl version >= 1.5
+    except AttributeError:
+        # slower, but backward-compatible
+        def _draw_all():
+            for f_mgr in Gcf.get_all_fig_managers():
+                f_mgr.canvas.draw_idle()
 
+    def _qt_kicker():
+        # The RunEngine Event Loop interferes with the qt event loop. Here we
+        # kick it to keep it going.
+        _draw_all()
 
-loop = asyncio.get_event_loop()
-loop.call_soon(_qt_kicker)
+        qApp.processEvents()
+        loop.call_later(0.03, _qt_kicker)
+
+    loop = asyncio.get_event_loop()
+    _INSTALLED = loop.call_soon(_qt_kicker)


### PR DESCRIPTION
There is now a function install_qt_kicker in qt_kicker which must be
called to install the kicker.

THIS WILL REQUIRE A CHANGE TO THE BEAMLINE CONFIG

The suggested pattern is:

from bluesky.qt_kicker import install_qt_kicker
install_qt_kicker()

closes #214 