### PR TITLE
ENH: Support optional 'pause' and 'resume' methods on Devices.

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -927,6 +927,10 @@ class RunEngine:
                                          "a 'checkpoint' message after the "
                                          "'close_run' message.")
         self.log.debug("Stopping run %s", self._run_start_uid)
+        # Clear any uncleared monitoring callbacks.
+        for obj, (cb, kwargs) in list(self._monitor_params.items()):
+            obj.clear_sub(cb)
+            del self._monitor_params[obj]
         doc = dict(run_start=self._run_start_uid,
                    time=ttime.time(), uid=new_uid(),
                    exit_status=self._exit_status,


### PR DESCRIPTION
Closes #415

I'm not doing anything with this, but now we have the hook when we need it / want to play with it. I don't think the Devices need to distinguish between 'pause' and 'suspend', so both actions call `device.pause()`.