### PR TITLE
Add a new 'input' Msg that takes raw_input while running event loop in background

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1881,6 +1881,7 @@ def relative_inner_product_scan(detectors, num, *args, per_step=None, md=None):
     return [plan]
 
 
+@planify
 def tweak(detector, target_field, motor, step, *, md=None):
     """
     Move and motor and read a detector with an interactive prompt.
@@ -1924,10 +1925,11 @@ def tweak(detector, target_field, motor, step, *, md=None):
                 pos = ret_mot[key]['value']
             yield Msg('trigger', d, group='A')
             yield Msg('wait', None, 'A')
-            reading = Msg('read', d)[target_field]['value']
+            reading = yield Msg('read', d)
+            val = reading[target_field]['value']
             yield Msg('save')
-            prompt = prompt_str.format(motor.name, pos, reading, step)
-            new_step = input(prompt)
+            prompt = prompt_str.format(motor.name, pos, val, step)
+            new_step = yield Msg('input', prompt=prompt)
             if new_step:
                 try:
                     step = float(new_step)

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -498,6 +498,23 @@ def deferred_pause():
     yield Msg('pause', defer=True)
 
 
+def input(prompt=''):
+    """
+    Prompt the user for text input.
+
+    Parameters
+    ----------
+    prompt : str
+        prompt string, e.g., 'enter user name' or 'enter next position'
+
+    Yields
+    ------
+    msg : Msg
+        Msg('input', prompt=prompt)
+    """
+    return (yield from (m in [Msg('input', prompt=prompt)]))
+
+
 def kickoff(obj, *, name=None, group=None, **kwargs):
     """
     Kickoff a fly-scanning device.


### PR DESCRIPTION
Testing raw_input in py.test is a can of worms I don't want to open this week, but this code works:

```python
from bluesky import RunEngine, Msg
from bluesky.examples import motor, det
from bluesky.plans import tweak
RE = RunEngine({})
def plan():
    p = yield Msg('input', prompt='where now?')
    print('moving to', p)
    yield Msg('set', motor, float(p))
RE(plan())
RE(tweak(det, 'det', motor, 1))
```