### PR TITLE
WIP: a sketch of a simulation mode

### DIFF
--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -1,0 +1,25 @@
+from bluesky.examples import Base, Mover, Flyer
+
+
+def dryrun(gen):
+    """
+    Replace all hardware objects with mocked objects.
+    
+    This could catch mistakes that lead to IllegalMessageSequence
+    or more basic problems like NameError.
+
+    Note: This does nothing to affect subscriptions, so simulated
+    data from the mocked objects will be saved unless the relevant
+    callbacks are unsubscribed.
+    """
+    # TODO Use obj.read_attrs (etc.) to create a better mock.
+    for msg in gen:
+        live_obj = msg.obj
+        if hasattr(live_obj, 'set'):
+            mock_obj = Mover
+        elif hasattr(live_obj, 'kickoff'):
+            mock_obj = Flyer()
+        else:
+            mock_obj = Base()
+        mock_msg = msg._replace(obj=mock_obj)
+        yield mock_msg


### PR DESCRIPTION
One of the attendees to a recent tutorial session picked up on the fact that bluesky/ophyd does not yet have a "simulation mode", as SPEC does.

There, I fixed it.

```python
RE(dryrun(plan))
```

Several months ago there was discussion of doing this on the RunEngine side like so:
 
```python
RE.unregister_command('set'); RE.register_command('set', fake_set)
```

But I think editing the messages on the way in is better. It avoid having to write `fake_*` methods that reimplement the RunEngine's state management.

(By the way, I notice that this will get a little more more complex if we change the Msg API to drop the required `obj`.)