### PR TITLE
ENH: Record data key order as a list in descriptor.

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -945,9 +945,12 @@ class RunEngine:
             # We don't not have an Event Descriptor for this set.
             data_keys = {}
             config = {}
+            object_keys = {}
             for obj in objs_read:
                 dks = self._describe_cache[obj]
                 name = obj.name
+                # dks is an OrderedDict. Record that order as a list.
+                object_keys[obj.name] = list(dks)
                 for field, dk in dks.items():
                     dk['object_name'] = name
                 data_keys.update(dks)
@@ -958,7 +961,8 @@ class RunEngine:
             descriptor_uid = new_uid()
             doc = dict(run_start=self._run_start_uid, time=ttime.time(),
                        data_keys=data_keys, uid=descriptor_uid,
-                       configuration=config, name=self._bundle_name)
+                       configuration=config, name=self._bundle_name,
+                       object_keys=object_keys)
             yield from self.emit(DocumentNames.descriptor, doc)
             self.log.debug("Emitted Event Descriptor")
             self._descriptors[(self._bundle_name, objs_read)] = descriptor_uid


### PR DESCRIPTION
On the collection side, we make use of the fact that `describe()` returns an `OrderedDict`, but we throw that information away when we put it in MDS. I would like to store that order in MDS so I can use it on the analysis side. Specifically, the order has given us a way to inject a useful heuristic: the first key is taken to be the "primary" or default key to use in plotting, etc.

Currently, we obtain this key in various places in bluesky by calling `describe()` on the object. Obviously, on the analysis side we cannot do that. It would be better to store the order in the documents.

We are already storing the mapping of data keys to object names. (This is how configuration is grouped with the data keys that it applies to.) In this PR, I add a list of `object_keys` mapping each object name to a list of its data keys. The code changes are minimal, and they are confined to the bluesky RunEngine. No other packages will need to be changed.

This "parallel structure" of a dict and list mirrors the internal structure of OrderedDict itself, which is IIRC backed by an ordinary dict plus a list of keys. @klauer and I came to agreement that this is the least confusing way to store this information.

This idea originally came up in a discussion with @ericdill. It will be useful to the LiveSpecCallback as well.