### PR TITLE
ENH: Add a stub plan for every command in the command_registry.

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -612,7 +612,7 @@ def open_run(md):
     msg : Msg
         Msg('open_run', **md)
     """
-    yield Msg('open_run', md)
+    yield Msg('open_run', **md)
 
 
 def close_run():

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -393,7 +393,10 @@ def trigger(obj, *, group=None, wait=False):
 
 def sleep(time):
     """
-    A plan that yields a single 'sleep' message.
+    Tell the RunEngine to sleep, while asynchronously doing other processing.
+
+    This is not the same as ``import time; time.sleep()`` because it allows
+    other actions, like interruptions, to be processed during the sleep.
 
     Parameters
     ----------
@@ -410,7 +413,7 @@ def sleep(time):
 
 def wait(group=None):
     """
-    A plan that waits for a group of statuses to report being finished.
+    Wait for all statuses in a group to report being finished.
 
     Parameters
     ----------
@@ -625,8 +628,8 @@ def close_run():
 
 
 def wait_for(futures, **kwargs):
-    """"
-    Low-level: wait for a list of asyncio.Future objects to set (complete).
+    """
+    Low-level: wait for a list of ``asyncio.Future`` objects to set (complete).
 
     Parameters
     ----------

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -180,7 +180,7 @@ def msg_mutator(plan, msg_proc):
     return plan.close()
 
 
-def bschain(*args):
+def pchain(*args):
     '''Like `itertools.chain` but using `yield from`
 
     This ensures than `.send` works as expected and the underlying
@@ -931,7 +931,7 @@ def relative_set(plan, devices=None):
         eligible = (devices is None) or (msg.obj in devices)
         seen = msg.obj in initial_positions
         if (msg.command == 'set') and eligible and not seen:
-                return bschain(read_and_stash_a_motor(msg.obj),
+                return pchain(read_and_stash_a_motor(msg.obj),
                                single_gen(msg)), None
         else:
             return None, None
@@ -967,7 +967,7 @@ def reset_positions(plan, devices=None):
         eligible = devices is None or msg.obj in devices
         seen = msg.obj in initial_positions
         if (msg.command == 'set') and eligible and not seen:
-            return bschain(read_and_stash_a_motor(msg.obj),
+            return pchain(read_and_stash_a_motor(msg.obj),
                            single_gen(msg)), None
         else:
             return None, None
@@ -1011,7 +1011,7 @@ def configure_count_time(plan, time):
                 # marked as belonging to a different event stream (or no
                 # event stream.
                 original_times[obj] = obj.count_time.get()
-                return bschain(single_gen(Msg('set', obj.count_time, time)),
+                return pchain(single_gen(Msg('set', obj.count_time, time)),
                                single_gen(msg)), None
         return None, None
 

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -269,7 +269,7 @@ def read(obj):
 
 def monitor(obj, *args, name=None, **kwargs):
     """
-    Asynchornously monitor for new values and emit Event documents.
+    Asynchronously monitor for new values and emit Event documents.
 
     Parameters
     ----------
@@ -291,7 +291,7 @@ def monitor(obj, *args, name=None, **kwargs):
 
 def unmonitor(obj):
     """
-    Stop mointoring.
+    Stop monitoring.
 
     Parameters
     ----------

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1111,6 +1111,7 @@ def trigger_and_read(devices, name='primary'):
     """
     devices = separate_devices(devices)  # remove redundant entries
     grp = _short_uid('trigger')
+    plan_stack = deque()
     for obj in devices:
         if hasattr(obj, 'trigger'):
             plan_stack.append(single_gen(Msg('trigger', obj, group=grp)))

--- a/bluesky/tests/test_generators.py
+++ b/bluesky/tests/test_generators.py
@@ -5,7 +5,7 @@ from itertools import zip_longest
 
 from bluesky import Msg
 
-from bluesky.plans import (msg_mutator, plan_mutator, bschain,
+from bluesky.plans import (msg_mutator, plan_mutator, pchain,
                            single_gen as single_message_gen, finalize)
 
 
@@ -132,7 +132,7 @@ def test_simple_mutator():
         if _mut_active:
             _mut_active = False
 
-            return (bschain(echo_plan(num=pre_count, command=pre_cmd),
+            return (pchain(echo_plan(num=pre_count, command=pre_cmd),
                             single_message_gen(msg)),
                     echo_plan(num=post_count, command=post_cmd))
         return None, None
@@ -221,7 +221,7 @@ def test_plan_mutator_exception_propogation():
         if _mut_active:
             _mut_active = False
 
-            return (bschain(echo_plan(num=2, command=cmd2),
+            return (pchain(echo_plan(num=2, command=cmd2),
                             single_message_gen(msg)),
                     bad_tail())
         return None, None

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -109,21 +109,22 @@ Stub Plans (ingredients for remixing)
     one_1d_step
     one_nd_step
 
-Concatenating Plans
--------------------
+Combining Plans
+---------------
 
 Plans are iterables (roughly speaking, lists) and the Python language has nice
 facilities for handling them. For example to join to plans together, use
 
 .. code-block:: python
 
-    from bluesky.plans import bschain
+    from bluesky.examples import motor, det
+    from bluesky.plans import scan, sleep
+    from itertools import chain
 
-    plan1 = scan([det1, det2], motor, 1, 5, 3)  # 1 to 5 in 3 steps
-    plan2 = scan([det1], motor, 5, 10, 2)  # 5 to 10 in 2 steps
+    master_plan = chain(scan([det], motor, 1, 5, 3),
+                        sleep(),
+                        scan([det], motor, 5, 10, 2)
 
-    # Do this.
-    master_plan = bschain(plan1, plan2)
     RE(master_plan)
 
 This has advantages over executing them in sequence like so:

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -35,6 +35,8 @@ The names below are links. Click for details, and see below for examples.
     relative_log_scan
     inner_product_scan
     outer_product_scan
+    relative_inner_product_scan
+    relative_outer_product_scan
     scan_nd
     adaptive_scan
     relative_adaptive_scan
@@ -316,8 +318,8 @@ The ``set`` method is a convenient way to update multiple parameters at once.
     LogScan
     RelativeLogScan
     InnerProductScan
-    RelativeInnerProductScan
     OuterProductScan
+    RelativeInnerProductScan
     RelativeOuterProductScan
     ScanND
     AdaptiveScan

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -286,7 +286,7 @@ uses.
 .. ipython:: python
 
     from bluesky.plans import Scan
-    from bluesky.examples import motor, det3
+    from bluesky.examples import motor, det, det3
     plan = Scan([det], motor, 1, 5, 10)
     RE(plan)
     RE(plan)

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -118,12 +118,11 @@ facilities for handling them. For example to join to plans together, use
 .. code-block:: python
 
     from bluesky.examples import motor, det
-    from bluesky.plans import scan, sleep
-    from itertools import chain
+    from bluesky.plans import scan, sleep, pchain
 
-    master_plan = chain(scan([det], motor, 1, 5, 3),
-                        sleep(),
-                        scan([det], motor, 5, 10, 2)
+    master_plan = pchain(scan([det], motor, 1, 5, 3),
+                         sleep(),
+                         scan([det], motor, 5, 10, 2)
 
     RE(master_plan)
 

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -3,93 +3,130 @@
 Plans
 =====
 
-In bluesky, a *plan* expresses experimental logic as an iterable (e.g., a list)
-of granular instructions.
+An experimental procedure is represented as a sequence of granular
+instructions. In bluesky, each instruction is called a *message* and a sequence
+of instructions is called a *plan*.
 
-For example, this is a plan:
+The plans are organized like a burger menu. A variety of fully-assembled plans
+are provided --- just as you might order the All-American Burger or The Hog
+Wild Burger. But you can also build your own plan by mixing the ingredients
+to make something original.
 
-.. code-block:: python
+(For developers: what we are calling a "plan" is not actually a special data
+structure. It is typically a generator, but it can be any iterable or iterator
+--- a list, for example. The messages in a plan are ``Msg`` objects, a
+namedtuple.)
 
-    plan = [Msg('set', motor1, 5), Msg('read', detector1)]
+Standard Plans (ready to use)
+-----------------------------
 
-Bluesky provides facilities for conveniently generating these plans for many
-common use cases, such as:
+The names below are links. Click for details, and see below for examples.
 
-* one-dimensional trajectories (e.g., linear-, log-, or unevenly-spaced)
-* trajectories that move multiple motors together
-* N-dimensional trajectories, such as a mesh
-* adaptive sampling, adjusting step size in response to readings
+.. autosummary::
+   :nosignatures:
+   :toctree:
 
-These plans are generated Mad-Libs style: "fill in the blacks" with motor(s)
-and detector(s), and bluesky generates the set of intructions -- the plan.
+    count
+    scan
+    relative_scan
+    list_scan
+    relative_list_scan
+    log_scan
+    relative_log_scan
+    inner_product_scan
+    outer_product_scan
+    scan_nd
+    adaptive_scan
+    relative_adaptive_scan
+    tweak
 
-That plan can be inspected, modified, customized. Finally, it is passed to
-the RunEngine, which supervises its executation and captures any data it
-generates.
+Basic Usage
+-----------
 
-Usage Example
--------------
+Before we begin, we'll make a RunEngine to execute our plans.
 
-.. ipython:: python
-    :suppress:
-
-    from bluesky.tests.utils import setup_test_run_engine
-    RE = setup_test_run_engine()
-    from bluesky.examples import motor, det1, det2, det3
-
-Make an instance of a plan, passing in parameters.
-
-.. ipython:: python
-
-    from bluesky.plans import AbsScanPlan
-    plan = AbsScanPlan([det1, det2], motor, 1, 5, 10)
-
-Running the plan is a separate step. The same plan can be run multiple times
-without respecifying its parameters.
-
-.. ipython:: python
-
-    RE(plan)
-    RE(plan)
-
-Any of the plan's parameters can be updated individually.
+**This RunEngine is not set up to save any data.** You may already have a
+RunEngine instance, ``RE``, defined in an IPython profile. If ``RE`` is already
+defined, do not redefine it. Just skip to the next step.
 
 .. ipython:: python
 
-    plan.num = 4  # change number of data points from 10 to 4
-    RE(plan)
-    plan.detectors.append(det3)  # add another detector
-    RE(plan)
+    from bluesky import RunEngine
+    RE = RunEngine({})
 
-The ``set`` method is a convenient way to update multiple parameters at once.
+
+Execute the a ``count`` plan, which reads one or more detectors.
 
 .. ipython:: python
 
-    plan.set(start=20, stop=25)
+    from bluesky.plans import count
+    from bluesky.examples import det  # a simulated detector
+    RE(count([det]))
+
+It worked, but the data was not displayed. This time, send the output
+``LiveTable``.
+
+.. ipython:: python
+
+    from bluesky.callbacks import LiveTable
+    RE(count([det]), LiveTable([det]))
+
+Stub Plans (ingredients for remixing)
+-------------------------------------
+
+.. autosummary::
+   :nosignatures:
+   :toctree:
+
+    trigger_and_read
+    abs_set
+    rel_set
+    wait
+    sleep
+    checkpoint
+    clear_checkpoint
+    pause
+    deferred_pause
+    open_run
+    close_run
+    create
+    save
+    trigger
+    read
+    monitor
+    unmonitor
+    kickoff
+    collect
+    configure
+    stage
+    unstage
+    subscribe
+    unsubscribe
+    wait_for
+    null
+    one_1d_step
+    one_nd_step
 
 Concatenating Plans
 -------------------
 
 Plans are iterables (roughly speaking, lists) and the Python language has nice
-facilities found handling them. For example to join to plans together, use
-``chain``.
+facilities for handling them. For example to join to plans together, use
 
-.. ipython:: python
+.. code-block:: python
 
-    from itertools import chain
+    from bluesky.plans import bschain
 
-    plan1 = AbsScanPlan([det1, det2], motor, 1, 5, 3)  # 1 to 5 in 3 steps
-    plan2 = AbsScanPlan([det1], motor, 5, 10, 2)  # 5 to 10 in 2 steps
+    plan1 = scan([det1, det2], motor, 1, 5, 3)  # 1 to 5 in 3 steps
+    plan2 = scan([det1], motor, 5, 10, 2)  # 5 to 10 in 2 steps
 
     # Do this.
-    master_plan = chain(plan1, plan2)
+    master_plan = bschain(plan1, plan2)
     RE(master_plan)
 
-Notice that the RunEngine retured a list of two unique IDs, one for each
-dataset generated by the plans. This has advantages over executing them in
-sequence like so:
+This has advantages over executing them in sequence like so:
 
-.. ipython:: python
+.. code-block:: python
 
     # Don't do this.
     RE(plan1); RE(plan2)
@@ -104,10 +141,11 @@ There is another way to combine plans to accomodate this.
 
 .. code-block:: python
 
-    plan1 = AbsScanPlan([det1, det2], motor, 1, 5, 10)
-    plan2 = DeltaScanPlan([det1], motor, 5, 10, 10)
 
     def make_master_plan():
+        plan1 = scan([det1, det2], motor, 1, 5, 10)
+        plan2 = relative_scan([det1], motor, 5, 10, 10)
+
         yield from plan1
         print('plan1 is finished -- moving onto plan2')
         yield from plan2
@@ -126,6 +164,9 @@ Here are a couple more useful recipes:
     "Run plan1, wait for user confirmation, then run plan2."
 
     def make_master_plan():
+        plan1 = scan([det1, det2], motor, 1, 5, 10)
+        plan2 = relative_scan([det1], motor, 5, 10, 10)
+
         yield from plan1
         # pause and consult the user
         if input('continue? (y/n)') != 'y':
@@ -138,43 +179,147 @@ Here are a couple more useful recipes:
 
     def make_master_plan():
         for num in range(5, 10):
-            plan1.num = num  # update the number of steps in the plan
+            # Change the number of steps in the plan in each loop
+            plan1 = scan([det1, det2], motor, 1, 5, num)
             yield from plan1
 
-Count
------
+Plan Context Managers
+---------------------
 
-.. autofunction:: Count
+These context managers provide a sunninct, readable syntax for inserting plans
+before and after other plans.
 
-1D Plans
---------
+.. autosummary::
+   :nosignatures:
+   :toctree:
 
-.. autofunction:: AbsScanPlan
-.. autofunction:: LogAbsScanPlan
-.. autofunction:: AbsListScanPlan
-.. autofunction:: DeltaScanPlan
-.. autofunction:: LogDeltaScanPlan
-.. autofunction:: DeltaListScanPlan
+    baseline_context
+    monitor_context
+    subs_context
+    run_context
+    event_context
+    stage_context
 
-N-dimensional Plans
--------------------
+For example, the ``baseline_context`` reads a list of detectors at the
+beginning and end of an experiment.
 
-.. autofunction:: InnerProductAbsScanPlan
-.. autofunction:: OuterProductAbsScanPlan
-.. autofunction:: InnerProductDeltaScanPlan
-.. autofunction:: OuterProductDeltaScanPlan
-.. autofunction:: PlanND
+.. code-block:: python
 
-.. _builtin-adaptive-scans:
+    from bluesky.plans import baseline_context, count
+    from bluesky.examples import det
 
-Adaptive Plans
+    plans = []
+    with baseline_context(plans, [det]):
+        plans.append(count([det]))
+
+Use with the ``planify`` decorator to join the list of plans into one plan.
+
+.. code-block:: python
+
+    from bluesky.plans import planify
+
+    @planify
+    def count_with_baseline_readings():
+        plans = []
+        with baseline_context(plans, [det]):
+            plans.append(count([det]))
+        return plans
+
+Plan Preprocessors
+------------------
+
+These "preprocessors" take in a plan and modify its contents on the fly.
+
+.. autosummary::
+   :nosignatures:
+   :toctree:
+
+    relative_set
+    reset_positions
+    lazily_stage
+    fly_during
+    finalize
+
+For example, ``relative_set`` rewrites all positions to be relative to the
+initial position.
+
+.. code-block:: python
+
+    def relative_scan(detectors, motor, start, stop, num):
+        absolute = scan(detectors, motor, start, stop, num)
+        relative = relative_set(absolute, [motor])
+        yield from relative    
+
+Or, equivalently, using the ``planify`` decorator:
+
+.. code-block:: python
+
+    @planify
+    def relative_scan(detectors, motor, start, stop, num):
+        absolute = scan(detectors, motor, start, stop, num)
+        relative = relative_set(absolute, [motor])
+        return [relative]
+
+Plan Utilities
 --------------
 
-.. autofunction:: AdaptiveAbsScanPlan
-.. autofunction:: AdaptiveDeltaScanPlan
-.. autofunction:: Center
+.. autosummary::
 
-Interactive Plans
------------------
+    planify
+    msg_mutator
+    plan_mutator
+    bschain
+    single_gen
+    broadcast_msg
+    repeater
+    caching_repeater
 
-.. autofunction:: Tweak
+Object-Oriented Standard Plans
+------------------------------
+
+These provide a different way of using the standard plans. The plan becomes
+a reusable object, whose parameters can be adjusted interactively between
+uses.
+
+.. ipython:: python
+
+    from bluesky.plans import Scan
+    from bluesky.examples import motor, det3
+    plan = Scan([det], motor, 1, 5, 10)
+    RE(plan)
+    RE(plan)
+
+Any of the plan's parameters can be updated individually.
+
+.. ipython:: python
+
+    plan.num = 4  # change number of data points from 10 to 4
+    RE(plan)
+    plan.detectors.append(det3)  # add another detector
+    RE(plan)
+
+The ``set`` method is a convenient way to update multiple parameters at once.
+
+.. ipython:: python
+
+    plan.set(start=20, stop=25)
+
+.. autosummary::
+   :nosignatures:
+   :toctree:
+
+    Count
+    Scan
+    RelativeScan
+    ListScan
+    RelativeListScan
+    LogScan
+    RelativeLogScan
+    InnerProductScan
+    RelativeInnerProductScan
+    OuterProductScan
+    RelativeOuterProductScan
+    ScanND
+    AdaptiveScan
+    RelativeAdaptiveScan
+    Tweak


### PR DESCRIPTION
This enables usage like:

```python
@planify
def plan():
    return [ct(), sleep(5), ct(), rel_set(motor, 2), ct()]
```

It's just an experiment.

One big benefit is that this provides de-facto API documentation for every kind of Msg, which has till recently been completely absent or buried in the RunEngine private method docstrings.