### PR TITLE
HACK: try to use motor.position in dscan

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -539,11 +539,15 @@ class AdaptiveDeltaScanPlan(_AdaptivePlanBase):
         return getattr(self, '_init_pos', None)
 
     def _pre(self):
-        ret = yield Msg('read', self.motor)
-        if len(ret.keys()) > 1:
-            raise NotImplementedError("Can't DScan a multiaxis motor")
-        key, = ret.keys()
-        current_value = ret[key]['value']
+        try:
+            current_value = self.motor.position
+        except AttributeError:
+            ret = yield Msg('read', self.motor)
+            if len(ret.keys()) > 1:
+                raise NotImplementedError("Can't DScan a multiaxis motor")
+            key, = ret.keys()
+            current_value = ret[key]['value']
+
         self._init_pos = current_value
         yield from super()._pre()
 
@@ -899,11 +903,14 @@ class InnerProductDeltaScanPlan(_InnerProductPlanBase):
         "Get current position for each motor."
         self._init_pos = {}
         for motor, start, stop, in chunked(self.args, 3):
-            ret = yield Msg('read', motor)
-            if len(ret.keys()) > 1:
-                raise NotImplementedError("Can't DScan a multiaxis motor")
-            key, = ret.keys()
-            current_value = ret[key]['value']
+            try:
+                current_value = motor.position
+            except AttributeError:
+                ret = yield Msg('read', motor)
+                if len(ret.keys()) > 1:
+                    raise NotImplementedError("Can't DScan a multiaxis motor")
+                key, = ret.keys()
+                current_value = ret[key]['value']
             self._init_pos[motor] = current_value
         yield from super()._pre()
 
@@ -974,11 +981,14 @@ class OuterProductDeltaScanPlan(_OuterProductPlanBase):
         "Get current position for each motor."
         self._init_pos = {}
         for motor, start, stop, num, snake in chunked(self.args, 5):
-            ret = yield Msg('read', motor)
-            if len(ret.keys()) > 1:
-                raise NotImplementedError("Can't DScan a multiaxis motor")
-            key, = ret.keys()
-            current_value = ret[key]['value']
+            try:
+                current_value = motor.position
+            except AttributeError:
+                ret = yield Msg('read', motor)
+                if len(ret.keys()) > 1:
+                    raise NotImplementedError("Can't DScan a multiaxis motor")
+                key, = ret.keys()
+                current_value = ret[key]['value']
             self._init_pos[motor] = current_value
         yield from super()._pre()
 


### PR DESCRIPTION
As originally conceived the D\*Plan family assumed that the motors
of interest only had 1 read key, however as implemented in the recent
versions of Ophyd EpicsMotor objects have 2 keys by
default (user_setpoint and user_readback) which causes D\*Plan to
fail (due to not knowing which of the keys to use as the 'primary' or
that semantically the those two keys are coupled).

This commit changes the plans to try to use the `Positioner` property
`position` while iterating through the Plan to extract the initial
position that should be returned to at the end of executing the Plan.
This breaks a key abstraction of the Plans (that they only interact with
the objects via the run engine), however this addresses a problem
discovered at the 11th hour without making any major architectural or API
changes to Ophyd or the RunEngine.

The best solution would be to provide an interface to the D*Plan classes
that can take as input the components of the 'motor' devices which
should be scanned, but that would require dropping the SPEC api clone.