### PR TITLE
ENH/API: Add raise_if_interrupted option and new Exception

### DIFF
--- a/bluesky/__init__.py
+++ b/bluesky/__init__.py
@@ -4,7 +4,7 @@ logger = logging.getLogger(__name__)
 from .run_engine import Msg
 from .run_engine import RunEngine
 from .run_engine import PanicError
-from .run_engine import RunInterrupt
+from .run_engine import RunEngineInterrupted
 from .run_engine import IllegalMessageSequence
 
 from .plans import PlanBase

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -25,10 +25,6 @@ from .utils import (CallbackRegistry, SignalHandler, normalize_subs_input)
 logger = logging.getLogger(__name__)
 
 
-__all__ = ['Msg', 'RunEngineStateMachine', 'RunEngine', 'Dispatcher',
-           'RunInterrupt', 'PanicError', 'IllegalMessageSequence']
-
-
 def expiring_function(func, *args, **kwargs):
     """
     If timeout has not occurred, call func(*args, **kwargs).

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -6,7 +6,8 @@ from bluesky.examples import (motor, simple_scan, det, sleepy, wait_one,
                               conditional_break, SynGauss
                               )
 from bluesky.callbacks import LivePlot
-from bluesky import RunEngine, Msg, PanicError, IllegalMessageSequence
+from bluesky import (RunEngine, Msg, PanicError, IllegalMessageSequence,
+                     RunEngineInterrupted)
 from bluesky.tests.utils import setup_test_run_engine
 import os
 import signal
@@ -562,3 +563,9 @@ def test_clear_checkpoint():
 
     RE(silly_plan)
     assert RE.state == 'idle'
+
+
+def test_interruption_exception():
+    with pytest.raises(RunEngineInterrupted):
+        RE([Msg('checkpoint'), Msg('pause')], raise_if_interrupted=True)
+    RE.stop()


### PR DESCRIPTION
If a run is interrupted but not exceptions are raised (which IIRC
can only occur because the RunEngine is paused or stopped) users
can use this flag to raise a special exception, aimed at interrupting
user scripts or functions that call the RunEngine.

- Add public raise_if_interrupted flag and private _interrupted flag.
- Add `RunEngineInterrupted(Exception)`.
- Remove `RunInterrupted(KeyboardInterrupted)` which was never used.
- Test.