### PR TITLE
Api kb interupts

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -741,7 +741,6 @@ class RunEngine:
             logger.error("%s", err)
             raise err
         finally:
-            self.state = 'idle'
             # call stop() on every movable object we ever set() or kickoff()
             for obj in self._movable_objs_touched:
                 try:
@@ -778,6 +777,7 @@ class RunEngine:
             for task in asyncio.Task.all_tasks(loop):
                 task.cancel()
             loop.stop()
+            self.state = 'idle'
 
     def _check_for_trouble(self):
         if self.state.is_running:

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -773,7 +773,9 @@ class RunEngine:
                     for task in asyncio.Task.all_tasks(loop):
                         task.cancel()
                     loop.stop()
+                    self.state = 'idle'
                     raise
+
             for task in asyncio.Task.all_tasks(loop):
                 task.cancel()
             loop.stop()

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -798,7 +798,6 @@ class RunEngine:
         # Check for pause requests from keyboard.
         if self.state.is_running:
             if self._sigint_handler.interrupted:
-                self._sigint_handler.interrupted = False
                 with SignalHandler(signal.SIGINT) as second_sigint_handler:
                     self.log.debug("RunEngine detected a SIGINT (Ctrl+C)")
                     # We know we will either pause or abort, so we can

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -24,7 +24,6 @@ class SignalHandler:
         self.original_handler = signal.getsignal(self.sig)
 
         def handler(signum, frame):
-            self.release()
             self.interrupted = True
 
         signal.signal(self.sig, handler)

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -17,14 +17,19 @@ logger = logging.getLogger(__name__)
 class SignalHandler:
     def __init__(self, sig):
         self.sig = sig
+        self.interrupted = False
+        self.count = 0
 
     def __enter__(self):
         self.interrupted = False
         self.released = False
+        self.count = 0
+
         self.original_handler = signal.getsignal(self.sig)
 
         def handler(signum, frame):
             self.interrupted = True
+            self.count += 1
 
         signal.signal(self.sig, handler)
         return self


### PR DESCRIPTION
Closes https://github.com/NSLS-II/wishlist/issues/105

This makes the `SignalHandler` hold onto control of the signal until the context block has exited.  Previously the handler would clean it's self up after the first signal it received which means hitting C-c three or more times could result an a KeyboardInterupt being raised deep in the code.  If this happens in the `finally` block it can leave the RE (and the hardware) in an inconsistent state.