### PR TITLE
TST: Fix LiveTable test by using lossless subs.

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -251,17 +251,21 @@ class RunEngine:
             'wait_for': self._wait_for,
         }
 
-        # public dispatcher for callbacks processed on the main thread
+        # public dispatcher for callbacks
+        # The Dispatcher's public methods are exposed through the
+        # RunEngine for user convenience.
         self.dispatcher = Dispatcher()
         self.ignore_callback_exceptions = True
         self.event_timeout = 0.1
         self.subscribe = self.dispatcher.subscribe
         self.unsubscribe = self.dispatcher.unsubscribe
 
-        # private registry of "critical" callbacks
+        # private dispatcher of critical callbacks
         # which get a lossless Event stream and abort a run if they raise
-        self._lossless_cb_registry = CallbackRegistry(
-            allowed_sigs=DocumentNames)
+        # Ths subscribe/unsubscribe are exposed through the RunEngine
+        # as subscribe_lossless and unsubscribe_lossless, defined below
+        # to provide special docstrings.
+        self._lossless_dispatcher = Dispatcher()
 
         self.verbose = False
 
@@ -451,7 +455,7 @@ class RunEngine:
         token : int
             an integer token that can be used to unsubscribe
         """
-        return self._lossless_cb_registry.connect(name, func)
+        return self._lossless_dispatcher.subscribe(name, func)
 
     def unsubscribe_lossless(self, token):
         """Un-register a 'critical' callback function.
@@ -461,7 +465,7 @@ class RunEngine:
         token : int
             an integer token returned by _subscribe_lossless
         """
-        self._lossless_cb_registry.disconnect(token)
+        self._lossless_dispatcher.unsubscribe(token)
 
     def __call__(self, plan, subs=None, **metadata_kw):
         """Run the scan defined by ``plan``
@@ -1151,7 +1155,7 @@ class RunEngine:
     def emit(self, name, doc):
         "Process blocking callbacks and schedule non-blocking callbacks."
         jsonschema.validate(doc, schemas[name])
-        self._lossless_cb_registry.process(name, name.name, doc)
+        self._lossless_dispatcher.process(name, doc)
         if name != DocumentNames.event:
             self.dispatcher.process(name, doc)
             logger.info("Emitting %s document: %r", name.name, doc)

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -272,10 +272,6 @@ class RunEngine:
         loop.call_soon(self._check_for_trouble)
         loop.call_soon(self._check_for_signals)
 
-        # aliases for back-compatibility
-        self._unsubscribe_lossless = self.unsubscribe_lossless
-        self._subscribe_lossless = self.subscribe_lossless
-
     @property
     def _run_is_open(self):
         return self._run_start_uid is not None
@@ -466,6 +462,10 @@ class RunEngine:
             an integer token returned by _subscribe_lossless
         """
         self._lossless_dispatcher.unsubscribe(token)
+
+    # aliases for back-compatibility
+    _unsubscribe_lossless = unsubscribe_lossless
+    _subscribe_lossless = subscribe_lossless
 
     def __call__(self, plan, subs=None, **metadata_kw):
         """Run the scan defined by ``plan``

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -268,6 +268,10 @@ class RunEngine:
         loop.call_soon(self._check_for_trouble)
         loop.call_soon(self._check_for_signals)
 
+        # aliases for back-compatibility
+        self._unsubscribe_lossless = self.unsubscribe_lossless
+        self._subscribe_lossless = self.subscribe_lossless
+
     @property
     def _run_is_open(self):
         return self._run_start_uid is not None
@@ -423,7 +427,7 @@ class RunEngine:
                 print("Cannot pause from {0} state. "
                       "Ignoring request.".format(self.state))
 
-    def _subscribe_lossless(self, name, func):
+    def subscribe_lossless(self, name, func):
         """Register a callback function to consume documents.
 
         Functions registered here are considered "critical." They receive
@@ -449,7 +453,7 @@ class RunEngine:
         """
         return self._lossless_cb_registry.connect(name, func)
 
-    def _unsubscribe_lossless(self, token):
+    def unsubscribe_lossless(self, token):
         """Un-register a 'critical' callback function.
 
         Parameters

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -116,11 +116,12 @@ def test_subscribe_msg():
 def test_unknown_cb_raises():
     def f(name, doc):
         pass
-    # Dispatches catches this case.
     with pytest.raises(KeyError):
         RE.subscribe('not a thing', f)
-    # CallbackRegistry catches this case (different error).
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
+        RE.subscribe_lossless('not a thing', f)
+    # back-compat alias for subscribe_lossless
+    with pytest.raises(KeyError):
         RE._subscribe_lossless('not a thing', f)
 
 

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -139,7 +139,10 @@ def test_table():
     with _print_redirect() as fout:
         table = LiveTable(['det', 'motor'])
         ad_scan = AdaptiveAbsScanPlan([det], 'det', motor, -15, 5, .01, 1, .05, True)
-        RE(ad_scan, subs={'all': [table]})
+        # use lossless sub here because rows can get dropped
+        token = RE.subscribe_lossless('all', table)
+        RE(ad_scan)
+        RE.unsubscribe_lossless(token)
 
     fout.seek(0)
 


### PR DESCRIPTION
The LiveTable test was failing because, I think, the lossy subscription was doing its job, dropping an event or two, and thus missing a row.

Also, this makes a non-breaking API change that was previously discussed: `RunEngine.subscribe_lossless` and `RunEngine.unsubscribe_lossless` are now public methods. Aliases for the private names are maintained in case someone (HXN?) is using them.

(These were originally (back in May) made private so that users didn't choke their processors by reaching for lossless subscriptions to liberally. That's not really the way private methods are supposed to be used, and in any case that imagined scenario has not been a problem.)