### PR TITLE
MNT: Deprecated qt_kicker module; move it to utils

### DIFF
--- a/bluesky/qt_kicker.py
+++ b/bluesky/qt_kicker.py
@@ -1,45 +1,8 @@
-import sys
-
-_INSTALLED = None
+import warnings
+from .utils import install_qt_kicker as _install_qt_kicker
 
 
 def install_qt_kicker():
-    """Install a periodic callback to integrate qt and asyncio event loops
-
-    If a version of the qt bindings are not already imported, this function
-    will do nothing.
-
-    It is safe to call this function multiple times.
-    """
-
-    global _INSTALLED
-    if _INSTALLED is not None:
-        return
-    if not any(p in sys.modules for p in ['PyQt4', 'pyside', 'PyQt5']):
-        return
-    import asyncio
-    import matplotlib.backends.backend_qt5
-    from matplotlib.backends.backend_qt5 import _create_qApp
-    from matplotlib._pylab_helpers import Gcf
-
-    _create_qApp()
-    qApp = matplotlib.backends.backend_qt5.qApp
-
-    try:
-        _draw_all = Gcf.draw_all  # mpl version >= 1.5
-    except AttributeError:
-        # slower, but backward-compatible
-        def _draw_all():
-            for f_mgr in Gcf.get_all_fig_managers():
-                f_mgr.canvas.draw_idle()
-
-    def _qt_kicker():
-        # The RunEngine Event Loop interferes with the qt event loop. Here we
-        # kick it to keep it going.
-        _draw_all()
-
-        qApp.processEvents()
-        loop.call_later(0.03, _qt_kicker)
-
-    loop = asyncio.get_event_loop()
-    _INSTALLED = loop.call_soon(_qt_kicker)
+    warnings.warn("The qt_kicker module is deprecated. Instead, use "
+                  "`from bluesky.utils import qt_kicker`")
+    _install_qt_kicker()

--- a/bluesky/tests/test_vertical_integration.py
+++ b/bluesky/tests/test_vertical_integration.py
@@ -8,21 +8,16 @@ import pytest
 def setup_module(module):
     try:
         import metadatastore
-    except ImportError:
-        pass  # test will be skipped
+    except ImportError as ie:
+        raise pytest.skip('ImportError: {0}'.format(ie))
     else:
         from metadatastore.test.utils import mds_setup
         mds_setup()
         register_mds(gs.RE)
 
 def teardown_module(module):
-    try:
-        import metadatastore
-    except ImportError:
-        pass  # test will be skipped
-    else:
-        from metadatastore.test.utils import mds_teardown
-        mds_teardown()
+    from metadatastore.test.utils import mds_teardown
+    mds_teardown()
 
 
 def test_scan_and_get_data():

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -540,3 +540,48 @@ def get_history():
             print("Storing HistoryDict in memory; it will not persist "
                   "when session is ended.")
             return historydict.HistoryDict(':memory:')
+
+
+_QT_KICKER_INSTALLED = None
+
+
+def install_qt_kicker():
+    """Install a periodic callback to integrate qt and asyncio event loops
+
+    If a version of the qt bindings are not already imported, this function
+    will do nothing.
+
+    It is safe to call this function multiple times.
+    """
+
+    global _QT_KICKER_INSTALLED
+    if _QT_KICKER_INSTALLED is not None:
+        return
+    if not any(p in sys.modules for p in ['PyQt4', 'pyside', 'PyQt5']):
+        return
+    import asyncio
+    import matplotlib.backends.backend_qt5
+    from matplotlib.backends.backend_qt5 import _create_qApp
+    from matplotlib._pylab_helpers import Gcf
+
+    _create_qApp()
+    qApp = matplotlib.backends.backend_qt5.qApp
+
+    try:
+        _draw_all = Gcf.draw_all  # mpl version >= 1.5
+    except AttributeError:
+        # slower, but backward-compatible
+        def _draw_all():
+            for f_mgr in Gcf.get_all_fig_managers():
+                f_mgr.canvas.draw_idle()
+
+    def _qt_kicker():
+        # The RunEngine Event Loop interferes with the qt event loop. Here we
+        # kick it to keep it going.
+        _draw_all()
+
+        qApp.processEvents()
+        loop.call_later(0.03, _qt_kicker)
+
+    loop = asyncio.get_event_loop()
+    _QT_KICKER_INSTALLED = loop.call_soon(_qt_kicker)


### PR DESCRIPTION
Addresses another piece of #189

Also a little test refactor suggested by @ericdill 