### PR TITLE
Change Ctrl+C behavior

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -428,9 +428,9 @@ def sleep(time):
     Yields
     ------
     msg : Msg
-        Msg('sleep', time)
+        Msg('sleep', None, time)
     """
-    yield Msg('sleep', time)
+    yield Msg('sleep', None, time)
 
 
 def wait(group=None):

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -762,6 +762,9 @@ class RunEngine:
                     # -- overriding the RunEngine -- and then raises instead
                     # of (properly) calling the RunEngine's handler.
                     # See https://github.com/NSLS-II/bluesky/pull/242
+                    print("An unknown external library has improperly raised "
+                          "KeyboardInterrupt. Intercepting and triggering "
+                          "a hard pause instead.")
                     loop.call_soon(self.request_pause, False, 'SIGINT')
                     print(PAUSE_MSG)
         except (StopIteration, RequestStop):

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -20,7 +20,6 @@ import numpy as np
 
 from .utils import (CallbackRegistry, SignalHandler, normalize_subs_input)
 
-logger = logging.getLogger(__name__)
 loop = asyncio.get_event_loop()
 
 
@@ -771,17 +770,17 @@ class RunEngine:
         except (FailedPause, RequestAbort, asyncio.CancelledError):
             self._exit_status = 'abort'
             yield from asyncio.sleep(0.001)  # TODO Do we need this?
-            logger.error("Run aborted")
-            logger.error("%s", self._exception)
+            self.log.error("Run aborted")
+            self.log.error("%s", self._exception)
             if isinstance(self._exception, PanicError):
-                logger.critical("RE panicked")
+                self.log.critical("RE panicked")
                 self._exit_status = 'fail'
                 raise self._exception
         except Exception as err:
             self._exit_status = 'fail'  # Exception raises during 'running'
             self._reason = str(err)
-            logger.error("Run aborted")
-            logger.error("%s", err)
+            self.log.error("Run aborted")
+            self.log.error("%s", err)
             raise err
         finally:
             # call stop() on every movable object we ever set() or kickoff()
@@ -792,13 +791,13 @@ class RunEngine:
                 try:
                     yield from self._collect(Msg('collect', obj))
                 except Exception:
-                    logger.error("Failed to collect %r", obj)
+                    self.log.error("Failed to collect %r", obj)
             # in case we were interrupted between 'stage' and 'unstage'
             for obj in list(self._staged):
                 try:
                     obj.unstage()
                 except Exception:
-                    logger.error("Failed to unstage %r", obj)
+                    self.log.error("Failed to unstage %r", obj)
                 self._staged.remove(obj)
             # Clear any uncleared monitoring callbacks.
             for obj, (cb, kwargs) in list(self._monitor_params.items()):
@@ -810,7 +809,7 @@ class RunEngine:
                 try:
                     yield from self._close_run(Msg('close_run'))
                 except Exception:
-                    logger.error("Failed to close run %r", self._run_start_uid)
+                    self.log.error("Failed to close run %r", self._run_start_uid)
                     # Exceptions from the callbacks should be re-raised.
                     # Close the loop first.
                     for task in asyncio.Task.all_tasks(loop):

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -564,7 +564,8 @@ class RunEngine:
             gen = (msg for msg in gen)
         self._genstack.append(gen)
         self._new_gen = True
-        with SignalHandler(signal.SIGINT) as self._sigint_handler:  # ^C
+        # Intercept ^C.
+        with SignalHandler(signal.SIGINT, self.log) as self._sigint_handler:
             self._task = loop.create_task(self._run())
             loop.run_forever()
             if self._task.done() and not self._task.cancelled():
@@ -633,9 +634,10 @@ class RunEngine:
     def _resume_event_loop(self):
         # may be called by 'resume' or 'abort'
         self.state = 'running'
-        with SignalHandler(signal.SIGINT) as self._sigint_handler:  # ^C
         self._last_sigint_time = None
         self._num_sigints_processed = 0
+        # Intercept ^C
+        with SignalHandler(signal.SIGINT, self.log) as self._sigint_handler:
             if self._task.done():
                 return
             loop.run_forever()

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -312,6 +312,7 @@ def test_pause_resume():
     assert RE.state == 'idle'
     start = ttime.time()
     loop.call_later(1, sim_kill)
+    loop.call_later(1.1, sim_kill)
     loop.call_later(2, done)
 
     RE(scan)
@@ -341,6 +342,7 @@ def test_pause_abort():
     assert RE.state == 'idle'
     start = ttime.time()
     loop.call_later(1, sim_kill)
+    loop.call_later(1.1, sim_kill)
     loop.call_later(2, done)
 
     RE(scan)

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -16,10 +16,11 @@ logger = logging.getLogger(__name__)
 
 
 class SignalHandler:
-    def __init__(self, sig):
+    def __init__(self, sig, log=None):
         self.sig = sig
         self.interrupted = False
         self.count = 0
+        self.log = log
 
     def __enter__(self):
         self.interrupted = False
@@ -31,6 +32,9 @@ class SignalHandler:
         def handler(signum, frame):
             self.interrupted = True
             self.count += 1
+            if self.log is not None:
+                self.log.debug('SignalHandler caught SIGINT; count is %r',
+                               self.count)
 
         signal.signal(self.sig, handler)
         return self


### PR DESCRIPTION
See commit messages for details. There are some small unrelated cleanup commits mixed in here.

Demo with DEBUG-level logging turned on:

```python
# demo.py
import logging
from bluesky import RunEngine, Msg
from bluesky.plans import sleep

logger = logging.basicConfig(level=logging.DEBUG)

RE = RunEngine({})
RE.verbose = True
def plan():
    while True:
        yield from sleep(1)
```

Look for the `^C`s in the output below:
```python
In [1]: RE(plan())
INFO:bluesky.run_engine_id4355736240:Change state on <bluesky.run_engine.RunEngine object at 0x1039f42b0> from 'idle' -> 'running'
DEBUG:bluesky.run_engine_id4355736240:Processing sleep: (None), (1,), {}
DEBUG:bluesky.run_engine_id4355736240:Response: None
DEBUG:bluesky.run_engine_id4355736240:Processing sleep: (None), (1,), {}
^C
DEBUG:bluesky.run_engine_id4355736240:SignalHandler caught SIGINT; count is 1
DEBUG:bluesky.run_engine_id4355736240:RunEngine caught a new SIGINT
A 'deferred pause' has been requested. The RunEngine will pause at the next checkpoint. To pause immediately, hit Ctrl+C again in the next 10 seconds.
Deferred pause acknowledged. Continuing to checkpoint.
DEBUG:bluesky.run_engine_id4355736240:Response: None
DEBUG:bluesky.run_engine_id4355736240:Processing sleep: (None), (1,), {}
(...10 seconds pass...)
DEBUG:bluesky.run_engine_id4355736240:Response: None
DEBUG:bluesky.run_engine_id4355736240:Processing sleep: (None), (1,), {}
DEBUG:bluesky.run_engine_id4355736240:It has been 10 seconds since the last SIGINT. Resetting SIGINT handler.
DEBUG:bluesky.run_engine_id4355736240:Response: None
DEBUG:bluesky.run_engine_id4355736240:Processing sleep: (None), (1,), {}
DEBUG:bluesky.run_engine_id4355736240:Response: None
DEBUG:bluesky.run_engine_id4355736240:Processing sleep: (None), (1,), {}
^C
DEBUG:bluesky.run_engine_id4355736240:SignalHandler caught SIGINT; count is 1
DEBUG:bluesky.run_engine_id4355736240:RunEngine caught a new SIGINT
DEBUG:bluesky.run_engine_id4355736240:Response: None
DEBUG:bluesky.run_engine_id4355736240:Processing sleep: (None), (1,), {}
DEBUG:bluesky.run_engine_id4355736240:Response: None
DEBUG:bluesky.run_engine_id4355736240:Processing sleep: (None), (1,), {}
DEBUG:bluesky.run_engine_id4355736240:Response: None
DEBUG:bluesky.run_engine_id4355736240:Processing sleep: (None), (1,), {}
(This time, 10 seconds have not yet passed.)
^C
DEBUG:bluesky.run_engine_id4355736240:SignalHandler caught SIGINT; count is 2
DEBUG:bluesky.run_engine_id4355736240:RunEngine caught a new SIGINT
DEBUG:bluesky.run_engine_id4355736240:RunEngine detected a second SIGINT -- waiting 0.5 seconds for a third.
DEBUG:bluesky.run_engine_id4355736240:RunEngine detected two SIGINTs. A hard pause will be requested.

Your RunEngine is entering a paused state. These are your options for changing
the state of the RunEngine:

resume()  --> will resume the scan
 abort()  --> will kill the scan with an 'aborted' state to indicate
              the scan was interrupted
  stop()  --> will kill the scan with a 'finished' state to indicate
              the scan stopped normally

Pro Tip: Next time, if you want to abort, tap Ctrl+C three times quickly.

Pausing...
INFO:bluesky.run_engine_id4355736240:Change state on <bluesky.run_engine.RunEngine object at 0x1039f42b0> from 'running' -> 'paused'
Out[1]: []

In [2]: RE.resume()
INFO:bluesky.run_engine_id4355736240:Change state on <bluesky.run_engine.RunEngine object at 0x1039f42b0> from 'paused' -> 'running'
DEBUG:bluesky.run_engine_id4355736240:Response: None
DEBUG:bluesky.run_engine_id4355736240:Processing sleep: (None), (1,), {}
^C
DEBUG:bluesky.run_engine_id4355736240:SignalHandler caught SIGINT; count is 1
DEBUG:bluesky.run_engine_id4355736240:RunEngine caught a new SIGINT
^C
DEBUG:bluesky.run_engine_id4355736240:SignalHandler caught SIGINT; count is 2
DEBUG:bluesky.run_engine_id4355736240:RunEngine caught a new SIGINT
DEBUG:bluesky.run_engine_id4355736240:RunEngine detected a second SIGINT -- waiting 0.5 seconds for a third.
^C
DEBUG:bluesky.run_engine_id4355736240:SignalHandler caught SIGINT; count is 3
DEBUG:bluesky.run_engine_id4355736240:RunEngine detected a third SIGINT -- aborting.
Aborting....
ERROR:bluesky.run_engine_id4355736240:Run aborted
ERROR:bluesky.run_engine_id4355736240:
INFO:bluesky.run_engine_id4355736240:Change state on <bluesky.run_engine.RunEngine object at 0x1039f42b0> from 'running' -> 'idle'
Out[2]: []
```