### PR TITLE
MNT/DOC: No metadata fields are required.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ install:
   - conda install "conda<4"
   - conda create -n testenv nose python=$TRAVIS_PYTHON_VERSION scipy requests matplotlib jsonschema traitlets pytest coverage
   - source activate testenv
-  - conda install metadatastore databroker ophyd historydict boltons doct toolz tifffile pymongo pcaspy pyepics readline super_state_machine cycler xray-vision lmfit event-model -c lightsource2 -c conda-forge -c soft-matter
+  - 'pip install https://github.com/NSLS-II/event-model/zipball/master#egg=event_model'
+  - conda install metadatastore databroker ophyd historydict boltons doct toolz tifffile pymongo pcaspy pyepics readline super_state_machine cycler xray-vision lmfit -c lightsource2 -c conda-forge -c soft-matter
   - conda remove metadatastore databroker filestore --yes
   - 'pip install https://github.com/NSLS-II/databroker/zipball/master#egg=databroker'
   - 'pip install https://github.com/NSLS-II/filestore/zipball/master#egg=filestore'

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1617,17 +1617,13 @@ Pro Tip: Next time, if you want to abort, tap Ctrl+C twice quickly.
 
 
 def _default_md_validator(md):
-    for field in ['beamline_id', 'owner', 'group']:
-        if field not in md:
-            raise KeyError("The field '{0}' was not specified as is "
-                           "required.".format(field))
-        if 'sample' in md and not (hasattr(md['sample'], 'keys')
-                                   or isinstance(md['sample'], str)):
-            raise ValueError(
-                "You specified 'sample' metadata. We give this field special "
-                "significance in order to make your data easily searchable. "
-                "Therefore, you must make 'sample' a string or a  "
-                "dictionary, like so: "
-                "GOOD: sample='dirt' "
-                "GOOD: sample={'color': 'red', 'number': 5} "
-                "BAD: sample=[1, 2] ")
+    if 'sample' in md and not (hasattr(md['sample'], 'keys')
+                                or isinstance(md['sample'], str)):
+        raise ValueError(
+            "You specified 'sample' metadata. We give this field special "
+            "significance in order to make your data easily searchable. "
+            "Therefore, you must make 'sample' a string or a  "
+            "dictionary, like so: "
+            "GOOD: sample='dirt' "
+            "GOOD: sample={'color': 'red', 'number': 5} "
+            "BAD: sample=[1, 2] ")

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -212,35 +212,6 @@ def test_md_historydict():
 def _md(md):
     RE = RunEngine(md)
     RE.ignore_callback_exceptions = False
-    scan = simple_scan(motor)
-    with pytest.raises(KeyError):
-        RE(scan)  # missing owner, beamline_id
-    scan = simple_scan(motor)
-    with pytest.raises(KeyError):
-        RE(scan, owner='dan')
-    scan = simple_scan(motor)
-    RE(scan, owner='dan', beamline_id='his desk',
-       group='some group', config={})  # this should work
-    scan = simple_scan(motor)
-    with pytest.raises(KeyError):
-        RE(scan)  # this should fail; none was persisted
-    RE.md['owner'] = 'dan'
-    RE.md['group'] = 'some group'
-    RE.md['config'] = {}
-    RE.md['beamline_id'] = 'his desk'
-    scan = simple_scan(motor)
-    RE(scan)  # this should work
-    RE.md.clear()
-    scan = simple_scan(motor)
-    with pytest.raises(KeyError):
-        RE(scan)
-    # We can prime the md directly.
-    RE.md['owner'] = 'dan'
-    RE.md['group'] = 'some group'
-    RE.md['config'] = {}
-    RE.md['beamline_id'] = 'his desk'
-    scan = simple_scan(motor)
-    RE(scan)
 
     # Check persistence.
     scan = simple_scan(motor)

--- a/bluesky/tests/utils.py
+++ b/bluesky/tests/utils.py
@@ -90,6 +90,8 @@ def define_state_machine_transitions_from_class(state_machine):
 
 
 def setup_test_run_engine():
+    # The metadata configured here used to be required for the RE to be
+    # usable. Now it is all optional, but maintained for legacy reasons.
     RE = RunEngine()
     RE.md['owner'] = 'test_owner'
     RE.md['group'] = 'Grant No. 12345'

--- a/doc/source/callbacks.rst
+++ b/doc/source/callbacks.rst
@@ -12,7 +12,6 @@ Live Feedback and Processing
    RE.verbose = False
    RE.md['owner'] = 'Jane'
    RE.md['group'] = 'Grant No. 12345'
-   RE.md['beamline_id'] = 'demo'
    from bluesky.plans import Count, AbsScanPlan
    plan = AbsScanPlan([det, det1, det2, det3], motor, 1, 4, 4)
 

--- a/doc/source/metadata.rst
+++ b/doc/source/metadata.rst
@@ -15,7 +15,6 @@ identify and analyze the data later.
     from bluesky.examples import det
     from bluesky.plans import Count
     RE = gs.RE
-    RE.md['beamline_id'] = 'demo'
     RE.md['owner'] = 'demo'
     RE.md['group'] = 'demo'
 
@@ -31,59 +30,62 @@ Or specified when the scan is run.
     plan = Count([det])
     RE(plan, experimenter='Emily', mood='excited')
 
-.. note::
+Special Fields
+--------------
 
-    To improve searchability, the key "sample" has specicial significance.
-    It must be either a string
+Custom metadata keywords can be mapped to strings (``task='calibration'``),
+numbers (``attempt=5``), lists (``dimensions=[1, 3]``), or
+dictionaries (``dimensions={'width': 1, 'height': 3}``). But certain keywords
+are given special significance by bluesky's document model.
 
-    .. code-block:: python
+String Fields
+=============
 
-        'red 10 20 5'
+To facilitate serachability, the keywords 'owner', 'group', and 'project' are
+given special significance. They are all optional, but if provided they must be
+strings like ``owner='Dan'``. A non-string, like ``owner=5`` will produce an
+error that will interrupt scan execution immediately after it starts.
 
-    or a dictionary
+Again, these fields are optional.
 
-    .. code-block:: python
+Sample
+======
 
-        {'color': 'red', 'dimensions': [10, 20, 5]}
+Similarly, the keyword "sample" has specicial significance. It must be either a
+string:
 
-    A dictionary is preferred because it is self-describing and more richly
-    searchable, but either is allowed.
+.. code-block:: python
 
-    Only "sample" has this restriciton. Invent custom-named keys (as in the
-    tongue-in-cheek "mood" example above) as needed. These can contain
-    strings, dictionaries, lists, and numbers.
+    'red 10 20 5'
+
+or a dictionary:
+
+.. code-block:: python
+
+    {'color': 'red', 'dimensions': [10, 20, 5]}
+
+A dictionary is preferred because it is self-describing and more richly
+searchable, but either is allowed.
+
+Scan ID
+=======
+
+The ``scan_id`` field is expected to be an integer, and it is automatically
+incremented between runs. If a ``scan_id`` is not provided by the user,
+it defaults to 1.
 
 Required Fields
 ---------------
 
-Some fields and required by our Document specification, and the RunEngine will
-raise a ``KeyError`` if they are not set. These fields are:
+In current versions of bluesky, **no fields are required**.
 
-* owner
-* group
-* beamline_id (e.g., 'csx')
-
-``standard_config.py`` fills some of these in automatically (e.g., 'owner'
-defaults to the username of the UNIX user currently logged in).
+In versions v0.4.3 and below, the keys ``owner``, ``group``, and
+``beamline_id`` were required.
 
 Persistence Between Runs
 ------------------------
 
-These fields are automatically reused between runs unless overridden.
-
-* owner
-* group
-* beamline_id
-* scan_id (which is automatically incremented)
-
-Custom fields, like 'experimenter' and 'mood' in the example above, are not
-reused by default, as we can see below.
-
-.. ipython:: python
-
-    RE(plan, sample={'color': 'blue', 'dimensions': [3, 1, 4]})
-
-To make a custom field persist between sessions, add it to ``RE.md``.
+To set a field of metadata to persist for future runs, add it to ``RE.md``.
 
 .. ipython:: python
 
@@ -107,6 +109,26 @@ To start fresh:
 .. ipython:: python
 
     RE.md.clear()
+
+Persistence Between Sessions
+----------------------------
+
+The ``RE.md`` attribute shown above may be a Python dictionary or anything
+that support the dictionary interface. To persist metadata between
+sessions, we suggest ``historydict`` --- a Python dictionary backed by a
+sqlite database.
+
+Example:
+
+.. ipython:: python
+
+    from historydict import HistoryDict
+    hist = HistoryDict('metadata-cache.sqlite')
+    RE = RunEngine(hist)
+    type(RE.md)
+
+Any metadata added to ``RE.md``, including the ``scan_id``, will be saved
+and can be re-loaded.
 
 Metadata Validator
 ------------------

--- a/doc/source/metadata.rst
+++ b/doc/source/metadata.rst
@@ -41,7 +41,7 @@ are given special significance by bluesky's document model.
 String Fields
 =============
 
-To facilitate serachability, the keywords 'owner', 'group', and 'project' are
+To facilitate searchability, the keywords 'owner', 'group', and 'project' are
 given special significance. They are all optional, but if provided they must be
 strings like ``owner='Dan'``. A non-string, like ``owner=5`` will produce an
 error that will interrupt scan execution immediately after it starts.
@@ -51,7 +51,7 @@ Again, these fields are optional.
 Sample
 ======
 
-Similarly, the keyword "sample" has specicial significance. It must be either a
+Similarly, the keyword "sample" has special significance. It must be either a
 string:
 
 .. code-block:: python
@@ -114,7 +114,7 @@ Persistence Between Sessions
 ----------------------------
 
 The ``RE.md`` attribute shown above may be a Python dictionary or anything
-that support the dictionary interface. To persist metadata between
+that supports the dictionary interface. To persist metadata between
 sessions, we suggest ``historydict`` --- a Python dictionary backed by a
 sqlite database.
 

--- a/doc/source/state-machine.rst
+++ b/doc/source/state-machine.rst
@@ -7,8 +7,6 @@
     RE = RunEngine()
     RE.md['owner'] = 'demo'
     RE.md['group'] = 'Grant No. 12345'
-    RE.md['config'] = {'detector_model': 'XYZ', 'pxiel_size': 10}
-    RE.md['beamline_id'] = 'demo'
 
 Pausing and Resuming
 ====================


### PR DESCRIPTION
- Former minimal working RunEngine instance was
  `RunEngine({'owner': '', 'group': '', 'beamline_id'})`
- New minimal working RunEngine instance is
  `RunEngine({})`

This is lighter for testing, debugging, teaching. It also removes
the domain-specific word "beamline" from the required lexicon.

I rewrote the metadata section of the docs, should be much
more clear.