### PR TITLE
Fix typo in exception

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1229,7 +1229,7 @@ class Dispatcher:
         exceptions = self.cb_registry.process(name, name.name, doc)
         for exc, traceback in exceptions:
             warn("A %r was raised during the processing of a %s "
-                 "Document. The error will be ingored to avoid "
+                 "Document. The error will be ignored to avoid "
                  "interrupting data collection. To investigate, "
                  "set RunEngine.ignore_callback_exceptions = False "
                  "and run again." % (exc, name.name))


### PR DESCRIPTION
In NSLS-II/Bug-Reports#80 Yugang posted some text which 
highlighted a typo in our Exception text. This fixes that