### PR TITLE
REF: Do not require objs to have read_attrs.

### DIFF
--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -25,7 +25,6 @@ class Base:
         self._fields = fields
         self._cb = None
         self._ready = False
-        self.read_attrs = fields
         self.configuration_attrs = []
         for field in fields:
             if isinstance(field, str):

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -393,12 +393,12 @@ def snake_cyclers(cyclers, snake_booleans):
 
 def first_key_heuristic(device):
     """
-    Get the fully-qualified data key for the first entry in read_attrs.
+    Get the fully-qualified data key for the first entry in describe().
 
     This will raise is that entry's `describe()` method does not return a
     dictionary with exactly one key.
     """
-    first_attr = device.read_attrs[0]
+    first_attr = next(iter(device.describe()))
     key, = getattr(device, first_attr).describe().keys()
     return key
 


### PR DESCRIPTION
- As @klauer pointed out awhile back, read() and describe()
  return OrderedDict objects, so we can figure out the first
  element in read_attrs but looking at these; we don't need
  to add read_attrs/describe_attrs to the list of things
  bluesky has to know about.
- This commit removes all refs to `read_attrs` from the codebase.

Do not merge until https://github.com/NSLS-II/ophyd/pull/265 is merged.

Closes #333 
