### PR TITLE
MNT: Fix spec callback.

### DIFF
--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -724,10 +724,14 @@ class LiveSpecFile(CallbackBase):
         data = doc['data']
         values = [str(data[k]) for k in self._read_fields]
         if self._motor == "Count":
-            doc['data']['Count'] = -1
+            motor_position = -1
+        elif self._motor = "seq_num":
+            motor_position = data['seq_num']
+        else:
+            motor_position = doc[self._motor]
         content = dict(acq_time=self._acq_time,
                        unix_time=doc['time'],
-                       motor_position=data[self._motor],
+                       motor_position=motor_position,
                        values=values)
         with open(self.specpath, 'a') as f:
             f.write(_SPEC_EVENT_TEMPLATE.render(content))

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -594,6 +594,12 @@ class LiveSpecFile(CallbackBase):
     Other documents can be issues before, between, and after, but
     these must be issued and in this order.
 
+    Notes
+    -----
+    `Reference <https://github.com/certified-spec/specPy/blob/master/doc/specformat.rst>`_
+    for the spec file format.
+    Nice find @danielballan!
+
     Example
     -------
     It is suggested to put this in the ipython profile:

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -560,7 +560,7 @@ _SPEC_HEADER_TEMPLATE = env.from_string("""#F {{ filepath }}
 #C {{ owner }}  User = {{ owner }}
 #O0 {{ positioners | join(' ') }}""")
 
-_SPEC_1D_COMMAND_TEMPLATE = env.from_string("{{ scan_type }} {{ scan_motor }} {{ start }} {{ stop }} {{ stides }} {{ time }}")
+_SPEC_1D_COMMAND_TEMPLATE = env.from_string("{{ scan_type }} {{ scan_motor }} {{ start }} {{ stop }} {{ strides }} {{ time }}")
 
 _PLAN_TO_SPEC_MAPPING = {'AbsScanPlan': 'ascan',
                          'DeltaScanPlan': 'dscan',
@@ -676,6 +676,7 @@ class LiveSpecFile(CallbackBase):
                     " cannot handle multiple scanning motors. Please request "
                     "this feature at https://github.com/NSLS-II/bluesky/issues" %
                     (len(self._motor), self._motor))
+        content['scan_motor'] = self._motor
         command = _SPEC_1D_COMMAND_TEMPLATE.render(content)
         # Can't write the entry until we see the descriptor, so stash it until
         # we get the descriptor

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -688,15 +688,10 @@ class LiveSpecFile(CallbackBase):
 
     def descriptor(self, doc):
         """Write the header for the actual scan data"""
-        try:
-            # see if we have a valid motor name
-            doc['data_keys'][self._motor]
-        except KeyError:
+        if self._motor not in list(doc['data_keys'].keys()) + ['Count']:
             # see if we can just append _user_readback to the motor
             self._motor += '_user_readback'
-            try:
-                doc['data_keys'][self._motor]
-            except KeyError:
+            if self._motor not in doc['data_keys']:
                 # give up and use the event sequence number as the motor.
                 # We are still throwing all the motor information into the
                 # spec file, but the user will have to manually choose the

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -598,7 +598,6 @@ class LiveSpecFile(CallbackBase):
     -----
     `Reference <https://github.com/certified-spec/specPy/blob/master/doc/specformat.rst>`_
     for the spec file format.
-    Nice find @danielballan!
 
     Example
     -------

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -720,10 +720,10 @@ class LiveSpecFile(CallbackBase):
         values = [str(data[k]) for k in self._read_fields]
         if self._motor == "Count":
             motor_position = -1
-        elif self._motor = "seq_num":
-            motor_position = data['seq_num']
+        elif self._motor == "seq_num":
+            motor_position = doc['seq_num']
         else:
-            motor_position = doc[self._motor]
+            motor_position = data[self._motor]
         content = dict(acq_time=self._acq_time,
                        unix_time=doc['time'],
                        motor_position=motor_position,

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -688,6 +688,25 @@ class LiveSpecFile(CallbackBase):
 
     def descriptor(self, doc):
         """Write the header for the actual scan data"""
+        try:
+            # see if we have a valid motor name
+            doc['data_keys'][self._motor]
+        except KeyError:
+            # see if we can just append _user_readback to the motor
+            self._motor += '_user_readback'
+            try:
+                doc['data_keys'][self._motor]
+            except KeyError:
+                # give up and use the event sequence number as the motor.
+                # We are still throwing all the motor information into the
+                # spec file, but the user will have to manually choose the
+                print("We are unable to guess the motor name. Please set the"
+                      "user_readback value to be the same as the motor name "
+                      "so that we are able to correctly guess your scanning "
+                      "motor. Your 'motor' is actually the sequence number of"
+                      "the event")
+                self._motor = 'seq_num'
+
         # List all scalar fields, excluding the motor (x variable).
         self._read_fields = sorted([k for k, v in doc['data_keys'].items()
                                     if k != self._motor and not v['shape']])


### PR DESCRIPTION
The spacings on the #L line needs to be hyper specific or pymca and other spec-file-reading utilities do not understand how to parse the information. 

This allows the LiveSpecFile to output correctly formatted spec documents

cc @yugangzhang @lwiegart