### PR TITLE
Add tifffile as a dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - conda create -n testenv nose python=$TRAVIS_PYTHON_VERSION scipy requests matplotlib jsonschema traitlets pytest
   - source activate testenv
   - pip install pytest-cov pytest-xdist
-  - conda install metadatastore databroker historydict boltons prettytable doct toolz -c lightsource2 -c conda-forge -c soft-matter
+  - conda install metadatastore databroker historydict boltons prettytable doct toolz tifffile -c lightsource2 -c conda-forge -c soft-matter
   - conda remove metadatastore databroker filestore --yes
   - conda install super_state_machine cycler xray-vision lmfit -c tacaswell
   - 'pip install https://github.com/NSLS-II/databroker/zipball/master#egg=databroker'

--- a/bluesky/broker_callbacks.py
+++ b/bluesky/broker_callbacks.py
@@ -7,7 +7,6 @@ from metadatastore.commands import run_start_given_uid, descriptors_by_start
 import matplotlib.pyplot as plt
 from xray_vision.backend.mpl.cross_section_2d import CrossSection
 from .callbacks import CallbackBase
-import tifffile
 import numpy as np
 import doct
 from databroker import DataBroker as db
@@ -143,6 +142,14 @@ class LiveTiffExporter(CallbackBase):
     filenames : list of filenames written in ongoing or most recent run
     """
     def __init__(self, field, template, dryrun=False, overwrite=False):
+        try:
+            import tifffile
+        except ImportError:
+            print("Tifffile is required by this callback. Please install"
+                  "tifffile and then try again."
+                  "\n\n\tpip install tifffile\n\nor\n\n\tconda install "
+                  "tifffile")
+            raise
         self.field = field
         self.template = template
         self.dryrun = dryrun

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - traitlets
     - historydict
     - jinja2
-    - tifffile
 
 test:
   requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - traitlets
     - historydict
     - jinja2
+    - tifffile
 
 test:
   requires:


### PR DESCRIPTION
bluesky was getting tifffile through pims making tifffile a runtime dep.  
Now that pims 0.3.3 does not have tifffile as a runtime dep, we should make
tifffile a dep of bluesky.