### PR TITLE
FIX: Fix error when resuming during first event bundle.

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -825,9 +825,11 @@ class RunEngine:
             yield from self.emit(DocumentNames.descriptor, doc)
             self.debug("*** Emitted Event Descriptor:\n%s" % doc)
             self._descriptor_uids[objs_read] = descriptor_uid
-            self._sequence_counters[objs_read] = count(1)
         else:
             descriptor_uid = self._descriptor_uids[objs_read]
+        # This is a separate check because it can be reset on resume.
+        if objs_read not in self._sequence_counters:
+            self._sequence_counters[objs_read] = count(1)
         self._bundling = False
 
         # Events


### PR DESCRIPTION
This issue was breaking `resume` when the interruption happened during the first data  point. Example Traceback:

```python
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-15-668cb5c44cab> in <module>()
----> 1 RE.resume()

/Users/dallan/Documents/Repos/bluesky/bluesky/run_engine.py in resume(self)
    545         self._sequence_counters.clear()
    546         self._sequence_counters.update(self._teed_sequence_counters)
--> 547         self._resume_event_loop()
    548         return self._run_start_uids
    549 

/Users/dallan/Documents/Repos/bluesky/bluesky/run_engine.py in _resume_event_loop(self)
    558                 exc = self._task.exception()
    559                 if exc is not None:
--> 560                     raise exc
    561 
    562     def request_suspend(self, fut):

/Users/dallan/miniconda/envs/py3/lib/python3.4/asyncio/tasks.py in _step(***failed resolving arguments***)
    236                 result = coro.send(value)
    237             else:
--> 238                 result = next(coro)
    239         except StopIteration as exc:
    240             self.set_result(exc.value)

/Users/dallan/Documents/Repos/bluesky/bluesky/run_engine.py in _run(self)
    650             logger.error("Run aborted")
    651             logger.error("%s", err)
--> 652             raise err
    653         finally:
    654             self.state = 'idle'

/Users/dallan/Documents/Repos/bluesky/bluesky/run_engine.py in _run(self)
    630                 self.debug("About to process: {0}, {1}".format(coro, msg))
    631                 yield from asyncio.sleep(0.001)  # TODO Do we need this?
--> 632                 response = yield from coro(msg)
    633                 self.debug('RE.state: ' + self.state)
    634                 self.debug('msg: {}\n   response: {}'.format(msg, response))

/Users/dallan/Documents/Repos/bluesky/bluesky/run_engine.py in _save(self, msg)
    832 
    833         # Events
--> 834         seq_num = next(self._sequence_counters[objs_read])
    835         event_uid = new_uid()
    836         # Merge list of readings into single dict.

KeyError: frozenset({reader: det})


```