### PR TITLE
API: Subs is always a dict of empty lists, including all valid keys.

### DIFF
--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -78,11 +78,11 @@ def test_subs_input():
     # Test input normalization on OO plans
     obj_ascan = AbsScanPlan([det], motor, 1, 5, 4)
     obj_ascan.subs = cb1
-    assert obj_ascan.subs == {'all': [cb1]}
+    assert obj_ascan.subs == {'all': [cb1], 'start': [], 'stop': [], 'descriptor': [], 'event': []}
     obj_ascan.subs.update({'start': [cb2]})
-    assert obj_ascan.subs == {'all': [cb1], 'start': [cb2]}
+    assert obj_ascan.subs == {'all': [cb1], 'start': [cb2], 'stop': [], 'descriptor': [], 'event': []}
     obj_ascan.subs = [cb2, cb3]
-    assert obj_ascan.subs == {'all': [cb2, cb3]}
+    assert obj_ascan.subs == {'all': [cb2, cb3], 'start': [], 'stop': [], 'descriptor': [], 'event': []}
 
     # Test input normalization on simple scans
     assert mesh.subs == mesh.default_subs
@@ -91,11 +91,11 @@ def test_subs_input():
     expected.update({'start': [cb2]})
     assert mesh.subs == expected
     mesh.subs = cb2
-    assert mesh.subs == {'all': [cb2]}
+    assert mesh.subs == {'all': [cb2], 'start': [], 'stop': [], 'descriptor': [], 'event': []}
     mesh.subs = [cb2, cb3]
-    assert mesh.subs == {'all': [cb2, cb3]}
+    assert mesh.subs == {'all': [cb2, cb3], 'start': [], 'stop': [], 'descriptor': [], 'event': []}
     mesh.subs.update({'start': [cb1]})
-    assert mesh.subs == {'all': [cb2, cb3], 'start': [cb1]}
+    assert mesh.subs == {'all': [cb2, cb3], 'start': [cb1], 'stop': [], 'descriptor': [], 'event': []}
 
 def test_subscribe_msg():
     assert RE.state == 'idle'


### PR DESCRIPTION
As a reminder, when attaching subscriptions to a plan, we accept `plan.subs = cb` as a shortcut for subscribing to all documents. (The explicit way is `plan.subs = {'all': [cb]}`.) The shortcut is convenient but confusing in a couple ways. It is accomplished using a descriptor that normalizes the input.

Given the confusion this has caused, removing the shortcut altogether is under discussion. But that's not what this PR does. This PR merely makes it a little more clear what is happening with subs. Maybe it goes far enough and we will not need to to remove the shortcut?

```python
In [1]: from bluesky.simple_scans import AbsScan

In [2]: ascan = AbsScan()
```

Before:

```python
In [3]: ascan.subs
Out[3]: {}
```

After:

```python
In [6]: ascan.subs
Out[6]: {'all': [], 'descriptor': [], 'event': [], 'start': [], 'stop': []}
```

Thus, `ascan.subs['event'].append(cb)` will now always work, no matter the state of `plan.subs`. This applies to both SPEC-style "simple scans" and Plans.