### PR TITLE
RunEngine starts in a resumable state

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1068,7 +1068,10 @@ class RunEngine:
             descriptor_uid = self._descriptors[(self._bundle_name, objs_read)]
         # This is a separate check because it can be reset on resume.
         if objs_read not in self._sequence_counters:
-            self._sequence_counters[objs_read] = count(1)
+            counter = count(1)
+            counter_copy1, counter_copy2 = tee(counter)
+            self._sequence_counters[objs_read] = counter_copy1
+            self._teed_sequence_counters[objs_read] = counter_copy2
         self._bundling = False
         self._bundle_name = None
 

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -209,7 +209,7 @@ class RunEngine:
         self._pause_requests = dict()  # holding {<name>: callable}
         self._block_groups = defaultdict(set)  # sets of objs to wait for
         self._temp_callback_ids = set()  # ids from CallbackRegistry
-        self._msg_cache = None  # may be used to hold recently processed msgs
+        self._msg_cache = deque() # history of processed msgs for rewinding
         self._genstack = deque()  # stack of generators to work off of
         self._new_gen = True  # flag if we need to prime the generator
         self._exit_status = 'success'  # optimistic default
@@ -296,7 +296,7 @@ class RunEngine:
         self._movable_objs_touched.clear()
         self._deferred_pause_requested = False
         self._genstack = deque()
-        self._msg_cache = None
+        self._msg_cache = deque()
         self._new_gen = True
         self._exception = None
         self._run_start_uids.clear()

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -90,13 +90,13 @@ def test_deferred_pause():
 
 def test_hard_pause_no_checkpoint():
     assert RE.state == 'idle'
-    RE(conditional_pause(det, motor, False, False))
+    RE([Msg('clear_checkpoint'), Msg('pause', False)]),
     assert RE.state == 'idle'
 
 
 def test_deferred_pause_no_checkpoint():
     assert RE.state == 'idle'
-    RE(conditional_pause(det, motor, True, False))
+    RE([Msg('clear_checkpoint'), Msg('pause', True)])
     assert RE.state == 'idle'
 
 
@@ -527,8 +527,7 @@ def test_clear_checkpoint():
                 Msg('clear_checkpoint'),
                 Msg('pause'),
                 'lies']
-    silly_plan = [Msg('pause'), 'lies']
-    good_plan = [Msg('checkpoint'), Msg('pause')]
+    good_plan = [Msg('pause')]
     fine_plan = [Msg('clear_checkpoint')]
 
     RE(good_plan)
@@ -541,9 +540,6 @@ def test_clear_checkpoint():
     # this should raise an attribute error if the last entry in the plan
     # is passed to the run engine
     RE(bad_plan)
-    assert RE.state == 'idle'
-
-    RE(silly_plan)
     assert RE.state == 'idle'
 
 

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -572,3 +572,24 @@ def test_failed_status_object():
     with pytest.raises(FailedStatus):
         RE([Msg('set', ff, None, block_group='a'),
             Msg('wait', None, 'a')])
+
+
+def test_rewindable_by_default():
+    class Sentinel(Exception):
+        pass
+
+    def plan():
+        yield Msg('pause')
+        raise Sentinel
+
+    RE(plan())
+    assert RE.state == 'paused'
+    with pytest.raises(Sentinel):
+        RE.resume()
+
+    def plan():
+        yield Msg('clear_checkpoint')
+        yield Msg('pause')
+
+    RE(plan())  # cannot pause
+    assert RE.state == 'idle'


### PR DESCRIPTION
Previous, if interrupted before the first 'checkpoint' message, it died. Now, unless it sees a 'clear_checkpoint' message, it rewinds to the beginning if interrupted.