### PR TITLE
API: Fix wait_for signature; use a consistent name for block_group/group.

### DIFF
--- a/bluesky/broker_examples.py
+++ b/bluesky/broker_examples.py
@@ -32,7 +32,7 @@ class SynGauss2D(Reader):
         # exception to be raised if/when the file system cleans its temp files
         self.output_dir = tempfile.gettempdir()
 
-    def trigger(self, *, block_group=True):
+    def trigger(self, *, group=True):
         self.ready = False
         m = self._motor._data[self._motor_field]['value']
         v = self.Imax * np.exp(-(m - self.center)**2 / (2 * self.sigma**2))

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -359,7 +359,7 @@ def fly_during(plan, flyers):
         inserted
     """
     grp = _short_uid('flyers')
-    kickoff_msgs = [Msg('kickoff', flyer, block_group=grp) for flyer in flyers]
+    kickoff_msgs = [Msg('kickoff', flyer, group=grp) for flyer in flyers]
     collect_msgs = [Msg('collect', flyer) for flyer in flyers]
     if flyers:
         # If there are any flyers, insert a Msg that waits for them to finish.
@@ -550,7 +550,7 @@ def reset_positions(plan, devices=None):
     def reset():
         blk_grp = 'reset-{}'.format(str(uuid.uuid4())[:6])
         for k, v in initial_positions.items():
-            yield Msg('set', k, v, block_group=blk_grp)
+            yield Msg('set', k, v, group=blk_grp)
         yield Msg('wait', None, blk_grp)
 
     return (yield from finalize(plan_mutator(plan, insert_reads), reset()))
@@ -686,7 +686,7 @@ def trigger_and_read(devices):
     grp = _short_uid('trigger')
     for obj in separate_devices(devices):
         if hasattr(obj, 'trigger'):
-            yield Msg('trigger', obj, block_group=grp)
+            yield Msg('trigger', obj, group=grp)
     yield Msg('wait', None, grp)
     for obj in devices:
         yield Msg('read', obj)
@@ -827,7 +827,7 @@ def one_1d_step(detectors, motor, step):
     def move():
         grp = _short_uid('set')
         yield Msg('checkpoint')
-        yield Msg('set', motor, step, block_group=grp)
+        yield Msg('set', motor, step, group=grp)
         yield Msg('wait', None, grp)
 
     plan_stack = deque()
@@ -1096,7 +1096,7 @@ def adaptive_scan(detectors, target_field, motor, start, stop,
             yield Msg('wait', None, 'A')
             yield Msg('create', None, name='primary')
             for det in detectors:
-                yield Msg('trigger', det, block_group='B')
+                yield Msg('trigger', det, group='B')
             yield Msg('wait', None, 'B')
             for det in separate_devices(detectors + [motor]):
                 cur_det = yield Msg('read', det)
@@ -1197,7 +1197,7 @@ def one_nd_step(detectors, step, pos_cache):
             if pos == pos_cache[motor]:
                 # This step does not move this motor.
                 continue
-            yield Msg('set', motor, pos, block_group=grp)
+            yield Msg('set', motor, pos, group=grp)
             pos_cache[motor] = pos
         yield Msg('wait', None, grp)
 
@@ -1431,7 +1431,7 @@ def tweak(detector, target_field, motor, step, *, md=None):
             ret_mot = yield Msg('read', motor)
             key, = ret_mot.keys()
             pos = ret_mot[key]['value']
-            yield Msg('trigger', d, block_group='A')
+            yield Msg('trigger', d, group='A')
             yield Msg('wait', None, 'A')
             reading = Msg('read', d)[target_field]['value']
             yield Msg('save')
@@ -1442,7 +1442,7 @@ def tweak(detector, target_field, motor, step, *, md=None):
                     step = float(new_step)
                 except ValueError:
                     break
-            yield Msg('set', motor, pos + step, block_group='A')
+            yield Msg('set', motor, pos + step, group='A')
             print('Motor moving...')
             sys.stdout.flush()
             yield Msg('wait', None, 'A')

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -645,7 +645,7 @@ class RunEngine:
             for obj, (cb, kwargs) in list(self._monitor_params.items()):
                 obj.clear_sub(cb)
                 del self._monitor_params[obj]
-            wait_msg = Msg('wait_for', [fut, ])
+            wait_msg = Msg('wait_for', None, [fut, ])
             for obj, (cb, kwargs) in monitor_params.items():
                 msg = Msg('monitor', obj, **kwargs)
                 self._msg_cache.appendleft(msg)
@@ -852,7 +852,7 @@ class RunEngine:
         Where ``obj`` and **kwargs are the position and keyword-only arguments
         for ``asyncio.await``
         """
-        futs = msg.obj
+        futs, = msg.args
         yield from asyncio.wait(futs, **msg.kwargs)
 
     @asyncio.coroutine
@@ -1332,9 +1332,9 @@ class RunEngine:
             Msg('wait', group=GROUP)
         """
         group = msg.kwargs.get('group', msg.args[0])
-        objs = list(self._groups.pop(group, []))
-        if objs:
-            yield from self._wait_for(Msg('wait_for', objs))
+        futs = list(self._groups.pop(group, []))
+        if futs :
+            yield from self._wait_for(Msg('wait_for', None, futs))
 
     def _failed_status(self, ret):
         """

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -847,7 +847,7 @@ class RunEngine:
 
         Expected message object is:
 
-            Msg('wait_for', obj, **kwargs)
+            Msg('wait_for', obj, futs)
 
         Where ``obj`` and **kwargs are the position and keyword-only arguments
         for ``asyncio.await``

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -847,7 +847,7 @@ class RunEngine:
 
         Expected message object is:
 
-            Msg('wait_for', obj, futs)
+            Msg('wait_for', None, futures, **kwargs)
 
         Where ``obj`` and **kwargs are the position and keyword-only arguments
         for ``asyncio.await``

--- a/bluesky/tests/abort.py
+++ b/bluesky/tests/abort.py
@@ -21,7 +21,7 @@ def run():
         ttime.sleep(0.1)
         os.kill(pid, signal.SIGINT)
 
-    scan = [Msg('checkpoint'), Msg('wait_for', [ev.wait(), ]), ]
+    scan = [Msg('checkpoint'), Msg('wait_for', None, [ev.wait(), ]), ]
     RE.verbose = True
     assert RE.state == 'idle'
     start = ttime.time()

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -308,7 +308,7 @@ def test_pause_resume():
     def sim_kill():
         os.kill(pid, signal.SIGINT)
 
-    scan = [Msg('checkpoint'), Msg('wait_for', [ev.wait(), ]), ]
+    scan = [Msg('checkpoint'), Msg('wait_for', None, [ev.wait(), ]), ]
     assert RE.state == 'idle'
     start = ttime.time()
     loop.call_later(1, sim_kill)
@@ -337,7 +337,7 @@ def test_pause_abort():
     def sim_kill():
         os.kill(pid, signal.SIGINT)
 
-    scan = [Msg('checkpoint'), Msg('wait_for', [ev.wait(), ]), ]
+    scan = [Msg('checkpoint'), Msg('wait_for', None, [ev.wait(), ]), ]
     assert RE.state == 'idle'
     start = ttime.time()
     loop.call_later(1, sim_kill)

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -570,5 +570,5 @@ def test_failed_status_object():
 
     ff = failer()
     with pytest.raises(FailedStatus):
-        RE([Msg('set', ff, None, block_group='a'),
+        RE([Msg('set', ff, None, group='a'),
             Msg('wait', None, 'a')])

--- a/bluesky/tests/test_scans.py
+++ b/bluesky/tests/test_scans.py
@@ -268,7 +268,7 @@ def test_wait_for():
 
     def done():
         ev.set()
-    scan = [Msg('wait_for', [ev.wait(), ]), ]
+    scan = [Msg('wait_for', None, [ev.wait(), ]), ]
     loop.call_later(2, done)
     start = ttime.time()
     RE(scan)

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -1,6 +1,29 @@
 API Changes
 ===========
 
+v0.5.0
+------
+
+* In all occurrences, the argument ``block_group`` has been renamed ``group``
+  for consistency. This affects the 'trigger' and 'set' messages.
+* The (not widely used) ``Center`` plan has been removed. It may be
+  distributed separately in the future.
+* Calling a "SPEC-like" plan now returns a generator that must be passed
+  to the RunEngine; it does not execute the plan with the global RunEngine in
+  gs.RE. There is a convenience wrapper available to restore the old behavior
+  as desired. But since that usage renders the plans un-composable, it is
+  discouraged.
+* The 'time' argument of the SPEC-like plans is a keyword-only argument.
+* The following special-case SPEC-like scans have been removed:
+    * hscan
+    * kscan
+    * lscan
+    * tscan
+    * dtscan 
+    * hklscan 
+    * hklmesh
+  They can be defined in configuration files as desired, and in that location
+  they will be easier to customize.
 
 v0.3.0
 ------
@@ -29,26 +52,3 @@ v0.3.0
 
   If classes derived from `CallbackBase` are being used this will not
   not have any effect on user code.
-
-v0.5.0
-------
-
-
-* The (not widely used) ``Center`` plan has been removed. It may be
-  distributed separately in the future.
-* Calling a "SPEC-like" plan now returns a generator that must be passed
-  to the RunEngine; it does not execute the plan with the global RunEngine in
-  gs.RE. There is a convenience wrapper available to restore the old behavior
-  as desired. But since that usage renders the plans un-composable, it is
-  discouraged.
-* The 'time' argument of the SPEC-like plans is a keyword-only argument.
-* The following special-case SPEC-like scans have been removed:
-    * hscan
-    * kscan
-    * lscan
-    * tscan
-    * dtscan 
-    * hklscan 
-    * hklmesh
-  They can be defined in configuration files as desired, and in that location
-  they will be easier to customize.

--- a/fuzz/fuzz.py
+++ b/fuzz/fuzz.py
@@ -282,7 +282,7 @@ def kickoff_and_collect(block=False, magic=False):
                 random.randint(1, 10)]     # step
 
     if block:
-        kwargs = {'block_group': unique_name()}
+        kwargs = {'group': unique_name()}
     return [Msg('kickoff', flyer, *args, **kwargs), Msg('collect', flyer)]
 
 


### PR DESCRIPTION
* `Msg('wait_for', futures)` -> `Msg('wait_for', None, futures)`. The second position in a Msg, `Msg.obj`, is always a Device or Signal. The current implementation was just a mistake, according to @tacaswell.
* Consistency: 'trigger' and 'set' messages call it a 'block_group'; 'wait' messages called it a 'group'. Now they all call it a 'group'.