### PR TITLE
ENH: switch to a configurable tiff exporter

### DIFF
--- a/bluesky/broker_callbacks.py
+++ b/bluesky/broker_callbacks.py
@@ -1,13 +1,8 @@
-import os
 from databroker import DataBroker as db, get_events
 import filestore.api as fsapi
 from metadatastore.commands import run_start_given_uid, descriptors_by_start
-import matplotlib.pyplot as plt
 from xray_vision.backend.mpl.cross_section_2d import CrossSection
 from .callbacks import CallbackBase
-import tifffile
-import numpy as np
-from databroker import get_images
 
 
 class LiveImage(CallbackBase):
@@ -25,9 +20,10 @@ class LiveImage(CallbackBase):
     relevant commit is a951b7.
     """
     def __init__(self, field):
+        from matplotlib.pyplot import figure
         super().__init__()
         self.field = field
-        fig = plt.figure()
+        fig = figure()
         self.cs = CrossSection(fig)
         self.cs._fig.show()
 

--- a/bluesky/broker_callbacks.py
+++ b/bluesky/broker_callbacks.py
@@ -1,6 +1,7 @@
 from databroker import DataBroker as db, get_events
 import filestore.api as fsapi
 from metadatastore.commands import run_start_given_uid, descriptors_by_start
+import matplotlib.pyplot as plt
 from xray_vision.backend.mpl.cross_section_2d import CrossSection
 from .callbacks import CallbackBase
 
@@ -20,10 +21,9 @@ class LiveImage(CallbackBase):
     relevant commit is a951b7.
     """
     def __init__(self, field):
-        from matplotlib.pyplot import figure
         super().__init__()
         self.field = field
-        fig = figure()
+        fig = plt.figure()
         self.cs = CrossSection(fig)
         self.cs._fig.show()
 

--- a/bluesky/broker_callbacks.py
+++ b/bluesky/broker_callbacks.py
@@ -93,7 +93,7 @@ def post_run(callback):
     return f
 
 
-def make_tiff_exporter(field, template):
+def make_tiff_exporter(fetch=None, template=None, prefix=None, **kwargs):
     """
     Build a function that, given a header, exports tiff files.
 
@@ -101,54 +101,38 @@ def make_tiff_exporter(field, template):
 
     Parameters
     ----------
-    field : str
-        a data key, e.g., 'pe1_image_lightfield'
-    template : str
-        A templated file path, where curly brackets will be filled in with
-        the attributes of 'h', a Header, and 'N', a sequential number.
-        e.g., "dir/scan{h.start.scan_id}_by_{h.start.experimenter}_{N}.tiff"
+    fetch : str or callable object, optional
+        Set function that will generate 2D arrays from databroker Header.
+        When string, obtain arrays using ``get_images(h, NAME)``.
+        See the TiffExporter class for more details.
+    template : str, optional
+        Set filename template where curly brackets are filled with entries
+        from databroker Header.  See the DataNaming class for more details.
+    prefix : str, optional
+        Set filename prefix, a constant output directory that is prepended
+        to generated filenames.
+        Default is ''.
+    kwargs : TiffExporter attributes, optional
+        Use to set any additional attributes of the constructed TiffExporter
+        object.  Raise AttributeError when TiffExporter does not have such
+        attribute.
 
     Returns
     -------
-    f : function
-        a function that accepts a header and saves TIFF files
+    TiffExporter
+        a callable object that accepts a header and saves TIFF files.
+
+    See Also
+    --------
+    bluesky.datanaming.TiffExporter : configurable TIFF export from a header.
+    bluesky.datanaming.DataNaming : file name generation from a header.
     """
-    # validate user input
-    if not '{N}' in template:
-        raise ValueError("template must include '{N}'")
-
-    def f(h, dryrun=False):
-        imgs = get_images(h, field)
-        # Fill in h, defer filling in N.
-        _template = template.format(h=h, N='{N}')
-        filenames = [_template.format(N=i) for i in range(len(imgs))]
-        # First check that none of the filenames exist.
-        for filename in filenames:
-            if os.path.isfile(filename):
-                raise FileExistsError("There is already a file at {}. Delete "
-                                      "it and try again.".format(filename))
-        if not dryrun:
-            # Write files.
-            for filename, img in zip(filenames, imgs):
-                tifffile.imsave(filename, np.asarray(img))
-        return filenames
-
-    # Write a customized docstring for f based on what is specifcally does.
-    f.__doc__ = """
-Export sequentially-numbered TIFF files from the {field} field.
-
-Parameters
-----------
-h : Header
-    a header from the databroker
-dryrun : bool
-    Set to True to return list of filenames without actually writing files.
-    False by default.
-
-Returns
--------
-filenames : list
-    list of filenames where files were written (or, if dryrun, *would* be
-    written)
-""".format(field=field)
-    return f
+    from bluesky.tiffexporter import TiffExporter
+    te = TiffExporter(fetch=fetch, template=template, prefix=prefix)
+    # validate and apply keyword arguments
+    emsg = "Invalid keyword argument {}, TiffExporter has no such attribute."
+    for n, v in kwargs.items():
+        if not hasattr(te, n):
+            raise AttributeError(emsg.format(n))
+        setattr(te, n, v)
+    return te

--- a/bluesky/datanaming.py
+++ b/bluesky/datanaming.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+
+
+"""Generation of file names for each event in databroker header.
+"""
+
+
+import os.path
+import re
+
+
+class DataNaming(object):
+    """
+    Build filenames from fields in databroker header.
+
+    Attributes
+    ----------
+    default_template : str, class attribute
+        Default value for the `template` when not specified.
+
+    template : str
+        filename template where curly brackets are filled with entries from
+        databroker header using the Python format mini-language.  Template
+        segments denoted with "<>", e.g., '<segment>' are silently omitted,
+        when their expansion fails.  The template expressions recognize the
+        following variables:
+
+        h    -- Header
+        e    -- Event object from the Header h.
+        N    -- sequence number of the Event e.
+        start    -- abbreviation for h.start
+        stop     -- abbreviation for h.stop if it exists
+        scan_id  -- abbreviation for h.start.scan_id
+
+    prefix : str
+        constant output directory that is prepended to the generated name.
+
+    Parameters
+    ----------
+    template : str, optional
+        Set the `template` attribute.  Use the `default_template` value
+        by default.
+    prefix : str, optional
+        Set the fixed ouput path `prefix`.
+    """
+
+    default_template = 'scan{scan_id:05d}_{N:03d}<-T{e.data[cs700]:03.1f}>.tiff'
+
+
+    def __init__(self, template=None, prefix=''):
+        self.template = self.default_template if template is None else template
+        self.prefix = prefix
+        return
+
+
+    def __repr__(self):
+        nm = type(self).__name__
+        fmt = "{0}(template={1.template!r}, prefix={1.prefix!r})"
+        return fmt.format(nm, self)
+
+
+    def __call__(self, h):
+        """
+        Generate names from fields in databroker header h.
+
+        Parameters
+        ----------
+        h : Header
+            a header from the databroker
+
+        Returns
+        -------
+        list
+            Filenames generated for the header.
+        """
+        from dataportal import get_events
+        tparts = self._split_template(self.template)
+        td = dict(h=h, start=h.start, scan_id=h.start.scan_id)
+        td['stop'] = getattr(h, 'stop', None)
+        events = get_events(h, fill=False)
+        rv = [self._makename(tparts, td)
+                for td['N'], td['e'] in enumerate(events)]
+        return rv
+
+
+    _template = None
+
+    @property
+    def template(self):
+        """
+        Template for generating names from databroker fields.
+
+        Raises
+        ------
+        ValueError
+            When a new template does not include event index {N}
+            or if it has unbalanced segment markers '<>'.
+        """
+        return self._template
+
+    @template.setter
+    def template(self, value):
+        self._validate_template(value)
+        self._template = value
+        return
+
+
+    def _makename(self, tparts, td):
+        nmparts = []
+        for seg, isopt in tparts:
+            try:
+                s = seg.format(**td)
+            except (AttributeError, KeyError):
+                if not isopt:  raise
+                s = ''
+            nmparts.append(s)
+        rv = ''.join(nmparts)
+        rv = os.path.join(self.prefix, rv)
+        return rv
+
+
+    @staticmethod
+    def _validate_template(t):
+        "Raise ValueError for invalid template string."
+        hasN = re.search(r'\{N\b', t)
+        if not hasN:
+            raise ValueError("template must include '{N}'")
+        tfixed = re.sub('[{][^}]*[}]', '', t)
+        cleft = tfixed.count('<')
+        cright = tfixed.count('>')
+        if cleft != cright:
+            raise ValueError("Unbalanced segment markers '<', '>'")
+        if re.search('<[^>]<|>[^<]*>', t):
+            raise ValueError("Nested or misordered segment markers '<', '>'")
+        return
+
+
+    @staticmethod
+    def _split_template(t):
+        """Split template string at '<segment>' markers.
+
+        Returns
+        -------
+        list
+            Template split into a list of `(component, optional)` pairs
+            where the `optional` flag marks up an optional components.
+        """
+        segments = [[]]
+        barebrac = re.split(r'(\{[^}]*\})', t)
+        isopt = False
+        isbracket = False
+        while barebrac:
+            w = barebrac.pop(0)
+            delim = '>' if isopt else '<'
+            if isbracket or not delim in w:
+                segments[-1].append(w)
+                isbracket = not isbracket
+                continue
+            assert delim in w
+            wb, we = w.split(delim, 1)
+            segments[-1].append(wb)
+            segments.append([])
+            isopt = not isopt
+            barebrac.insert(0, we)
+            continue
+        rv = []
+        for i, seg in enumerate(segments):
+            isopt = bool(i % 2)
+            s = ''.join(seg)
+            if s:  rv.append((s, isopt))
+        return rv
+
+# class DataNaming

--- a/bluesky/datanaming.py
+++ b/bluesky/datanaming.py
@@ -8,6 +8,8 @@
 import os.path
 import re
 
+from dataportal import get_events
+
 
 class DataNaming(object):
     """
@@ -73,7 +75,6 @@ class DataNaming(object):
         list
             Filenames generated for the header.
         """
-        from dataportal import get_events
         tparts = self._split_template(self.template)
         td = dict(h=h, start=h.start, scan_id=h.start.scan_id)
         td['stop'] = getattr(h, 'stop', None)

--- a/bluesky/tests/test_datanaming.py
+++ b/bluesky/tests/test_datanaming.py
@@ -1,0 +1,52 @@
+from nose.tools import assert_equal, assert_is, assert_raises
+from bluesky.datanaming import ConditionalFormat
+
+
+class TestConditionalFormat:
+
+    def test_validate(self):
+        validate = ConditionalFormat.validate
+        # pass for paired markers or any markers in format fields
+        assert_is(None, validate("{first}< {last}>"))
+        assert_is(None, validate("{first} {last}"))
+        assert_is(None, validate("{first<5}"))
+        assert_is(None, validate("{first>99}"))
+        # fail for unbalanced or nested markers
+        assert_raises(ValueError, validate, "<{first}")
+        assert_raises(ValueError, validate, "{first}>")
+        assert_raises(ValueError, validate, "{first} <<{last}>>")
+        assert_raises(ValueError, validate, "<{first}> >{last}<")
+        return
+
+
+    def test___str__(self):
+        cfmt = ConditionalFormat("<foo>bar")
+        assert_equal("<foo>bar", str(cfmt))
+        assert_equal("<foo>bar", cfmt.s)
+        return
+
+
+    def test_format(self):
+        cfmt = ConditionalFormat("<foo>bar")
+        assert_equal('foobar', cfmt.format())
+        cfmt = ConditionalFormat("{first}< {mi}.> {last}")
+        assert_raises(KeyError, cfmt.format)
+        assert_equal('John Doe', cfmt.format(first='John', last='Doe'))
+        assert_equal('John M. Doe', cfmt.format(
+            first='John', last='Doe', mi='M'))
+        assert_raises(KeyError, cfmt.format, first='John', mi='M')
+        class _Entry:
+            pass
+        e = _Entry()
+        e.first = "John"
+        # raise exception for missing attributes in standard segments
+        cfmt = ConditionalFormat("{e.first}< {e.mi}.> {e.last}")
+        assert_raises(AttributeError, cfmt.format, e=e)
+        # omit when attribute is missing in a conditional segment
+        e.last = "Doe"
+        assert_equal('John Doe', cfmt.format(e=e))
+        e.mi = "M"
+        assert_equal('John M. Doe', cfmt.format(e=e))
+        return
+
+# class TestConditionalFormat

--- a/bluesky/tiffexporter.py
+++ b/bluesky/tiffexporter.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python
+
+
+"""Export of 2D image data from databroker header in TIFF format.
+"""
+
+import os.path
+import datetime
+
+from bluesky.datanaming import DataNaming
+
+
+class TiffExporter(object):
+    """
+    Export detector image data from databroker header in a TIFF format.
+
+    Build a callable object which saves image data from a databroker
+    header.  Output files are built from a template that may include values
+    from the header and its associated events.  TiffExporter can either
+    skip or overwrite already existing files.  The TIFF file modification
+    time is by default set to the timestamp of the exported event.  The
+    timestamp is also used to identify already exported images, possibly
+    under a different naming scheme.
+
+    Attributes
+    ----------
+    default_fetch : str or callable object, class attribute
+        Default value for the `fetch` argument in initialization.
+        Default is 'pe1_image_lightfield'.
+    fetch : callable object
+        Function which generates 2D output arrays from databroker Header.
+        When set to a string NAME, extract arrays using
+        ``databroker.get_images(h, NAME)``.
+    naming : DataNaming instance
+        Callable object which generates output file names from databroker
+        Header.  Use ``naming(h)`` to obtain a list of output names.
+        To adjust naming scheme, modifying the `naming.template` and
+        `naming.prefix` attributes.
+    use_mtime : bool
+        When True (default), write output files with modification time set
+        according to the exported Event.  Also use modification time to
+        identify existing outputs.  When False, write files with current
+        modification time and only check if target paths exist.
+        Default is `True`.
+    mtime_window : float
+        Precision in file modification times when searching for existing
+        output files.   Ignored when `use_mtime` is `False`.
+
+    Parameters
+    ----------
+    fetch : str or callable object, optional
+        Set function that will generate 2D arrays from databroker Header.
+        When string, obtain arrays using ``get_images(h, NAME)``.
+        Use the `default_fetch` value when not specified.
+    template : str, optional
+        Set `naming.template`, a filename template where curly brackets
+        are filled with entries from databroker Header.  See the DataNaming
+        class for more details.
+    prefix : str, optional
+        Set `naming.prefix` a constant output directory that is prefixed
+        to the generated filenames.
+        Default is ''.
+
+    See Also
+    --------
+    bluesky.datanaming.DataNaming : file name generation from a header.
+    """
+
+    # class attributes and defaults
+
+    default_fetch = 'pe1_image_lightfield'
+    use_mtime = True
+    mtime_window = 0.05
+
+
+    def __init__(self, fetch=None, template=None, prefix=None):
+        self.fetch = self.default_fetch if fetch is None else fetch
+        self.naming = DataNaming(template, prefix)
+        return
+
+
+    def __repr__(self):
+        nm = type(self).__name__
+        rv = ("<{0} fetch:{1.fetch} naming:{1.naming} "
+               "use_mtime:{1.use_mtime}>").format(nm, self)
+        return rv
+
+
+    def __call__(self, h, select=None, dryrun=False, overwrite=False):
+        """Export sequentially-numbered TIFF files from databroker header.
+
+        Parameters
+        ----------
+        h : Header
+            a header from the databroker
+        select : integer indices or mask array or slice, optional
+            Export image arrays only at corresponding indices, for example,
+            ``[4, 5]`` or ``numpy.s_[-3:]``.  Export all images by default.
+        dryrun : bool, optional
+            When True, display what would be done without taking any
+            action.
+        overwrite : bool, optional
+            Replace existing tiff files when True.
+
+        Returns
+        -------
+        list
+            Exported output files.
+        """
+        import tifffile
+        from databroker import get_events
+        if dryrun:
+            dryordo = lambda msg, f, *args, **kwargs:  print(msg)
+        else:
+            dryordo = lambda msg, f, *args, **kwargs:  f(*args, **kwargs)
+        setmtime = lambda f, t: os.utime(f, (os.path.getatime(f), t))
+        noop = lambda : None
+        msgrm = "remove existing output {}"
+        msgskip = "skip {f} already saved as {o}"
+        outputfiles = self.naming(h)
+        eventtimes = [e.time for e in get_events(h, fill=False)]
+        n = len(eventtimes)
+        selection = _makesetofindices(n, select)
+        dircache = {}
+        outputfrom = {
+                f : self.outputFileExists(f,
+                    mtime=self.use_mtime and etime, dircache=dircache)
+                for f, etime in zip(outputfiles, eventtimes)}
+        imgs = self.fetch(h)
+        rv = []
+        for i, f, img, etime in zip(range(n), outputfiles, imgs, eventtimes):
+            if not i in selection:  continue
+            existingoutputs = outputfrom[f]
+            # skip this image when overwrite is False
+            if not overwrite:
+                for o in existingoutputs:
+                    print(msgskip.format(f=f, o=o))
+                if existingoutputs:  continue
+            assert overwrite or not existingoutputs
+            for o in existingoutputs:
+                dryordo(msgrm.format(o), os.remove, o)
+            msg = "write image data to {}".format(f)
+            dryordo(msg, tifffile.imsave, f, img)
+            rv.append(f)
+            if self.use_mtime:
+                isotime = datetime.datetime.fromtimestamp(etime).isoformat(' ')
+                msg = "adjust image file mtime to {}".format(isotime)
+                dryordo(msg, setmtime, f, etime)
+        return rv
+
+
+    def findExistingOutputs(self, h, select=None):
+        """Find any already saved output files given a databroker header.
+
+        When `use_mtime` is active, find files with the same extension
+        and output directory that have the same modification time.
+
+        Parameters
+        ----------
+        h : Header
+            a header from the databroker
+        select : integer indices or mask array or slice, optional
+            Find outputs only for the events at specified indices, for
+            example, ``[0, 1, 2]`` or ``numpy.s_[-3:]``.  Search all
+            events by default.
+
+        Returns
+        -------
+        list
+            Existing absolute output paths or an empty list.
+        """
+        from databroker import get_events
+        # avoid repeated calls to os.listdir
+        dircache = {}
+        filenames = self.naming(h)
+        eventtimes = [e.time for e in get_events(h, fill=False)]
+        if not self.use_mtime:
+            eventtimes = len(eventtimes) * [None]
+        n = len(eventtimes)
+        selection = _makesetofindices(n, select)
+        rv = []
+        for i, f, etime in zip(range(n), filenames, eventtimes):
+            if not i in selection:  continue
+            rv.extend(self.outputFileExists(f, etime, dircache=dircache))
+        return rv
+
+
+    def outputFileExists(self, filename, mtime, dircache=None):
+        """Check for already saved instances of the given output path.
+
+        When `mtime` is non-zero, include files with the same extension
+        and directory that have that modification time.
+
+        Parameters
+        ----------
+        filename : str
+            output filename to be checked
+        mtime : float or None
+            modification time in epoch seconds to be used for locating
+            outputs with a different naming scheme.  Do not use when
+            zero or None.
+        dircache : dict, optional
+            cached outputs from `os.listdir`.  For internal use only.
+
+        Returns
+        -------
+        list
+            Existing absolute output paths or an empty list.
+        """
+        fa = os.path.abspath(filename)
+        rv = [fa] if os.path.exists(filename) else []
+        if not mtime:  return rv
+        outputdir = os.path.abspath(os.path.dirname(filename))
+        ext = os.path.splitext(filename)
+        dircache = dircache if dircache is not None else {}
+        if not outputdir in dircache:
+            ofiles = [os.path.join(outputdir, f)
+                    for f in os.listdir(outputdir)]
+            ofiles = [f for f in ofiles
+                    if f.endswith(ext) and os.path.isfile(f)]
+            dircache[outputdir] = ofiles
+        for f in dircache[outputdir]:
+            if f == fa:
+                assert rv[0] == f
+                continue
+            dt = abs(os.path.getmtime(f) - mtime)
+            if dt < self.mtime_window:
+                rv.append(f)
+        return rv
+
+    # Properties -------------------------------------------------------------
+
+    @property
+    def fetch(self):
+        """Function that generates image arrays from a databroker headers.
+
+        Must be a callable object or a string.  When set to a string NAME,
+        use get_images(headers, NAME).
+        """
+        return self._fetch
+
+    @fetch.setter
+    def fetch(self, value):
+        if isinstance(value, str):
+            from functools import partial
+            from databroker import get_images
+            self._fetch = partial(get_images, name=value)
+        elif callable(value):
+            self._fetch = value
+        else:
+            emsg = "The fetch attribute must be a string or callable object."
+            raise TypeError(emsg)
+        return
+
+# class TiffExporter
+
+
+def _makesetofindices(n, select):
+    import numpy
+    indices = numpy.arange(n)
+    if select is not None:
+        indices = indices[select].flat
+    return set(indices)

--- a/bluesky/tiffexporter.py
+++ b/bluesky/tiffexporter.py
@@ -6,7 +6,10 @@
 
 import os.path
 import datetime
+import functools
+import numpy
 
+from databroker import get_events, get_images
 from bluesky.datanaming import DataNaming
 
 
@@ -108,7 +111,6 @@ class TiffExporter(object):
             Exported output files.
         """
         import tifffile
-        from databroker import get_events
         if dryrun:
             dryordo = lambda msg, f, *args, **kwargs:  print('[dryrun]', msg)
         else:
@@ -169,7 +171,6 @@ class TiffExporter(object):
         list
             Existing absolute output paths or an empty list.
         """
-        from databroker import get_events
         # avoid repeated calls to os.listdir
         dircache = {}
         filenames = self.naming(h)
@@ -242,9 +243,7 @@ class TiffExporter(object):
     @fetch.setter
     def fetch(self, value):
         if isinstance(value, str):
-            from functools import partial
-            from databroker import get_images
-            self._fetch = partial(get_images, name=value)
+            self._fetch = functools.partial(get_images, name=value)
         elif callable(value):
             self._fetch = value
         else:
@@ -254,9 +253,9 @@ class TiffExporter(object):
 
 # class TiffExporter
 
+# Local helpers --------------------------------------------------------------
 
 def _makesetofindices(n, select):
-    import numpy
     indices = numpy.arange(n)
     if select is not None:
         indices = indices[select].flat

--- a/bluesky/tiffexporter.py
+++ b/bluesky/tiffexporter.py
@@ -110,7 +110,7 @@ class TiffExporter(object):
         import tifffile
         from databroker import get_events
         if dryrun:
-            dryordo = lambda msg, f, *args, **kwargs:  print(msg)
+            dryordo = lambda msg, f, *args, **kwargs:  print('[dryrun]', msg)
         else:
             dryordo = lambda msg, f, *args, **kwargs:  f(*args, **kwargs)
         setmtime = lambda f, t: os.utime(f, (os.path.getatime(f), t))


### PR DESCRIPTION
Add configurable TiffExporter class with a similar defaults as the exporter function.  Move output name generation to a DataNaming class.  Support custom data-extraction function when image data need to be transformed. @danielballan, @chiahaoliu, @sbillinge

## demo session at XPD

```python
In [1]: from bluesky.broker_callbacks import make_tiff_exporter
        from dataportal.broker import DataBroker as db
        h = db['97064560']
        te = make_tiff_exporter(prefix='/tmp')
Out[1]: <TiffExporter 
  fetch:functools.partial(<function get_images at 0x7fab5b840b70>, name='pe1_image_lightfield')
  naming:DataNaming(template='apples{scan_id:05d}_{N:03d}<-T{e.data[cs700]:03.1f}>.tiff', prefix='/tmp')
  use_mtime:True>

In [2]: te.naming(h)
Out[2]:
['/tmp/scan00015_000.tiff',
 '/tmp/scan00015_001.tiff',
 '/tmp/scan00015_002.tiff',
 '/tmp/scan00015_003.tiff',
 '/tmp/scan00015_004.tiff',
 '/tmp/scan00015_005.tiff']

In [3]: te.findExistingOutputs(h)
Out[3]: []

In [4]: te(h, dryrun=1);
[dryrun] write image data to /tmp/scan00015_000.tiff
[dryrun] adjust image file mtime to 2015-09-24 14:13:12.031946
[dryrun] write image data to /tmp/scan00015_001.tiff
[dryrun] adjust image file mtime to 2015-09-24 14:13:23.855054
[dryrun] write image data to /tmp/scan00015_002.tiff
[dryrun] adjust image file mtime to 2015-09-24 14:13:36.101679
[dryrun] write image data to /tmp/scan00015_003.tiff
[dryrun] adjust image file mtime to 2015-09-24 14:13:48.093346
[dryrun] write image data to /tmp/scan00015_004.tiff
[dryrun] adjust image file mtime to 2015-09-24 14:13:59.882183
[dryrun] write image data to /tmp/scan00015_005.tiff
[dryrun] adjust image file mtime to 2015-09-24 14:14:11.803296

In [5]: te(h, dryrun=1, select=slice(3));
[dryrun] write image data to /tmp/scan00015_000.tiff
[dryrun] adjust image file mtime to 2015-09-24 14:13:12.031946
[dryrun] write image data to /tmp/scan00015_001.tiff
[dryrun] adjust image file mtime to 2015-09-24 14:13:23.855054
[dryrun] write image data to /tmp/scan00015_002.tiff
[dryrun] adjust image file mtime to 2015-09-24 14:13:36.101679

In [6]: te(h, select=range(3));
Out[6]:
['/tmp/scan00015_000.tiff',
 '/tmp/scan00015_001.tiff',
 '/tmp/scan00015_002.tiff']

In [7]: te(h, dryrun=1)
[dryrun] skip /tmp/scan00015_000.tiff already saved as /tmp/scan00015_000.tiff
[dryrun] skip /tmp/scan00015_001.tiff already saved as /tmp/scan00015_001.tiff
[dryrun] skip /tmp/scan00015_002.tiff already saved as /tmp/scan00015_002.tiff
[dryrun] write image data to /tmp/scan00015_003.tiff
[dryrun] adjust image file mtime to 2015-09-24 14:13:48.093346
[dryrun] write image data to /tmp/scan00015_004.tiff
[dryrun] adjust image file mtime to 2015-09-24 14:13:59.882183
[dryrun] write image data to /tmp/scan00015_005.tiff
[dryrun] adjust image file mtime to 2015-09-24 14:14:11.803296

In [8]: import re
        te.naming.template = re.sub('^scan', 'apples', te.naming.template)
        te(h, dryrun=1)
[dryrun] skip /tmp/apples00015_000.tiff already saved as /tmp/scan00015_000.tiff
[dryrun] skip /tmp/apples00015_001.tiff already saved as /tmp/scan00015_001.tiff
[dryrun] skip /tmp/apples00015_002.tiff already saved as /tmp/scan00015_002.tiff
[dryrun] write image data to /tmp/apples00015_003.tiff
[dryrun] adjust image file mtime to 2015-09-24 14:13:48.093346
[dryrun] write image data to /tmp/apples00015_004.tiff
[dryrun] adjust image file mtime to 2015-09-24 14:13:59.882183
[dryrun] write image data to /tmp/apples00015_005.tiff
[dryrun] adjust image file mtime to 2015-09-24 14:14:11.803296
Out[8]:
['/tmp/apples00015_003.tiff',
 '/tmp/apples00015_004.tiff',
 '/tmp/apples00015_005.tiff']

In [9]: te(h)
skip /tmp/apples00015_000.tiff already saved as /tmp/scan00015_000.tiff
skip /tmp/apples00015_001.tiff already saved as /tmp/scan00015_001.tiff
skip /tmp/apples00015_002.tiff already saved as /tmp/scan00015_002.tiff
Out[9]:
['/tmp/apples00015_003.tiff',
 '/tmp/apples00015_004.tiff',
 '/tmp/apples00015_005.tiff']

In [10]: te.findExistingOutputs(h)
Out[10]:
['/tmp/scan00015_000.tiff',
 '/tmp/scan00015_001.tiff',
 '/tmp/scan00015_002.tiff',
 '/tmp/apples00015_003.tiff',
 '/tmp/apples00015_004.tiff',
 '/tmp/apples00015_005.tiff']

In [11]: te(h, select=range(3), overwrite=1)
Out[11]:
['/tmp/apples00015_000.tiff',
 '/tmp/apples00015_001.tiff',
 '/tmp/apples00015_002.tiff']

In [12]: te.findExistingOutputs(h)
Out[12]:
['/tmp/apples00015_000.tiff',
 '/tmp/apples00015_001.tiff',
 '/tmp/apples00015_002.tiff',
 '/tmp/apples00015_003.tiff',
 '/tmp/apples00015_004.tiff',
 '/tmp/apples00015_005.tiff']

```