### PR TITLE
ENH: Better error message if 'sample' md is not a dict.

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1238,3 +1238,10 @@ def _default_md_validator(md):
         if field not in md:
             raise KeyError("The field '{0}' was not specified as is "
                            "required.".format(field))
+        if 'sample' in md and not hasattr(md['sample'], 'keys'):
+            raise ValueError(
+                "You specified 'sample' metadata. We give this field special "
+                "significance in order to make your data easily searchable. "
+                "Therefore, you must make 'sample' a dictionary, like so: "
+                "GOOD: sample={'color': 'red', 'number': 5} "
+                "BAD: sample='red_5' ")

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -188,6 +188,13 @@ def test_live_plotter():
     assert_equal(RE.state, 'idle')
 
 
+def test_sample_md_dict_requirement():
+    scan = simple_scan(motor)
+    # We avoid a json ValidationError and make a user-friendly ValueError.
+    assert_raises(ValueError, RE, scan, sample=1)
+    RE(scan, sample={'number': 1})  # should not raise
+
+
 def test_md_dict():
     yield _md, {}
 


### PR DESCRIPTION
Closes #253 

attn @ambarb -- does this message look good?