### PR TITLE
FIX: stage_context neglected to separate devices

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1011,7 +1011,7 @@ def stage_context(plan_stack, devices):
         list of devices to stage immediately on entrance and unstage on exit
     """
     # Resolve unique devices, avoiding redundant staging.
-    devices = [device.root for device in devices]
+    devices = separate_devices([device.root for device in devices])
 
     def stage():
         # stage devices explicitly passed to 'devices' argument


### PR DESCRIPTION
First bug found in v0.5.0. Fix is tested at XPD (and presenty source-installed there).

Example of failing case:

```python
inner_product_scan([det], num, device.subdevice1, start1, stop1, device.subdevice2, start2, stop2)
```