### PR TITLE
FIX: Avoid reading device and its subdevice.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
 
 install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
-  - conda update conda
+  - conda install "conda<4"
   - conda create -n testenv nose python=$TRAVIS_PYTHON_VERSION scipy requests matplotlib jsonschema traitlets pytest coverage
   - source activate testenv
   - conda install metadatastore databroker ophyd historydict boltons doct toolz tifffile pymongo pcaspy pyepics readline super_state_machine cycler xray-vision lmfit -c lightsource2 -c conda-forge -c soft-matter

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - conda update conda
   - conda create -n testenv nose python=$TRAVIS_PYTHON_VERSION scipy requests matplotlib jsonschema traitlets pytest coverage
   - source activate testenv
-  - conda install metadatastore databroker historydict boltons doct toolz tifffile pymongo pcaspy pyepics readline super_state_machine cycler xray-vision lmfit -c lightsource2 -c conda-forge -c soft-matter
+  - conda install metadatastore databroker ophyd historydict boltons doct toolz tifffile pymongo pcaspy pyepics readline super_state_machine cycler xray-vision lmfit -c lightsource2 -c conda-forge -c soft-matter
   - conda remove metadatastore databroker filestore --yes
   - 'pip install https://github.com/NSLS-II/databroker/zipball/master#egg=databroker'
   - 'pip install https://github.com/NSLS-II/filestore/zipball/master#egg=filestore'

--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -22,6 +22,7 @@ class MockSignal:
 class Base:
     def __init__(self, name, fields):
         self.name = name
+        self.parent = None
         self._fields = fields
         self._cb = None
         self._ready = False

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -7,7 +7,7 @@ from cycler import cycler
 import numpy as np
 from .run_engine import Msg
 from .utils import (Struct, snake_cyclers, Subs, normalize_subs_input,
-                    scalar_heuristic)
+                    scalar_heuristic, separate_devices)
 
 
 class PlanBase(Struct):
@@ -176,7 +176,7 @@ class Count(PlanBase):
     def _one_count(self):
         # This is broken out in a separate method so we can loop
         # over it in different ways in _gen, above.
-        dets = self.detectors
+        dets = separate_devices(self.detectors)
         yield Msg('checkpoint')
         yield Msg('create', None, name='primary')
         for det in dets:
@@ -197,17 +197,16 @@ class Plan1D(PlanBase):
         return {'detectors': self.detectors, 'motors': [self.motor]}
 
     def _gen(self):
-        dets = self.detectors
+        dets = separate_devices(self.detectors)
         for step in self._abs_steps:
             yield Msg('checkpoint')
             yield Msg('set', self.motor, step, block_group='A')
             yield Msg('wait', None, 'A')
             yield Msg('create', None, name='primary')
-            yield Msg('read', self.motor)
             for det in dets:
                 yield Msg('trigger', det, block_group='B')
             yield Msg('wait', None, 'B')
-            for det in dets:
+            for det in separate_devices(dets + [self.motor]):
                 yield Msg('read', det)
             yield Msg('save')
 
@@ -443,18 +442,17 @@ class _AdaptivePlanBase(PlanBase):
         cur_I = None
         cur_det = {}
         motor = self.motor
-        dets = self.detectors
+        dets = separate_devices(self.detectors)
         target_field = self.target_field
         while next_pos < stop:
             yield Msg('checkpoint')
             yield Msg('set', motor, next_pos)
             yield Msg('wait', None, 'A')
             yield Msg('create', None, name='primary')
-            yield Msg('read', motor)
             for det in dets:
                 yield Msg('trigger', det, block_group='B')
             yield Msg('wait', None, 'B')
-            for det in dets:
+            for det in separate_devices(dets + [self.motor]):
                 cur_det = yield Msg('read', det)
                 if target_field in cur_det:
                     cur_I = cur_det[target_field]['value']
@@ -615,7 +613,7 @@ class Center(PlanBase):
             from lmfit.models import GaussianModel, LinearModel
         except ImportError:
             raise ImportError("This scan requires the package lmfit.")
-        self.detectors = detectors
+        self.detectors = separate_devices(detectors)
         self.target_field = target_field
         self.motor = motor
         self.initial_center = initial_center
@@ -644,7 +642,7 @@ class Center(PlanBase):
         # We checked in the __init__ that this import works.
         from lmfit.models import GaussianModel, LinearModel
         # For thread safety (paranoia) make copies of stuff
-        dets = self.detectors
+        dets = separate_devices(self.detectors)
         target_field = self.target_field
         motor = self.motor
         initial_center = self.initial_center
@@ -658,14 +656,14 @@ class Center(PlanBase):
                              initial_center + self.RANGE * initial_width,
                              self.NUM_SAMPLES, endpoint=True):
             yield Msg('set', motor, x)
-            yield Msg('create', None, name='primary')
             ret_mot = yield Msg('read', motor)
+            yield Msg('create', None, name='primary')
             key, = ret_mot.keys()
             seen_x.append(ret_mot[key]['value'])
             for det in dets:
                 yield Msg('trigger', det, block_group='B')
             yield Msg('wait', None, 'B')
-            for det in dets:
+            for det in separate_devices(dets + [motor]):
                 ret_det = yield Msg('read', det)
                 if target_field in ret_det:
                     seen_y.append(ret_det[target_field]['value'])
@@ -688,14 +686,14 @@ class Center(PlanBase):
                             np.random.randn(1) * guesses['sigma'],
                             min_cen, max_cen)
             yield Msg('set', motor, next_cen)
-            yield Msg('create', None, name='primary')
             ret_mot = yield Msg('read', motor)
+            yield Msg('create', None, name='primary')
             key, = ret_mot.keys()
             seen_x.append(ret_mot[key]['value'])
             for det in dets:
                 yield Msg('trigger', det, block_group='B')
             yield Msg('wait', None, 'B')
-            for det in dets:
+            for det in separate_devices(dets + [motor]):
                 ret_det = yield Msg('read', det)
                 if target_field in ret_det:
                     seen_y.append(ret_det[target_field]['value'])
@@ -723,7 +721,7 @@ class PlanND(PlanBase):
 
     def _gen(self):
         self._last_set_point = {m: None for m in self.motors}
-        dets = self.detectors
+        dets = separate_devices(self.detectors)
         for step in list(self.cycler):
             yield Msg('checkpoint')
             for motor, pos in step.items():
@@ -736,12 +734,10 @@ class PlanND(PlanBase):
             yield Msg('wait', None, 'A')
             yield Msg('create', None, name='primary')
 
-            for motor in self.motors:
-                yield Msg('read', motor)
             for det in dets:
                 yield Msg('trigger', det, block_group='B')
             yield Msg('wait', None, 'B')
-            for det in dets:
+            for det in separate_devices(dets + list(self.motors)):
                 yield Msg('read', det)
             yield Msg('save')
 

--- a/bluesky/tests/test_devices.py
+++ b/bluesky/tests/test_devices.py
@@ -1,18 +1,46 @@
-from ophyd import Component as Cpt, Device, SoftSignal
-from bluesky.utils import ancestry, separate_devices
+from ophyd import Component as Cpt, Device, Signal as UnusableSignal
+from bluesky.utils import ancestry, share_ancestor, separate_devices
+
+
+class Signal(UnusableSignal):
+    def __init__(self, _, *, name=None, parent=None):
+        super().__init__(name=name, parent=parent)
+
 
 
 class A(Device):
-    s1 = Cpt(SoftSignal, '')
-    s2 = Cpt(SoftSignal, '')
+    s1 = Cpt(Signal, '')
+    s2 = Cpt(Signal, '')
 
 
 class B(Device):
-    a = Cpt(A, '')
+    a1 = Cpt(A, '')
+    a2 = Cpt(A, '')
 
 
 def test_ancestry():
-    b = B()
+    b = B('')
     assert ancestry(b) == [b]
-    assert ancestry(b.a) == [b.a, b]
-    assert ancestry(b.a.s1) == [b.a.s1, b.a, b]
+    assert ancestry(b.a1) == [b.a1, b]
+    assert ancestry(b.a1.s1) == [b.a1.s1, b.a1, b]
+
+def test_share_ancestor():
+    b1 = B('')
+    b2 = B('')
+    assert share_ancestor(b1, b1)
+    assert share_ancestor(b1, b1.a1)
+    assert share_ancestor(b1, b1.a1.s1)
+    assert not share_ancestor(b2, b1)
+    assert not share_ancestor(b2, b1.a1)
+    assert not share_ancestor(b2, b1.a1.s1)
+
+
+def test_separate_devices():
+    b1 = B('')
+    b2 = B('')
+    a = A('')
+    assert separate_devices([b1, b1.a1]) == [b1]
+    assert separate_devices([b1.a1, b1.a2]) == [b1.a1, b1.a2]
+    assert separate_devices([b1, b2.a1]) == [b1, b2.a1]
+    assert separate_devices([b1.a1, b2.a2]) == [b1.a1, b2.a2]
+    assert separate_devices([b1, a]) == [b1, a]

--- a/bluesky/tests/test_devices.py
+++ b/bluesky/tests/test_devices.py
@@ -1,0 +1,18 @@
+from ophyd import Component as Cpt, Device, SoftSignal
+from bluesky.utils import ancestry, separate_devices
+
+
+class A(Device):
+    s1 = Cpt(SoftSignal, '')
+    s2 = Cpt(SoftSignal, '')
+
+
+class B(Device):
+    a = Cpt(A, '')
+
+
+def test_ancestry():
+    b = B()
+    assert ancestry(b) == [b]
+    assert ancestry(b.a) == [b.a, b]
+    assert ancestry(b.a.s1) == [b.a.s1, b.a, b]

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -418,7 +418,17 @@ def scalar_heuristic(device):
 
 def ancestry(obj):
     """
-    List parent, grandparent, ... back to ultimate ancestor.
+    List self, parent, grandparent, ... back to ultimate ancestor.
+
+    Parameters
+    ----------
+    obj : object
+        must have a `parent` attribute
+
+    Returns
+    -------
+    ancestry : list
+        list of objects, starting with obj and tracing parents recursively
     """
     ancestry = []
     ancestor = obj
@@ -432,6 +442,19 @@ def ancestry(obj):
 def is_ancestor(obj1, obj2):
     """
     Check whether obj1 is an ancestor (parent, grandparent, etc.) of obj2.
+
+    If obj1 is obj2, the result is False. An object is not its own ancestor.
+
+    Parameters
+    ----------
+    obj1 : object
+        must have a `parent` attribute
+    obj2 : object
+        must have a `parent` attribute
+
+    Returns
+    -------
+    result : boolean
     """
     if obj1 is obj2:
         return False
@@ -443,11 +466,37 @@ def is_ancestor(obj1, obj2):
 def have_common_ancestor(obj1, obj2):
     """
     Check whether obj1 and obj2 have a common ancestor.
+
+    Parameters
+    ----------
+    obj1 : object
+        must have a `parent` attribute
+    obj2 : object
+        must have a `parent` attribute
+
+    Returns
+    -------
+    result : boolean
     """
     return ancestry(obj1)[-1] is ancestry(obj2)[-1]
 
 
 def separate_devices(devices)
+    """
+    Filter out elements that have other elements as their ancestors.
+
+    If A is an ancestor of B, [A, B, C] -> [A, C].
+
+    Paremeters
+    ----------
+    devices : list
+        All elements must have a `parent` attribute.
+
+    Returns
+    -------
+    result : list
+        subset of input, with order retained
+    """
     result = []
     for det in devices:
         for existing_det in result:

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -439,27 +439,7 @@ def ancestry(obj):
         ancestor = ancestor.parent
 
 
-def is_ancestor(obj1, obj2):
-    """
-    Check whether obj1 is an ancestor (parent, grandparent, etc.) of obj2.
-
-    If obj1 is obj2, the result is True. An object is its own ancestor.
-
-    Parameters
-    ----------
-    obj1 : object
-        must have a `parent` attribute
-    obj2 : object
-        must have a `parent` attribute
-
-    Returns
-    -------
-    result : boolean
-    """
-    return obj2 in ancestry(obj1)
-
-
-def have_common_ancestor(obj1, obj2):
+def share_ancestor(obj1, obj2):
     """
     Check whether obj1 and obj2 have a common ancestor.
 

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -414,3 +414,51 @@ def scalar_heuristic(device):
     reading = device.read()
     key = first_key_heuristic(device)
     return reading[key]['value']
+
+
+def ancestry(obj):
+    """
+    List parent, grandparent, ... back to ultimate ancestor.
+    """
+    ancestry = []
+    ancestor = obj
+    while True:
+        ancestry.append(ancestor)
+        ancestor = ancestor.parent
+        if ancestor.parent is None:
+            return ancestry
+
+
+def is_ancestor(obj1, obj2):
+    """
+    Check whether obj1 is an ancestor (parent, grandparent, etc.) of obj2.
+    """
+    if obj1 is obj2:
+        return False
+    if obj2 in ancestry(obj1):
+        return True
+    return False
+
+
+def have_common_ancestor(obj1, obj2):
+    """
+    Check whether obj1 and obj2 have a common ancestor.
+    """
+    return ancestry(obj1)[-1] is ancestry(obj2)[-1]
+
+
+def separate_devices(devices)
+    result = []
+    for det in devices:
+        for existing_det in result:
+            if existing_det is det:
+                continue
+            elif is_ancestor(existing_det, det):
+                continue  # det will be read as part of existing_det
+            elif is_ancestor(det, existing_det):
+                # existing_det is redundant; use det in its place
+                result.remove(existing_det)
+                result.append(det)
+            else:
+                result.append(det)
+    return result

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -434,16 +434,16 @@ def ancestry(obj):
     ancestor = obj
     while True:
         ancestry.append(ancestor)
-        ancestor = ancestor.parent
         if ancestor.parent is None:
             return ancestry
+        ancestor = ancestor.parent
 
 
 def is_ancestor(obj1, obj2):
     """
     Check whether obj1 is an ancestor (parent, grandparent, etc.) of obj2.
 
-    If obj1 is obj2, the result is False. An object is not its own ancestor.
+    If obj1 is obj2, the result is True. An object is its own ancestor.
 
     Parameters
     ----------
@@ -456,11 +456,7 @@ def is_ancestor(obj1, obj2):
     -------
     result : boolean
     """
-    if obj1 is obj2:
-        return False
-    if obj2 in ancestry(obj1):
-        return True
-    return False
+    return obj2 in ancestry(obj1)
 
 
 def have_common_ancestor(obj1, obj2):
@@ -481,7 +477,7 @@ def have_common_ancestor(obj1, obj2):
     return ancestry(obj1)[-1] is ancestry(obj2)[-1]
 
 
-def separate_devices(devices)
+def separate_devices(devices):
     """
     Filter out elements that have other elements as their ancestors.
 
@@ -499,15 +495,15 @@ def separate_devices(devices)
     """
     result = []
     for det in devices:
+        skip = False
         for existing_det in result:
-            if existing_det is det:
-                continue
-            elif is_ancestor(existing_det, det):
-                continue  # det will be read as part of existing_det
+            if is_ancestor(existing_det, det):
+                skip = True
+                break
             elif is_ancestor(det, existing_det):
                 # existing_det is redundant; use det in its place
                 result.remove(existing_det)
-                result.append(det)
-            else:
-                result.append(det)
+                break  # we won't find any ancestors of existing_det in result
+        if not skip:
+            result.append(det)
     return result

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -475,15 +475,14 @@ def separate_devices(devices):
     """
     result = []
     for det in devices:
-        skip = False
         for existing_det in result:
-            if is_ancestor(existing_det, det):
-                skip = True
+            if existing_det in ancestry(det):
+                # known issue: here we assume that det is in the read_attrs
+                # of existing_det -- to be addressed after plans.py refactor
                 break
-            elif is_ancestor(det, existing_det):
+            elif det in ancestry(existing_det):
                 # existing_det is redundant; use det in its place
                 result.remove(existing_det)
-                break  # we won't find any ancestors of existing_det in result
-        if not skip:
+        else:
             result.append(det)
     return result

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
 test:
   requires:
     - nslsii_dev_configuration
+    - ophyd
   imports:
     - 'bluesky'
     - 'bluesky.examples'


### PR DESCRIPTION
As discovered at CSX, putting a device and a subdevice into the list of (detectors + motors) causes the RunEngine to error when it see the same reading twice. In this PR, we inspect (sub)device ancestry to make sure a device and its ancestor are not both read.

In each plan, we:
* Determine a unique list of all devices to be triggered and waited on -- that's detectors only.
* Determine a (potentially different) unique list of all devices to read -- that's detectors and motor(s).

As an aside, notice that using the convenience functions introduced in this PR, the `root` attribute of object could potentially be factored out and ultimately removed from ophyd if we want. One problem at a time.