### PR TITLE
FIX: Cache kwargs for subscribe.

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -203,7 +203,7 @@ class RunEngine:
         self._config_values_cache = dict()  # " obj.read_configuration() values
         self._config_ts_cache = dict()  # " obj.read_configuration() timestamps
         self._descriptors = dict()  # cache of {(name, objs_frozen_set): uid}
-        self._monitor_params = dict()  # cache of {obj: (cb, args, kwargs)}
+        self._monitor_params = dict()  # cache of {obj: (cb, kwargs)}
         self._sequence_counters = dict()  # a seq_num counter per Descriptor
         self._teed_sequence_counters = dict()  # for if we redo datapoints
         self._pause_requests = dict()  # holding {<name>: callable}
@@ -435,7 +435,7 @@ class RunEngine:
         # stop accepting new tasks in the event loop (existing tasks will
         # still be processed)
         loop.stop()
-        for obj, (cb, args, kwargs) in list(self._monitor_params.items()):
+        for obj, (cb, kwargs) in list(self._monitor_params.items()):
             obj.clear_sub(cb)
         # During pause, all motors should be stopped.
         for obj in self._movable_objs_touched:
@@ -598,8 +598,8 @@ class RunEngine:
 
         self._interrupted = False
         self._rewind()
-        for obj, (cb, args, kwargs) in self._monitor_params.items():
-            obj.subscribe(cb, *args, **kwargs)
+        for obj, (cb, kwargs) in self._monitor_params.items():
+            obj.subscribe(cb, **kwargs)
         self._resume_event_loop()
         return self._run_start_uids
 
@@ -640,13 +640,14 @@ class RunEngine:
             self._exception = FailedPause()
         else:
             print("Suspending....To get prompt hit Ctrl-C to pause the scan")
-            objs_monitored = list(self._monitor_params)
-            for obj, (cb, args, kwargs) in list(self._monitor_params.items()):
+            # Stash a copy in a local var to re-instating the monitors.
+            monitor_params = self._monitor_params.copy()
+            for obj, (cb, kwargs) in list(self._monitor_params.items()):
                 obj.clear_sub(cb)
                 del self._monitor_params[obj]
             wait_msg = Msg('wait_for', [fut, ])
-            for obj in objs_monitored:
-                msg = Msg('monitor', obj)
+            for obj, (cb, kwargs) in monitor_params.items():
+                msg = Msg('monitor', obj, **kwargs)
                 self._msg_cache.appendleft(msg)
             self._msg_cache.appendleft(wait_msg)
             self._rewind()
@@ -776,8 +777,7 @@ class RunEngine:
                     logger.error("Failed to unstage %r", obj)
                 self._staged.remove(obj)
             # Clear any uncleared monitoring callbacks.
-            monitor_params = list(self._monitor_params.items())
-            for obj, (cb, args, kwargs) in monitor_params:
+            for obj, (cb, kwargs) in list(self._monitor_params.items()):
                 obj.clear_sub(cb)
                 del self._monitor_params[obj]
             sys.stdout.flush()
@@ -1004,10 +1004,15 @@ class RunEngine:
 
         Expected message object is:
 
-            Msg('monitor', obj)
-            Msg('monitor', obj, name='event-stream-name')
+            Msg('monitor', obj, **kwargs)
+            Msg('monitor', obj, name='event-stream-name', **kwargs)
+
+        where kwargs are passed through to ``obj.subscribe()``
         """
         obj = msg.obj
+        if msg.args:
+            raise ValueError("The 'monitor' Msg does not accept positional "
+                             "arguments.")
         name = msg.kwargs.get('name')
         if not self._run_is_open:
             raise IllegalMessageSequence("A 'monitor' message was sent but no "
@@ -1043,8 +1048,8 @@ class RunEngine:
             # implemented as flyers.
             self.dispatcher.process(DocumentNames.event, doc)
 
-        self._monitor_params[obj] = emit_event, msg.args, msg.kwargs
-        obj.subscribe(emit_event, *msg.args, **msg.kwargs)
+        self._monitor_params[obj] = emit_event, msg.kwargs
+        obj.subscribe(emit_event, **msg.kwargs)
         yield from self.emit(DocumentNames.descriptor, desc_doc)
 
     @asyncio.coroutine
@@ -1057,7 +1062,7 @@ class RunEngine:
             Msg('unmonitor', obj)
         """
         obj = msg.obj
-        cb, args, kwargs = self._monitor_params[obj]
+        cb, kwargs = self._monitor_params[obj]
         obj.clear_sub(cb)
         del self._monitor_params[obj]
 


### PR DESCRIPTION
Current situation:

1. A 'monitor' Msg is processed -> `obj.subscribe(cb, *args, **kwargs)`
2. Plan is paused; monitoring is correctly suspended -> `obj.clear_sub(cb)`
3. Plan is resumed; monitoring is reapplied but *the original args and kwargs are dropped* -> `obj.subscribe(cb)`

This PR stashed those and args and kwargs and correctly reapplies them upon resuming.
