### PR TITLE
WIP: Validate order or create/save.

### DIFF
--- a/bluesky/__init__.py
+++ b/bluesky/__init__.py
@@ -1,5 +1,6 @@
 import logging
-from .run_engine import (Msg, RunEngine, PanicError, RunInterrupt)
+from .run_engine import (Msg, RunEngine, PanicError, RunInterrupt,
+                         IllegalMessageSequence)
 from .scans import *
 
 logger = logging.getLogger(__name__)

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -528,6 +528,11 @@ class RunEngine:
             raise PanicError("Run Engine is panicked. If are you sure all is "
                              "well, call the all_is_well() method.")
 
+        # This is needed to 'cancel' an open bundling (e.g. create) if
+        # the pause happens after a 'checkpoint', after a 'create', but before
+        # the paired 'save'.
+        self._bundling = False
+
         # Check that all pause requests have been released.
         outstanding_requests = []
         for name, func in list(self._pause_requests.items()):

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -787,6 +787,11 @@ class RunEngine:
 
     @asyncio.coroutine
     def _create(self, msg):
+        if self._bundling:
+            raise IllegalMessageSequence("A second 'create' message is not "
+                                         "allowed until the current event "
+                                         "bundle is closed with a 'save' "
+                                         "message.")
         self._read_cache.clear()
         self._objs_read.clear()
         self._bundling = True
@@ -812,6 +817,10 @@ class RunEngine:
 
     @asyncio.coroutine
     def _save(self, msg):
+        if not self._bundling:
+            raise IllegalMessageSequence("A 'create' message must be sent, to "
+                                         "open an event bundle, before that "
+                                         "bundle can be saved with 'save'.")
         # The Event Descriptor is uniquely defined by the set of objects
         # read in this Event grouping.
         objs_read = frozenset(self._objs_read)


### PR DESCRIPTION
Add straightforward validation in `_create` and `_save` methods on `RunEngine` and tests to match. One of our *old* tests tripped the validation, exposing a pre-existing issue in the generator stack where the first Message is run twice. In every one of our built in scans, this Message happens to be 'create', so no harm was done.

Will revisit. This PR is full of debug prints and stuff to be removed before merging.