### PR TITLE
HOTFIX: Apply key-guessing heuristic to more places

### DIFF
--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -28,7 +28,10 @@ class Base:
         self.read_attrs = fields
         self.configuration_attrs = []
         for field in fields:
-            setattr(self, field, MockSignal(field))
+            if isinstance(field, str):
+                # Flyers pass objects in as fields, not names.
+                # hotfix 2016 -- revisit this!
+                setattr(self, field, MockSignal(field))
 
     def describe(self):
         return {k: {'source': self.name, 'dtype': 'number', 'shape': None}

--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -7,12 +7,28 @@ from .run_engine import Msg
 loop = asyncio.get_event_loop()
 
 
+class MockSignal:
+    "hotfix for 2016 winter cycle -- build out more thoroughly later"
+    def __init__(self, field):
+        self._field = field
+
+    def read(self):
+        return {self._field: (0, 0)}
+
+    def describe(self):
+        return {self._field: (0, 0)}
+
+
 class Base:
     def __init__(self, name, fields):
         self.name = name
         self._fields = fields
         self._cb = None
         self._ready = False
+        self.read_attrs = fields
+        self.configuration_attrs = []
+        for field in fields:
+            setattr(self, field, MockSignal(field))
 
     def describe(self):
         return {k: {'source': self.name, 'dtype': 'number', 'shape': None}

--- a/bluesky/simple_scans.py
+++ b/bluesky/simple_scans.py
@@ -28,7 +28,8 @@ from bluesky.callbacks import LiveTable, LivePlot, LiveRaster, _get_obj_fields
 from bluesky.scientific_callbacks import PeakStats
 from boltons.iterutils import chunked
 from bluesky.global_state import gs
-from bluesky.utils import normalize_subs_input, Subs, DefaultSubs
+from bluesky.utils import (normalize_subs_input, Subs, DefaultSubs,
+                           first_key_heuristic)
 from collections import defaultdict
 from itertools import filterfalse, chain
 
@@ -55,21 +56,23 @@ def table_gs_only(scan):
 
 def plot_first_motor(scan):
     "Setup a LivePlot by inspecting a scan and gs."
-    fig_name = 'BlueSky: {} v {}'.format(list(scan.motors)[0].name, gs.PLOT_Y)
+    key = first_key_heuristic(list(scan.motors)[0])
+    fig_name = 'BlueSky: {} v {}'.format(key, gs.PLOT_Y)
     fig = plt.figure(fig_name)
     if not gs.OVERPLOT:
         fig.clf()
-    return LivePlot(gs.PLOT_Y, list(scan.motors)[0].name, fig=fig)
+    return LivePlot(gs.PLOT_Y, key, fig=fig)
 
 
 def plot_motor(scan):
     "Setup a LivePlot by inspecting a scan and gs."
-    fig_name = 'BlueSky: {} v {}'.format(scan.motor.name, gs.PLOT_Y)
+    key = first_key_heuristic(scan.motor)
+    fig_name = 'BlueSky: {} v {}'.format(key, gs.PLOT_Y)
 
     fig = plt.figure(fig_name)
     if not gs.OVERPLOT:
         fig.clf()
-    return LivePlot(gs.PLOT_Y, scan.motor.name, fig=fig)
+    return LivePlot(gs.PLOT_Y, key, fig=fig)
 
 
 def raster(scan):
@@ -86,16 +89,16 @@ def raster(scan):
 
 def peakstats_first_motor(scan):
     "Set up peakstats"
-    ps = PeakStats(_get_obj_fields([list(scan.motors)[0]])[0],
-                   gs.MASTER_DET_FIELD, edge_count=3)
+    key = first_key_heuristic(list(scan.motors)[0])
+    ps = PeakStats(key, gs.MASTER_DET_FIELD, edge_count=3)
     gs.PS = ps
     return ps
 
 
 def peakstats(scan):
     "Set up peakstats"
-    ps = PeakStats(_get_obj_fields([scan.motor])[0],
-                   gs.MASTER_DET_FIELD, edge_count=3)
+    key = first_key_heuristic(scan.motor)
+    ps = PeakStats(key, gs.MASTER_DET_FIELD, edge_count=3)
     gs.PS = ps
     return ps
 

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -393,7 +393,8 @@ def first_key_heuristic(device):
     """
     Get the fully-qualified data key for the first entry in read_attrs.
 
-    This will raise is that entry is not a Signal.
+    This will raise is that entry's `describe()` method does not return a
+    dictionary with exactly one key.
     """
     first_attr = device.read_attrs[0]
     key, = getattr(device, first_attr).describe().keys()

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -387,3 +387,29 @@ def snake_cyclers(cyclers, snake_booleans):
             expanded = v2[:total_length]
             new_cyclers.append(cycler(k, expanded))
     return reduce(operator.add, new_cyclers)
+
+
+def first_key_heuristic(device):
+    """
+    Get the fully-qualified data key for the first entry in read_attrs.
+
+    This will raise is that entry is not a Signal.
+    """
+    first_attr = device.read_attrs[0]
+    key, = getattr(device, first_attr).describe().keys()
+    return key
+
+
+def scalar_heuristic(device):
+    """
+    If a device like a motor has multiple read_fields, we need some way of
+    knowing which one is the 'primary' or 'scalar' position, the one to
+    use as the "initial position" when computing a relative trajecotry
+    or the one to plot against when automatically choosing at x variable.
+
+    This is a hot-fix in advance of the Winter 2016 cycle -- should be
+    rethought when there is time.
+    """
+    reading = device.read()
+    key = first_key_heuristic(device)
+    return reading[key]['value']


### PR DESCRIPTION
Following up on #281, a little less hack-ish. Bluesky looks at the *order* of `read_attrs` and assumes the first one is the one it should use to (1) compute relative trajectories and (2) plot against in the subscription factories in `simple_scans.py`.