### PR TITLE
FIX: Avoid staging objects redundantly.

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -92,9 +92,12 @@ class PlanBase(Struct):
         # itself as its argument and returns a generator of messages
         if self.pre_run is not None:
             yield from self.pre_run(self)
+        staged = []  # to track duplicates
         for objs in self._objects.values():
             for obj in objs:
-                yield Msg('stage', obj)
+                if obj not in staged:
+                    yield Msg('stage', obj)
+                    staged.append(obj)
 
     def _post(self):
         """
@@ -104,9 +107,12 @@ class PlanBase(Struct):
         """
         # postrun is expected to be a callable that takes the Scan object
         # itself as its argument and returns a generator of messages
+        unstaged = []  # to track duplicates
         for objs in self._objects.values():
-            for obj in objs:
-                yield Msg('unstage', obj)
+            for obj in reversed(list(objs)):
+                if obj not in unstaged:
+                    yield Msg('unstage', obj)
+                    unstaged.append(obj)
         if self.post_run is not None:
             yield from self.post_run(self)
 


### PR DESCRIPTION
As discovered by @ambarb, if you include your 'motor' as one of your 'detectors' (which is a reasonable thing to do) `Plan` tries to stage it twice and blows up. This is a simple fix.