### PR TITLE
ENH: Add tiff export function factory.

### DIFF
--- a/bluesky/broker_callbacks.py
+++ b/bluesky/broker_callbacks.py
@@ -117,7 +117,7 @@ def make_tiff_exporter(field, template):
     if not '{N}' in template:
         raise ValueError("template must include '{N}'")
 
-    def f(h):
+    def f(h, dryrun=False):
         imgs = get_images(h, field)
         # Fill in h, defer filling in N.
         _template = template.format(h=h, N='{N}')
@@ -127,9 +127,11 @@ def make_tiff_exporter(field, template):
             if os.path.isfile(filename):
                 raise FileExistsError("There is already a file at {}. Delete "
                                       "it and try again.".format(filename))
-        # Write files.
-        for filename, img in zip(filenames, imgs):
-            tifffile.imsave(filename, np.asarray(img))
+        if not dryrun:
+            # Write files.
+            for filename, img in zip(filenames, imgs):
+                tifffile.imsave(filename, np.asarray(img))
+        return filenames
 
     # Write a customized docstring for f based on what is specifcally does.
     f.__doc__ = """
@@ -139,5 +141,14 @@ Parameters
 ----------
 h : Header
     a header from the databroker
+dryrun : bool
+    Set to True to return list of filenames without actually writing files.
+    False by default.
+
+Returns
+-------
+filenames : list
+    list of filenames where files were written (or, if dryrun, *would* be
+    written)
 """.format(field=field)
     return f

--- a/bluesky/broker_callbacks.py
+++ b/bluesky/broker_callbacks.py
@@ -93,7 +93,7 @@ def post_run(callback):
     return f
 
 
-def exporter_factory(field, template):
+def make_tiff_exporter(field, template):
     """
     Build a function that, given a header, exports tiff files.
 

--- a/bluesky/broker_callbacks.py
+++ b/bluesky/broker_callbacks.py
@@ -1,3 +1,4 @@
+import os
 from databroker import DataBroker as db, get_events
 import filestore.api as fsapi
 from metadatastore.commands import run_start_given_uid, descriptors_by_start
@@ -120,8 +121,14 @@ def exporter_factory(field, template):
         imgs = get_images(h, field)
         # Fill in h, defer filling in N.
         _template = template.format(h=h, N='{N}')
-        for i, img in enumerate(imgs):
-            filename = _template.format(N=i)
+        filenames = [_template.format(N=i) for i in range(len(imgs))]
+        # First check that none of the filenames exist.
+        for filename in filenames:
+            if os.path.isfile(filename):
+                raise FileExistsError("There is already a file at {}. Delete "
+                                      "it and try again.".format(filename))
+        # Write files.
+        for filename, img in zip(filenames, imgs):
             tifffile.imsave(filename, np.asarray(img))
 
     # Write a customized docstring for f based on what is specifcally does.

--- a/bluesky/broker_callbacks.py
+++ b/bluesky/broker_callbacks.py
@@ -114,7 +114,7 @@ def exporter_factory(field, template):
     """
     # validate user input
     if not '{N}' in template:
-        raise ValueError("format_stirng must include '{N}'")
+        raise ValueError("template must include '{N}'")
 
     def f(h):
         imgs = get_images(h, field)


### PR DESCRIPTION
@sbillinge @timoHMM This is how I would implement TIFF export.

```python
In [2]: from bluesky.broker_callbacks import exporter_factory

In [3]: f = exporter_factory('img', 'test/{h.start.scan_id}_{N}.tiff')

In [4]: header = db['0b96536a']  # example data with 20 images in a field named `'img'`

In [6]: !mkdir test

In [7]: f(header)

In [8]: !ls test
1_0.tiff   1_11.tiff  1_14.tiff  1_17.tiff  1_2.tiff   1_5.tiff   1_8.tiff
1_1.tiff   1_12.tiff  1_15.tiff  1_18.tiff  1_3.tiff   1_6.tiff   1_9.tiff
1_10.tiff  1_13.tiff  1_16.tiff  1_19.tiff  1_4.tiff   1_7.tiff
```

As you can see, it is simple to customize the filename based on any piece of metadata. It's all contained in the Header. See docstring for more.