### PR TITLE
MNT: Allow sample to be dict or string.

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1416,10 +1416,13 @@ def _default_md_validator(md):
         if field not in md:
             raise KeyError("The field '{0}' was not specified as is "
                            "required.".format(field))
-        if 'sample' in md and not hasattr(md['sample'], 'keys'):
+        if 'sample' in md and not (hasattr(md['sample'], 'keys')
+                                   or isinstance(md['sample'], str)):
             raise ValueError(
                 "You specified 'sample' metadata. We give this field special "
                 "significance in order to make your data easily searchable. "
-                "Therefore, you must make 'sample' a dictionary, like so: "
+                "Therefore, you must make 'sample' a string or a  "
+                "dictionary, like so: "
+                "GOOD: sample='dirt' "
                 "GOOD: sample={'color': 'red', 'number': 5} "
-                "BAD: sample='red_5' ")
+                "BAD: sample=[1, 2] ")

--- a/bluesky/schema/run_start.json
+++ b/bluesky/schema/run_start.json
@@ -5,7 +5,7 @@
             "description": "Name of project that this run is part of"
         },
         "sample": {
-            "type": ["object"],
+            "type": ["object", "string"],
             "description": "Information about the sample, may be a UID to another collection"
         },
         "beamline_id": {

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -193,6 +193,7 @@ def test_sample_md_dict_requirement():
     with pytest.raises(ValueError):
         RE(simple_scan(motor), sample=1)
     RE(simple_scan(motor), sample={'number': 1})  # should not raise
+    RE(simple_scan(motor), sample='label')  # should not raise
 
 
 def test_md_dict():

--- a/doc/source/metadata.rst
+++ b/doc/source/metadata.rst
@@ -33,21 +33,25 @@ Or specified when the scan is run.
 
 .. note::
 
-    Structured data, such as
+    To improve searchability, the key "sample" has specicial significance.
+    It must be either a string
+
+    .. code-block:: python
+
+        'red 10 20 5'
+
+    or a dictionary
 
     .. code-block:: python
 
         {'color': 'red', 'dimensions': [10, 20, 5]}
 
-    is much better than a long string like
+    A dictionary is preferred because it is self-describing and more richly
+    searchable, but either is allowed.
 
-    .. code-block:: python
-
-        'red_10_20_5'
-
-    because it is searchable and self-describing. To encourage good practices,
-    the RunEngine inists that 'sample' be a dictionary. Any other fields
-    you invent can be anything you want.
+    Only "sample" has this restriciton. Invent custom-named keys (as in the
+    tongue-in-cheek "mood" example above) as needed. These can contain
+    strings, dictionaries, lists, and numbers.
 
 Required Fields
 ---------------


### PR DESCRIPTION
We tried to encourage people to use dictionaries to record their sample information by requiring that the field called 'sample' be a dict. This has turned out to be more annoying that helpful. Sometimes you just want sample to be a string. The error is off-putting and more likely causes users to simply avoid the metadata feature than to discover the joy of dictionaries.

This would require a corresponding change in metadataservice and the (so far unused) event-model repo. Is this OK with you @arkilic?

This one's for you, @lwiegart. (But I have come to agree.)