### PR TITLE
Include object names in Start document

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -24,9 +24,6 @@ class PlanBase(Struct):
       set, which is used to stage/unstage everything
     - a class level ``_fields`` attribute which is used to
       construct the init signature via meta-class magic
-    - optionally, a class level ``_derived_fields`` attribute which is used to
-      indicate other attributes, beyond _fields, which should be included in
-      metadata
 
     If you do not use the class-level ``_fields`` and write a custom
     ``__init__`` (which you need to do if you want to have optional kwargs)
@@ -41,15 +38,9 @@ class PlanBase(Struct):
         """
         a metadata dictionary, passed to the 'open_run' Message
         """
-        for field in self._fields + self._derived_fields:
-            self._md[field] = repr(getattr(self, field))
-        # The 'plan_args' key is a dict of kwargs that recreate the object.
-        # It is an intentionally redundant subset of the top-level metadata.
-        plan_args = {}
-        for field in self._fields:
-            plan_args[field] = repr(getattr(self, field))
-        self._md['plan_args'] = plan_args
         self._md['plan_type'] = type(self).__name__
+        self._md['plan_args'] = {field: repr(getattr(self, field))
+                                 for field in self._fields}
         return self._md
 
     def __iter__(self):


### PR DESCRIPTION
This a change to PlanBase. ~~I'd like to get it in before users start taking data tomorrow.~~ (There are no users tomorrow after all.)

It would be nice to be able to search on object name:

```python
db(start_time='2016-01-19', detectors='fccd')
```

where mongo should interpret this as, "all of yesterday's scans that included that fccd as a detector."

This PR adds top-level fields to the Start Document for every category of object ('motor' or 'motors', 'detector' or 'detectors'). This is addition to storing the full reprs in 'plan_args', as we have been doing for some time now.

This also strips out some gratuitous complication from PlanBase. The 'derived_fields' concept is no more. It was supposed to make custom metadata "easy," but it really only made things more complicated.