### PR TITLE
FIX: do not try bulk insertion with no events

### DIFF
--- a/bluesky/register_mds.py
+++ b/bluesky/register_mds.py
@@ -38,7 +38,8 @@ def _insert_run_start(name, doc):
 def _insert_bulk_events(name, doc):
     """Bulk insert each event stream in doc."""
     for desc_uid, events in doc.items():
-        bulk_insert_events(desc_uid, events)
+        if events:
+            bulk_insert_events(desc_uid, events)
 
 
 insert_funcs = {DocumentNames.event: _make_insert_func(mds.insert_event),


### PR DESCRIPTION
If a flyer yeilds no events, an empyt list bubbles it's way through
to pymongo which raises on a no-op bulk operation.

This is deployed as a hot fix at CSX.