### PR TITLE
ENH: throw exceptions at generator

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -661,10 +661,16 @@ class RunEngine:
                         # We have a checkpoint.
                         self._msg_cache.append(msg)
                     self._new_gen = False
-                    coro = self._command_registry[msg.command]
-                    logger.debug("Processing message %r", msg)
-                    self.debug("About to process: {0}, {1}".format(coro, msg))
-                    response = yield from coro(msg)
+                    try:
+                        coro = self._command_registry[msg.command]
+                        logger.debug("Processing message %r", msg)
+                        self.debug("About to process: {0}, {1}".
+                                   format(coro, msg))
+                        response = yield from coro(msg)
+                    except KeyboardInterrupt:
+                        raise
+                    except Exception as e:
+                        self._genstack[-1].throw(e)
                     self.debug('RE.state: ' + self.state)
                     self.debug('msg: {}\n  response: {}'.format(msg, response))
                 except KeyboardInterrupt:


### PR DESCRIPTION
If the run engine has an exception raised during
 - look up of the coroutine to run
 - running the coroutine

throw the exception back at the generator.  This gives two
major features:

 - tracebacks will include the line in the generator which yielded the
   bad message
 - allows generators to attempt to handle the excetion without killing
   the run.