### PR TITLE
MNT: Define _fields and _objects in ScanBase to make errors clearer.

### DIFF
--- a/bluesky/scans.py
+++ b/bluesky/scans.py
@@ -33,6 +33,16 @@ class ScanBase(Struct):
     _derived_fields = []
 
     @property
+    def _fields(self):
+        "Subclasses are required to define this. See class docstring above."
+        raise NotImplementedError
+
+    @property
+    def _objects(self):
+        "Subclasses are required to define this. See class docstring above."
+        raise NotImplementedError
+
+    @property
     def objects(self):
         return {obj: list(obj.describe().keys()) for obj in self._objects}
 


### PR DESCRIPTION
Rationale: @klauer didn't define `_objects` on one of his scan classes. When the RunEngine went to access the scan's `md` attribute, an `AttributeError` propagated up from `_objects`, and the RunEngine concluded that there was no metadata on the scan.

I think is a reasonable way to catch this mistake sooner and in a clearer way. Let's let this PR sit until @tacaswell returns. I'm not 100% sure this is a best approach to the problem.