### PR TITLE
ENH: Support infinite ct: Count(num=None)

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -73,11 +73,11 @@ class PlanBase(Struct):
         yield Msg('open_run', **self.md)
         for flyer in self.flyers:
             yield Msg('kickoff', flyer, block_group='_flyers')
-            yield Msg('wait', None, '_flyers')
+        yield Msg('wait', None, '_flyers')
         yield from self._gen()
         for flyer in self.flyers:
             yield Msg('collect', flyer, block_group='_flyers')
-            yield Msg('wait', None, '_flyers')
+        yield Msg('wait', None, '_flyers')
         yield Msg('close_run')
         for token in tokens:
             yield Msg('unsubscribe', None, token)
@@ -174,8 +174,7 @@ class Count(PlanBase):
         yield Msg('create')
         for det in dets:
             yield Msg('trigger', det, block_group='A')
-        for det in dets:
-            yield Msg('wait', None, 'A')
+        yield Msg('wait', None, 'A')
         for det in dets:
             yield Msg('read', det)
         yield Msg('save')
@@ -201,8 +200,7 @@ class Plan1D(PlanBase):
             yield Msg('read', self.motor)
             for det in dets:
                 yield Msg('trigger', det, block_group='B')
-            for det in dets:
-                yield Msg('wait', None, 'B')
+            yield Msg('wait', None, 'B')
             for det in dets:
                 yield Msg('read', det)
             yield Msg('save')
@@ -452,8 +450,7 @@ class _AdaptivePlanBase(PlanBase):
             yield Msg('read', motor)
             for det in dets:
                 yield Msg('trigger', det, block_group='B')
-            for det in dets:
-                yield Msg('wait', None, 'B')
+            yield Msg('wait', None, 'B')
             for det in dets:
                 cur_det = yield Msg('read', det)
                 if target_field in cur_det:
@@ -662,8 +659,7 @@ class Center(PlanBase):
             seen_x.append(ret_mot[key]['value'])
             for det in dets:
                 yield Msg('trigger', det, block_group='B')
-            for det in dets:
-                yield Msg('wait', None, 'B')
+            yield Msg('wait', None, 'B')
             for det in dets:
                 ret_det = yield Msg('read', det)
                 if target_field in ret_det:
@@ -693,8 +689,7 @@ class Center(PlanBase):
             seen_x.append(ret_mot[key]['value'])
             for det in dets:
                 yield Msg('trigger', det, block_group='B')
-            for det in dets:
-                yield Msg('wait', None, 'B')
+            yield Msg('wait', None, 'B')
             for det in dets:
                 ret_det = yield Msg('read', det)
                 if target_field in ret_det:
@@ -741,8 +736,7 @@ class PlanND(PlanBase):
                 yield Msg('read', motor)
             for det in dets:
                 yield Msg('trigger', det, block_group='B')
-            for det in dets:
-                yield Msg('wait', None, 'B')
+            yield Msg('wait', None, 'B')
             for det in dets:
                 yield Msg('read', det)
             yield Msg('save')


### PR DESCRIPTION
This is a little piece of SPEC functionality that we are missing. The intention here is that the scan will end with a user-initiated pause + stop or abort.

@cmazzoli and @ambarb asked for `ct(num=0)`, but in Python we prefer not to use numbers as sentinel values. Instead we can use `ct(num=None)`, which is, if you think about it, a more accurate description of what is happening. I hope this is suitable for you. :- )