### PR TITLE
MNT: All motors should be stopped during a pause.

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -432,6 +432,12 @@ class RunEngine:
                 self.state = 'paused'
                 if self.resumable:
                     loop.stop()
+                    # During pause, all motors should be stopped.
+                    for obj in self._movable_objs_touched:
+                        try:
+                            obj.stop()
+                        except Exception:
+                            logger.error("Failed to stop %r", obj)
                 else:
                     print("No checkpoint; cannot pause. Aborting...")
                     self._exception = FailedPause()


### PR DESCRIPTION
This came up during the tutorial today. When a scan is paused, all motors should be stopped.

I can't think of a reason that this would cause a problem -- if your scan can't recover from a stop, then you shouldn't be using checkpoints -- and it's easy to think of case where the current behavior causes a problem.