### PR TITLE
CLN: Remove logging that outputs whole documents

### DIFF
--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -22,19 +22,19 @@ class CallbackBase:
         return getattr(self, name)(doc)
 
     def event(self, doc):
-        logger.debug("CallbackBase: I'm an event with doc = %r", doc)
+        pass
 
     def bulk_events(self, doc):
-        logger.debug("CallbackBase: I'm an event with a big doc")
+        pass
 
     def descriptor(self, doc):
-        logger.debug("CallbackBase: I'm a descriptor with doc = %r", doc)
+        pass
 
     def start(self, doc):
-        logger.debug("CallbackBase: I'm a start with doc = %r", doc)
+        pass
 
     def stop(self, doc):
-        logger.debug("CallbackBase: I'm a stop with doc = %r", doc)
+        pass
 
 
 class CallbackCounter:


### PR DESCRIPTION
This was useful when callbacks were new but now they are gratuitous.