### PR TITLE
Add monitor_context (and -- unrelated -- sundry RunEngine docstrings)

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -258,7 +258,7 @@ class RunEngine:
         # to provide special docstrings.
         self._lossless_dispatcher = Dispatcher()
 
-        loop.call_soon(self._check_for_trouble)
+        loop.call_soon(self._check_for_panic)
         loop.call_soon(self._check_for_signals)
 
     @property
@@ -370,9 +370,9 @@ class RunEngine:
         If the panic occurred during a pause, the run can be resumed.
         """
         self._panic = False
-        # The cycle where _check_for_trouble schedules a future call to itself
+        # The cycle where _check_for_panic schedules a future call to itself
         # is broken when it raises a PanicError.
-        loop.call_later(0.1, self._check_for_trouble)
+        loop.call_later(0.1, self._check_for_panic)
 
     def request_pause(self, defer=False, name=None, callback=None):
         """
@@ -781,7 +781,7 @@ class RunEngine:
                 del self._monitor_cbs[obj]
             self.state = 'idle'
 
-    def _check_for_trouble(self):
+    def _check_for_panic(self):
         if self.state.is_running:
             # Check for panic.
             if self._panic:
@@ -794,7 +794,7 @@ class RunEngine:
                                  "exit_status='fail'.")
                 self._exception = exc  # will stop _run coroutine
 
-        loop.call_later(0.1, self._check_for_trouble)
+        loop.call_later(0.1, self._check_for_panic)
 
     def _check_for_signals(self):
         # Check for pause requests from keyboard.

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -937,6 +937,13 @@ class RunEngine:
 
     @asyncio.coroutine
     def _read(self, msg):
+        """
+        Add a reading to the open event bundle.
+
+        Expected Msg object is:
+
+            Msg('read', obj)
+        """
         obj = msg.obj
         self._objs_read.append(obj)
         if obj not in self._describe_cache:
@@ -968,6 +975,19 @@ class RunEngine:
 
     @asyncio.coroutine
     def _monitor(self, msg):
+        """
+        Monitor a signal. Emit event documents asynchronously.
+
+        A descriptor document is emitted immediately. Then, a closure is
+        defined that emits Event documents associated with that descriptor
+        from a separate thread. This process is not related to the main
+        bundling process (create/read/save).
+
+        Expected Msg object is:
+
+            Msg('monitor', obj)
+            Msg('monitor', obj, name='event-stream-name')
+        """
         obj = msg.obj
         name = msg.kwargs.get('name')
         if not self._run_is_open:
@@ -1010,6 +1030,13 @@ class RunEngine:
 
     @asyncio.coroutine
     def _unmonitor(self, msg):
+        """
+        Stop monitoring; i.e., remove the callback emitting event documents.
+
+        Expected Msg object is:
+
+            Msg('unmonitor', obj)
+        """
         obj = msg.obj
         cb = self._monitor_cbs[obj]
         obj.clear_sub(cb)
@@ -1143,6 +1170,13 @@ class RunEngine:
 
     @asyncio.coroutine
     def _collect(self, msg):
+        """
+        Collect data cached by a flyer and emit descriptor and event documents.
+
+        Expect message object is
+
+            Msg('collect', obj)
+        """
         if not self._run_is_open:
             raise IllegalMessageSequence("A 'collect' message was sent but no "
                                          "run is open.")
@@ -1194,10 +1228,25 @@ class RunEngine:
 
     @asyncio.coroutine
     def _null(self, msg):
+        """
+        A no-op message, mainly for debugging and testing.
+        """
         pass
 
     @asyncio.coroutine
     def _set(self, msg):
+        """
+        Set a device and cache the returned status object.
+
+        Also, note that the device has been touched so it can be stopped upon
+        exit.
+
+        Expected messgage object is
+
+            Msg('set', obj, *args, **kwargs)
+
+        where arguments are passed through to `obj.set(*args, **kwargs)`.
+        """
         block_group = msg.kwargs.pop('block_group', None)
         self._movable_objs_touched.add(msg.obj)
         ret = msg.obj.set(*msg.args, **msg.kwargs)
@@ -1221,6 +1270,13 @@ class RunEngine:
 
     @asyncio.coroutine
     def _trigger(self, msg):
+        """
+        Trigger a device and cache the returned status object.
+
+        Expected Msg object is:
+
+            Msg('trigger', obj)
+        """
         block_group = msg.kwargs.pop('block_group', None)
         ret = msg.obj.trigger(*msg.args, **msg.kwargs)
 

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -969,6 +969,7 @@ class RunEngine:
     @asyncio.coroutine
     def _monitor(self, msg):
         obj = msg.obj
+        name = msg.kwargs.get('name')
         if not self._run_is_open:
             raise IllegalMessageSequence("A 'monitor' message was sent but no "
                                          "run is open.")
@@ -982,7 +983,7 @@ class RunEngine:
         object_keys = {obj.name: list(data_keys)}
         desc_doc = dict(run_start=self._run_start_uid, time=ttime.time(),
                         data_keys=data_keys, uid=descriptor_uid,
-                        configuration=config, name=None,
+                        configuration=config, name=name,
                         object_keys=object_keys)
         self.log.debug("Emitted Event Descriptor")
         seq_num_counter = count()


### PR DESCRIPTION
This PR is based on #345 which should be merged first.

See docstring of `monitor_context` for usage and details.