### PR TITLE
FIX: Catch KeyboardInterrupt from badly-behaving external code.

### DIFF
--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -394,6 +394,17 @@ def test_abort():
     assert stop - start < 2
 
 
+def test_rogue_sigint():
+    def bad_scan():
+        yield Msg('open_run')
+        yield Msg('checkpoint')
+        raise KeyboardInterrupt
+
+    RE(bad_scan())
+    assert_equal(RE.state, 'paused')
+    RE.abort()
+
+
 def test_seqnum_nonrepeated():
     def gen():
         yield Msg('open_run')


### PR DESCRIPTION
This addresses another subtle case that may have caused #226.

If some external code (in the case of #226, something in `pyOlog` or `requests`) takes control of SIGINT / Ctrl+C away from the RunEngine and then raises `KeyboardInterrupt`, the run will fail on a generic error. This PR captures `KeyboardInterrupt` and then calls `RunEngine.request_pause` as we normally do when we capture SIGINT.

If external code is behaving properly, a `KeyboardInterrupt` should never be raised. The external code should defer to the previously-registered SIGINT handler (that is, the RunEngine's handler) instead of raising KeyboardInterrupt. Therefore, this should be fixed upstream if the problem can be identified. At the same time, we can mitigate the issue in general --- it might come up again from other external code.