### PR TITLE
FIX: Stage Plan.flyers.

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1948,10 +1948,11 @@ class Plan(Struct):
             setattr(self, key, val)
         try:
             plan_stack = deque()
-            with subs_context(plan_stack, subs):
-                plan = self._gen()
-                plan_stack.append(fly_during(plan, flyers))
-                plan_stack.append(single_gen(Msg('checkpoint')))
+            with stage_context(plan_stack, flyers):
+                with subs_context(plan_stack, subs):
+                    plan = self._gen()
+                    plan_stack.append(fly_during(plan, flyers))
+                    plan_stack.append(single_gen(Msg('checkpoint')))
         finally:
             for key, val in current_settings.items():
                 setattr(self, key, val)

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1477,7 +1477,7 @@ class RunEngine:
         _, obj, args, kwargs = msg
         # If an object has no 'stage' method, assume there is nothing to do.
         if not hasattr(obj, 'stage'):
-            return
+            return []
         result = obj.stage()
         self._staged.add(obj)  # add first in case of failure below
         return result
@@ -1493,7 +1493,7 @@ class RunEngine:
         _, obj, args, kwargs = msg
         # If an object has no 'unstage' method, assume there is nothing to do.
         if not hasattr(obj, 'unstage'):
-            return
+            return []
         result = obj.unstage()
         # use `discard()` to ignore objects that are not in the staged set.
         self._staged.discard(obj)


### PR DESCRIPTION
Bug: In this scenario, the `flyer` is never staged.

```python
c = Count[])
c.flyers = [flyer]
```

Perhaps no one has encountered this bug yet because no one had written a flyer that *needed* to be staged until today. As a reminder, this will not affect any existing flyers that don't implement stage/unstage. The RunEngine checks to see if `msg.obj` has a stage/unstage method before attempting to call it.

The second commit may be fixing a nonexistent problem, but it feels like the right thing to do. Preventative medicine.