### PR TITLE
ENH/DOC: Overhaul callbacks doc, improve tiff export

### DIFF
--- a/bluesky/broker_callbacks.py
+++ b/bluesky/broker_callbacks.py
@@ -137,12 +137,6 @@ def LiveTiffExporter(CallbackBase):
     overwrite : bool
         default to False, raising an OSError if file exists
 
-    Returns
-    -------
-    f : function
-        a function that accepts a header and saves TIFF files
-
-
     Attributes
     ----------
     filenames : list of filenames written in ongoing or most recent run

--- a/bluesky/broker_callbacks.py
+++ b/bluesky/broker_callbacks.py
@@ -9,6 +9,7 @@ from xray_vision.backend.mpl.cross_section_2d import CrossSection
 from .callbacks import CallbackBase
 import tifffile
 import numpy as np
+import doct
 from databroker import DataBroker as db
 
 
@@ -160,9 +161,14 @@ class LiveTiffExporter(CallbackBase):
 
     def start(self, doc):
         self.filenames = []
-        self._start = doc
+        # Convert doc from dict into dottable dict, more convenient
+        # in Python format strings: doc.key == doc['key']
+        self._start = doct.Document('start', doc)
 
     def event(self, doc):
+        # Convert doc from dict into dottable dict, more convenient
+        # in Python format strings: doc.key == doc['key']
+        doc = doct.Document('event', doc)
         if self.field not in doc['data']:
             return
         fill_event(doc)  # modifies in place

--- a/bluesky/broker_callbacks.py
+++ b/bluesky/broker_callbacks.py
@@ -117,11 +117,11 @@ def verify_files_saved(name, doc):
         print('\x1b[1A\u2713')  # print a checkmark on the previous line
 
 
-def LiveTiffExporter(CallbackBase):
+class LiveTiffExporter(CallbackBase):
     """
-    Build a function that, given a header, exports tiff files.
+    Save TIFF files.
 
-    The file names will incorporate the contents of the Header.
+    Incorporate metadata and data from individual data points in the filenames.
 
     Parameters
     ----------
@@ -153,9 +153,9 @@ def LiveTiffExporter(CallbackBase):
         if not self.overwrite:
             if os.path.isfile(filename):
                 raise OSError("There is already a file at {}. Delete "
-                                      "it and try again.".format(filename))
+                              "it and try again.".format(filename))
         if not self.dryrun:
-            tifffile.imsave(filename, np.asarray(img))
+            tifffile.imsave(filename, np.asarray(image))
         self.filenames.append(filename)
 
     def start(self, doc):
@@ -165,16 +165,15 @@ def LiveTiffExporter(CallbackBase):
     def event(self, doc):
         if self.field not in doc['data']:
             return
-        fill_event(doc)
+        fill_event(doc)  # modifies in place
         image = np.asarray(doc['data']['field'])
         if image.ndim == 2:
-            filename = self.template.format(start=self._start,
-                                            event=self._event)
+            filename = self.template.format(start=self._start, event=doc)
             self._save_image(image, filename)
         if image.ndim == 3:
             for i, plane in enumerate(image):
-                filename = self. template.format(i=i, start=self._start,
-                                           event=self._event)
+                filename = self.template.format(i=i, start=self._start,
+                                                event=doc)
                 self._save_image(plane, filename)
         # RunEngine will ignore this return value, but it
         # might be handy for interactive use.

--- a/bluesky/broker_callbacks.py
+++ b/bluesky/broker_callbacks.py
@@ -1,6 +1,7 @@
 import os
 import time as ttime
 from databroker import DataBroker as db, get_events
+from databroker.databroker import fill_event
 import filestore.api as fsapi
 from metadatastore.commands import run_start_given_uid, descriptors_by_start
 import matplotlib.pyplot as plt
@@ -8,7 +9,7 @@ from xray_vision.backend.mpl.cross_section_2d import CrossSection
 from .callbacks import CallbackBase
 import tifffile
 import numpy as np
-from databroker import get_images, DataBroker as db
+from databroker import DataBroker as db
 
 
 class LiveImage(CallbackBase):
@@ -94,67 +95,6 @@ def post_run(callback):
     return f
 
 
-def make_tiff_exporter(field, template):
-    """
-    Build a function that, given a header, exports tiff files.
-
-    The file names will incorporate the contents of the Header.
-
-    Parameters
-    ----------
-    field : str
-        a data key, e.g., 'pe1_image_lightfield'
-    template : str
-        A templated file path, where curly brackets will be filled in with
-        the attributes of 'h', a Header, and 'N', a sequential number.
-        e.g., "dir/scan{h.start.scan_id}_by_{h.start.experimenter}_{N}.tiff"
-
-    Returns
-    -------
-    f : function
-        a function that accepts a header and saves TIFF files
-    """
-    # validate user input
-    if not '{N}' in template:
-        raise ValueError("template must include '{N}'")
-
-    def f(h, dryrun=False):
-        imgs = get_images(h, field)
-        # Fill in h, defer filling in N.
-        _template = template.format(h=h, N='{N}')
-        filenames = [_template.format(N=i) for i in range(len(imgs))]
-        # First check that none of the filenames exist.
-        for filename in filenames:
-            if os.path.isfile(filename):
-                raise FileExistsError("There is already a file at {}. Delete "
-                                      "it and try again.".format(filename))
-        if not dryrun:
-            # Write files.
-            for filename, img in zip(filenames, imgs):
-                tifffile.imsave(filename, np.asarray(img))
-        return filenames
-
-    # Write a customized docstring for f based on what is specifcally does.
-    f.__doc__ = """
-Export sequentially-numbered TIFF files from the {field} field.
-
-Parameters
-----------
-h : Header
-    a header from the databroker
-dryrun : bool
-    Set to True to return list of filenames without actually writing files.
-    False by default.
-
-Returns
--------
-filenames : list
-    list of filenames where files were written (or, if dryrun, *would* be
-    written)
-""".format(field=field)
-    return f
-
-
 def verify_files_saved(name, doc):
     "This is a brute-force approach. We retrieve all the data."
     ttime.sleep(0.1)  # Wati for data to be saved.
@@ -175,3 +115,77 @@ def verify_files_saved(name, doc):
         print("  Verification Failed! Error: {0}".format(e))
     else:
         print('\x1b[1A\u2713')  # print a checkmark on the previous line
+
+
+def LiveTiffExporter(CallbackBase):
+    """
+    Build a function that, given a header, exports tiff files.
+
+    The file names will incorporate the contents of the Header.
+
+    Parameters
+    ----------
+    field : str
+        a data key, e.g., 'image'
+    template : str
+        A templated file path, where curly brackets will be filled in with
+        the attributes of 'start', 'event', and (for image stacks) 'i',
+        a sequential number.
+        e.g., "dir/scan{start.scan_id}_by_{start.experimenter}_{i}.tiff"
+    dryrun : bool
+        default to False; if True, do not write any files
+    overwrite : bool
+        default to False, raising an OSError if file exists
+
+    Returns
+    -------
+    f : function
+        a function that accepts a header and saves TIFF files
+
+
+    Attributes
+    ----------
+    filenames : list of filenames written in ongoing or most recent run
+    """
+    def __init__(self, field, template, dryrun=False, overwrite=False):
+        self.field = field
+        self.template = template
+        self.dryrun = dryrun
+        self.overwrite = overwrite
+        self.filenames = []
+        self._start = None
+
+    def _save_image(self, image, filename):
+        if not self.overwrite:
+            if os.path.isfile(filename):
+                raise OSError("There is already a file at {}. Delete "
+                                      "it and try again.".format(filename))
+        if not self.dryrun:
+            tifffile.imsave(filename, np.asarray(img))
+        self.filenames.append(filename)
+
+    def start(self, doc):
+        self.filenames = []
+        self._start = doc
+
+    def event(self, doc):
+        if self.field not in doc['data']:
+            return
+        fill_event(doc)
+        image = np.asarray(doc['data']['field'])
+        if image.ndim == 2:
+            filename = self.template.format(start=self._start,
+                                            event=self._event)
+            self._save_image(image, filename)
+        if image.ndim == 3:
+            for i, plane in enumerate(image):
+                filename = self. template.format(i=i, start=self._start,
+                                           event=self._event)
+                self._save_image(plane, filename)
+        # RunEngine will ignore this return value, but it
+        # might be handy for interactive use.
+        return filename
+
+    def stop(self, doc):
+        self._start = None
+        self.filenames = []

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -16,10 +16,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class CallbackBase(object):
-    def __init__(self):
-        super().__init__()
-
+class CallbackBase:
     def __call__(self, name, doc):
         "Dispatch to methods expecting particular doc types."
         return getattr(self, name)(doc)

--- a/doc/source/callbacks.rst
+++ b/doc/source/callbacks.rst
@@ -1,5 +1,5 @@
 Live Feedback and Processing
-============================
+****************************
 
 .. ipython:: python
    :suppress:
@@ -197,19 +197,45 @@ LiveImage
 
 .. autoclass:: bluesky.broker_callbacks.LiveImage
 
-Post-scan Data Export
-+++++++++++++++++++++
+Automated Post-scan Data Export
++++++++++++++++++++++++++++++++
 
-.. warning::
+Exporting Image Data as TIFF Files
+==================================
 
-    This isn't tested or documented yet, but it's possible.
+First, configure an "exporter", a Python function that composes a filename based
+on some metadata.
+
+The first argument is the name of the image field -- it might be 'image' or
+something like 'my_detector_image'. The second argument is a template (Python
+calls it a "format string") with metadata.
+
+.. code-block:: python
+
+    from bluesky.broker_callbacks import make_tiff_exporter, post_run
+
+    # Notice we put {N} where the sequential number, counting tiffs, goes.
+    exporter = make_tiff_exporter('image', 'output_dir/{start.scan_id}_{start.experimenter}_{start.color}_{N}.tiff')
+
+    def exporter_as_callback(name, doc):
+        if name == 'stop':
+            run_start_uid = doc['run_start']
+            header = db[run_start_uid]
+            exporter(header)
+
+Most metadata comes from the "start" document, hence ``start.scan_id`` above.
+(In a future release, information from the event, like ``event.seq_num`` should
+also be available. See
+`here <https://nsls-ii.github.io/architecture-overview.html>`_ for a more
+comprehensive explanation of what is in the documents.)
+
+Exporting All Data and Metadata in an HDF5 File
+===============================================
 
 Post-scan Data Validation
 +++++++++++++++++++++++++
 
-.. warning::
 
-    This isn't tested or documented yet, but it's possible.
 
 Writing Custom Callbacks
 ------------------------

--- a/doc/source/callbacks.rst
+++ b/doc/source/callbacks.rst
@@ -13,32 +13,8 @@ Live Feedback and Processing
    RE.md['owner'] = 'Jane'
    RE.md['group'] = 'Grant No. 12345'
    RE.md['beamline_id'] = 'demo'
-   from bluesky.plans import Count
-
-Demo: live-updating table
--------------------------
-
-We begin with the simplest useful example of live feedback, a table. We'll
-assume we already defined a plan, ready to use. (See :doc:`plans`.)
-
-.. ipython:: python
-    :suppress:
-
-    from bluesky.plans import AbsListScanPlan, AbsScanPlan
-    from bluesky.callbacks import LiveTable
-    dets = [det1, det2, det3]
-    table = LiveTable(dets)
-    RE.subscribe('all', table)  # Subscribe table to all future runs.
-    plan = AbsListScanPlan(dets, motor, [1,2,4,8])
-
-.. ipython:: python
-
-    RE(plan)
-
-.. ipython:: python
-    :suppress:
-
-    RE.unsubscribe(0)
+   from bluesky.plans import Count, AbsScanPlan
+   plan = AbsScanPlan([det, det1, det2, det3], motor, 1, 4, 4)
 
 Overview of Callbacks
 ---------------------
@@ -48,13 +24,33 @@ dictionaries organized in a `specified but flexible
 <http://nsls-ii.github.io/architecture-overview.html>`__ way. These Documents
 contain the data and metadata generated during the plan's execution. Each time
 a new Document is created, the RunEngine passes it to a list of functions.
-These functions can do anyting: store the data to disk, transfer the data to a
-cluster, update a plot, print a message, etc. The functions are called
-"callbacks."
+These functions can do anyting: store the data to disk, print a line of text
+to the scren, add a point to a plot, or even transfer the data to a cluster
+for immediate processing. These functions are called "callbacks."
 
 We subscribe callbacks to the live stream of Documents. You can think of a
-subscription as a self-addressed stamped envelope. They tell the RunEngine,
-"When you create a Document, send it to this callback for processing."
+callback as a self-addressed stamped envelope. It tells the RunEngine,
+"When you create a Document, send it to this function for processing."
+
+In order to keep up with the scan and avoiding slowing down data collection,
+most subscriptions skip some Documents when they fall behind. A table might
+skip a row, a plot might skip a point. But *critical* subscriptions -- like
+saving the data -- are run in a lossless mode guananteed to process all
+the Docuemnts.
+
+Simplest Example
+----------------
+
+This example passes every Document to the ``print`` function, printing
+each Document as it is generated during data collection.
+
+.. code-block:: python
+
+    RE(plan, print)
+
+We will not show the lenthy output of this command here; the documents are not
+so nice to read in their raw form. See ``LiveTable`` below for a more refined
+implementation of this basic example.
 
 Ways to Invoke Callbacks
 ------------------------
@@ -62,66 +58,72 @@ Ways to Invoke Callbacks
 Subscribe on a per-run basis
 ++++++++++++++++++++++++++++
 
-To set up callbacks for a single use on a particular run, pass a second
-argument to the call to the RunEngine.
+As in the simple example above, pass a second argument to the RunEngine.
 
 .. ipython:: python
 
+    dets = [det1, det2, det3]
     RE(plan, LiveTable(dets))
 
-To use multiple callbacks, simply pass a list of them.
+``LiveTable`` takes a list of objects or names to tell it which data columns to
+show. It prints the lines one at a time, as data collection proceeds.
+
+To use multiple callbacks, you may pass a list of them.
 
 .. ipython:: python
 
     RE(plan, [LiveTable(dets), LivePlot(det1)])
 
-.. note::
+Use this more verbose form to filter the Documents by type, feeding only
+certain document types to certain callbacks.
 
-    **Advanced:** Note that this more explicit syntax is equivalent.
+.. code-block:: python
 
-    .. ipython:: python
+    # Give all documents to LiveTable and LivePlot.
+    # Send only 'start' Documents to the print function.
+    RE(plan, {'all': [LiveTable(dets), LivePlot(det1)], 'start': print})
 
-        dets = [det1, det2, det3]
-        RE(plan, subs={'all': [LiveTable(dets), LivePlot(det1)]})
+The allowed keys are 'all', 'start', 'stop', 'descriptor', and 'event',
+corresponding to the names of the Documents.
 
-    The allowed keys are 'all', 'start', 'stop', 'descriptor', and 'event',
-    corresponding to the names of the Documents.
-
-Subscribe each time a certain scan is used
+Subscribe each time a certain plan is used
 ++++++++++++++++++++++++++++++++++++++++++
 
-Often, the same subscriptions are useful each time a certain kind of scan is
-run. To associate particular callbacks with a given scan, give the scan
+Often, the same subscriptions are useful each time a certain kind of plan is
+run. To associate particular callbacks with a given plan, give the plan 
 a ``subs`` attribute.
-
-This simplest way is to simply "monkey-patch" the scan instance like so:
 
 .. ipython:: python
 
     plan.subs = LiveTable(dets)
 
-As above, this can one callback, a list of callbacks, or a dictionary. They
-will be used automatically each time the scan is run.
+As above, this can be one callback, a list of callbacks, or a dictionary. They
+will be used automatically each time the plan is executed by the Run Engine.
 
 .. ipython:: python
 
     RE(plan)
 
-More complex subscriptions can configured using a property, which can inspect
-the internal state --- for example, using the range of motor positions to
-set plot limits in advance.
+To customize the callback based on the content of the plan, use a subscription
+factory: a function that takes in a plan and returns a callback function. For
+example, ``LiveTable`` takes list of data columns to be displayed. A
+*subscription* requires us to update that list if we use different detectors. A
+*subscription factory* intercepts the plan before it is executed and can update
+the list of columns on the fly.
 
-.. ipython:: python
+.. code-block:: python
 
-    class PlottingAbsScan(AbsScanPlan):
-        @property
-        def subs(self):
-            lp = LivePlot(self.detectors[0], self.motor,
-                          xlim=(self.start, self.stop))
-            return lp
+    def table_of_detectors(plan):
+        dets = plan.detectors
+        return LiveTable(dets)
 
-Advanced: Subscribe for every scan
-++++++++++++++++++++++++++++++++++
+    plan.sub_factories = table_of_detectors
+
+Every time the plan is executed a new ``LiveTable`` is made on the fly, based
+with a list of columns that is updated to reflect the list of detectors.
+
+Subscribe for every run
++++++++++++++++++++++++
 
 The RunEngine itself can store a collection of subscriptions to be applied to
 every single scan it executes.
@@ -135,107 +137,166 @@ The method ``RE.subscribe`` passes through to this method:
 
 .. automethod:: bluesky.run_engine.Dispatcher.subscribe
 
+.. automethod:: bluesky.run_engine.Dispatcher.unsubscribe
 
-*Lossless subscriptions* are also applied to every scan. See below for more on
-this topic.
 
-Running Callbacks on Completed Runs
-+++++++++++++++++++++++++++++++++++
+Running Callbacks on Saved Data
++++++++++++++++++++++++++++++++
+
+Callbacks are designed to work live, but they also work retroactively on
+completed runs with data that has been saved to disk.
 
 .. warning::
 
     This subsection documents a feature that has not been released yet.
 
-If the data is being saved to metadatastore (as it is if you use the standard
+If the data is accessible from the Data Broker (as it is if you use the standard
 configuration) then you can feed data from the Data Broker in the callbacks.
 
-.. ipython:: python
-    :verbatim:
+.. code-block:: python
 
-    In [1]: from dataportal import DataBroker, stream
-    
-    In [2]: stream(header, LiveTable(cols))
+    from dataportal import DataBroker, stream
+    stream(header, callback_func) 
 
-Built-in Callbacks
-------------------
-
-LiveTable
-+++++++++
+Live Table
+----------
 
 As each data point is collected (i.e., as each Event Document is generated) a
 row is added to the table. For nonscalar detectors, such as area detectors,
 the sum is shown. (See LiveImage, below, to view the images themselves.)
 
 The only crucial parameter is the first one, which specifies which fields to
-include in the table. These can include specific fields (e.g., ``sclr_chan4``)
-or readable objects (e.g., ``sclr``). The other parameters adjust the display
-format.
+include in the table. These can include specific fields (e.g., the string
+``'sclr_chan4'``) or readable objects (e.g., the object ``sclr``).
+
+Numerous other parameters allow you to customize the display style.
 
 .. autoclass:: bluesky.callbacks.LiveTable
 
-LivePlot
-++++++++
+Live Plot for Scalar Data
+-------------------------
 
 Plot scalars.
 
-.. note::
-
-    In order to keep up with the scan, subscriptions skip over some Documents
-    when they fall behind. Be aware that plots may not show all points. (Don't
-    worry: *all* the data is still being saved.)
-
 .. autoclass:: bluesky.callbacks.LivePlot
 
-LiveImage
-+++++++++
-
-.. note::
-
-    In order to keep up with the scan, subscriptions skip over some Documents
-    when they fall behind. Be aware that plots may not show all points. (Don't
-    worry: *all* the data is still being saved.)
+Live Image Plot
+---------------
 
 .. autoclass:: bluesky.broker_callbacks.LiveImage
 
-Automated Post-scan Data Export
-+++++++++++++++++++++++++++++++
+Live Raster Plot (Heat Map)
+---------------------------
+
+.. autoclass:: bluesky.callbacks.LiveRaster
+
+Automated Data Export
+---------------------
 
 Exporting Image Data as TIFF Files
-==================================
+++++++++++++++++++++++++++++++++++
 
-First, configure an "exporter", a Python function that composes a filename based
-on some metadata.
-
-The first argument is the name of the image field -- it might be 'image' or
-something like 'my_detector_image'. The second argument is a template (Python
-calls it a "format string") with metadata.
+First, compose a filename template. This is a simple working example.
 
 .. code-block:: python
 
-    from bluesky.broker_callbacks import make_tiff_exporter, post_run
+    template = "output_dir/{start.scan_id}_{event.seq_num}.tiff"
 
-    # Notice we put {N} where the sequential number, counting tiffs, goes.
-    exporter = make_tiff_exporter('image', 'output_dir/{start.scan_id}_{start.experimenter}_{start.color}_{N}.tiff')
+The template can include metadata or event data from the scan.
 
-    def exporter_as_callback(name, doc):
-        if name == 'stop':
-            run_start_uid = doc['run_start']
-            header = db[run_start_uid]
-            exporter(header)
+.. code-block:: python
 
-Most metadata comes from the "start" document, hence ``start.scan_id`` above.
-(In a future release, information from the event, like ``event.seq_num`` should
-also be available. See
+    template = ("output_dir/{start.scan_id}_{start.sample_name}_"
+                "{event.data.temperature}_{event.seq_num}.tiff")
+
+It can be handy to use the metadata to sort the images into directories.
+
+.. code-block:: python
+
+    template = "{start.user}/{start.scan_id}/{event.seq_num}.tiff"
+
+If each image data point is actually a stack of 2D image planes, the template
+must also include ``{i}``, which will count through the iamge planes in the
+stack.
+
+(Most metadata comes from the "start" document, hence ``start.scan_id`` above.
+See
 `here <https://nsls-ii.github.io/architecture-overview.html>`_ for a more
-comprehensive explanation of what is in the documents.)
+comprehensive explanation of what is in the different documents.)
 
-Exporting All Data and Metadata in an HDF5 File
-===============================================
+Next, create an exporter.
 
-Post-scan Data Validation
-+++++++++++++++++++++++++
+.. code-block:: python
+
+    from bluesky.broker_callbacks import LiveTiffExporter
+
+    exporter = LiveTiffExporter('image', template)
+
+Finally, to export all the images from a run when it finishes running, wrap the
+exporter in ``post_run`` and subscribe.
+
+.. code-block:: python
+
+    from bluesky.broker_callbacks import post_run
+
+    RE.subscribe('all', post_run(exporter))
+
+It also possible to write TIFFs live, hence the name ``LiveTiffExporter``, but
+there is an important disadvantage to this: in order to ensure that every image
+is saved, a lossless subscription must be used. And, as a consequence, the
+progress of the experiment may be intermittently slowed while data is written
+to disk. In some circumstances, this affect on the timing of the experiment may
+not be acceptable.
+
+.. code-block:: python
+
+    RE.subscribe_lossless('all', exporter)
+
+There are more configuration options avaiable, as given in detail below.
+
+.. autoclass:: bluesky.broker_callbacks.LiveTiffExporter
+
+Export All Data and Metadata in an HDF5 File
+++++++++++++++++++++++++++++++++++++++++++++
+
+A Stop Document is emitted at the end of every run. Subscribe to it, using it
+as a cue to load the dataset via the DataBroker and export an HDF5 file
+using `suitcase <https://nsls-ii.github.io/suitcase>`_.
 
 
+Working example:
+
+.. code-block:: python
+
+    from databroker import DataBroker as db
+    import suitcase
+
+    def suitcase_as_callback(name, doc):
+        if name != 'stop':
+            return
+        run_start_uid = doc['run_start']
+        header = db[run_start_uid]
+        filename = '{}.h5'.format(run_start_uid)
+        suitcase.export(header, filename)
+
+    RE.subscribe('stop', suitcase_as_callback)
+
+Verify Data Has Been Saved
+--------------------------
+
+The following verifies that all Documents and external files from a run have
+been saved to disk and are accessible from the DataBroker.  It prints a message
+indicating success or failure.
+
+Note: If the data collection machine is not able to access the machine where
+some external data is being saved, it will indicate failure. This can be a
+false alarm.
+
+.. code-block:: python
+
+    from bluesky.broker_callbacks import post_run, verify_files_saved
+
+    RE.subscribe('all', post_run(verify_files_saved))
 
 Writing Custom Callbacks
 ------------------------
@@ -305,7 +366,7 @@ it uses 'event' to see the data, and it uses 'stop' to draw the bottom border.
 A convenient pattern for this kind of subscription is a class with a method
 for each Document type.
 
-.. ipython:: python
+.. code-block:: python
 
     from bluesky.callbacks import CallbackBase
     class MyCallback(CallbackBase):
@@ -326,30 +387,8 @@ The base class, ``CallbackBase``, takes care of dispatching each Document to
 the corresponding method. If your application does not need all four, you may
 simple omit methods that aren't required.
 
-Advanced: Subscribing During a Scan
------------------------------------
-
-.. warning::
-
-    This section requires some familiarity with Messages, covered in
-    :doc:`custom-plans`. If you haven't at least skimmed that section of the
-    documents, head over to that page and then revisit this.
-
-Subscriptions can added and removing during the course of a scan.
-
-.. ipython:: python
-
-    def count_with_table(detectors):
-        table = LiveTable(detectors)
-        yield Msg('subscribe', None, 'start', table)
-        yield Msg('subscribe', None, 'descriptor', table)
-        yield Msg('subscribe', None, 'event', table)
-        yield Msg('subscribe', None, 'stop', table)
-        yield from Count(detectors)
-    RE(count_with_table(dets))
-
-Critical Lossless Subscriptions
--------------------------------
+Lossless Subscriptions for Critical Functions
+---------------------------------------------
 
 Because subscriptions are processed during a scan, it's possible that they
 can slow down data collection. We mitigate this by making the subscriptions
@@ -368,7 +407,8 @@ are registered as critical subscriptions.
 If your subscription requires the complete, lossless stream of Documents
 and you are will to accept the possibility of slowing down data
 collection while that stream in processed, you can register your own critical
-subscriptions. Use ``RE._subscribe_lossless(name, func)`` where ``name``
-if one of ``'start'``, ``'descriptor'``, ``'event'``, ``'stop'``, and ``func``
-is a callable that accepts a Python dictionary as its argument. Note that
-there is no ``'all'`` callback implemented for critical subscriptions.
+subscriptions.
+
+.. automethod:: bluesky.run_engine.subscribe_lossless
+
+.. automethod:: bluesky.run_engine.unsubscribe_lossless


### PR DESCRIPTION
This PR:

* Overhauls organization of the callbacks documentation, leaving it much more readable.
* Documents "subscription factories" and `LiveRaster`, both previously unmentioned in docs.
* Provides new examples for automated data verification, automated TIFF export, and automated HDF5 export via suitcase. (cc @licode)
* Nukes `make_tiff_exporter` in favor of `LiveTiffExporter`, which (1) can write TIFFs out live, potentially letting @sbillinge's software crank in real time and (2) incorporates some of the functionality in @pavoljuhas's #263. It's still comparatively light but can be more easily extended for more specific use cases.