### PR TITLE
REF: post-run cleanup re-ordering

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -652,13 +652,6 @@ class RunEngine:
             raise err
         finally:
             self.state = 'idle'
-            # in case we were interrupted between 'configure' and 'deconfigure'
-            for obj in list(self._configured):
-                try:
-                    obj.deconfigure()
-                except Exception:
-                    logger.error("Failed to deconfigure %r", obj)
-                self._configured.remove(obj)
             # call stop() on every movable object we ever set() or kickoff()
             for obj in self._movable_objs_touched:
                 try:
@@ -672,6 +665,13 @@ class RunEngine:
                     yield from self._collect(Msg('collect', obj))
                 except Exception:
                     logger.error("Failed to collect %r", obj)
+            # in case we were interrupted between 'configure' and 'deconfigure'
+            for obj in list(self._configured):
+                try:
+                    obj.deconfigure()
+                except Exception:
+                    logger.error("Failed to deconfigure %r", obj)
+                self._configured.remove(obj)
             sys.stdout.flush()
             # Emit RunStop if necessary.
             if self._run_is_open:


### PR DESCRIPTION
This PR re-orders the post-run clean-up to be: stop(), collect(), deconfigure()

Fix for `deconfigure` in areadetector filestore clearing the `filestore_resource`, causing any further `collect()` calls to fail.