### PR TITLE
For now, don't implicitly update RE.md

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -753,13 +753,6 @@ class RunEngine:
         self._metadata_per_run.update(self._metadata_per_call)
         self._metadata_per_run.update(msg.kwargs)
 
-        for field, val in list(self.md.items()):
-            new_val = self._metadata_per_run[field]
-            if val != new_val:
-                # Stored value has been overriden by __call__ or Msg.
-                # Update the stored value.
-                self.md[field] = new_val
-
         # The metadata is final. Validate it now, at the last moment.
         # Use copy for some reasonable (admittedly not total) protection
         # against users mutating the md with their validator.

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -235,11 +235,12 @@ def _md(md):
     RE.md['project'] = 'sitting'
     scan = simple_scan(motor)
     RE(scan, subs={'start': [validate_dict_cb('project', 'sitting')]})
-    # new values to 'project' passed in the call update the value in md
+    # new values to 'project' passed in the call override the value in md
     scan = simple_scan(motor)
     RE(scan, project='standing',
        subs={'start': [validate_dict_cb('project', 'standing')]})
-    assert_equal(RE.md['project'], 'standing')
+    # ...but they do not update the value in md
+    assert_equal(RE.md['project'], 'sitting')
 
 
 def validate_dict_cb(key, val):

--- a/doc/source/metadata.rst
+++ b/doc/source/metadata.rst
@@ -103,8 +103,6 @@ raise a ``KeyError`` if they are not set. These fields are:
 * owner
 * group
 * beamline_id (e.g., 'csx')
-* config, a dictionary describing the hardware, calibration, dead pixels on
-  detectors, etc.
 
 ``standard_config.py`` fills some of these in automatically (e.g., 'owner'
 defaults to the username of the UNIX user currently logged in).


### PR DESCRIPTION
In #240, several of us agreed that the *default* behavior should be that kwarg-based metadata should not implicitly update persistent metadata. Some advocated for a switch to turn implicit updating on and off. I came out somewhat against this. I would reconsider if users seem to want it. So far, the only users I've heard from want the explicit way, so that is what this PR does.