### PR TITLE
API/FIX: clear msg cache on un-cacheable msg

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2492,7 +2492,6 @@ class Plan(Struct):
                 with subs_context(plan_stack, subs):
                     plan = self._gen()
                     plan_stack.append(fly_during(plan, flyers))
-                    plan_stack.append(single_gen(Msg('checkpoint')))
 
             for gen in plan_stack:
                 yield from gen

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -96,7 +96,8 @@ class LoggingPropertyMachine(PropertyMachine):
 class RunEngine:
 
     state = LoggingPropertyMachine(RunEngineStateMachine)
-    _UNCACHEABLE_COMMANDS = ['pause', 'subscribe', 'unsubscribe', 'stage']
+    _UNCACHEABLE_COMMANDS = ['pause', 'subscribe', 'unsubscribe', 'stage',
+                             'unstage', 'monitor', 'unmonitor']
 
     def __init__(self, md=None, *, loop=None, md_validator=None):
         """
@@ -209,6 +210,7 @@ class RunEngine:
         self._groups = defaultdict(set)  # sets of objs to wait for
         self._temp_callback_ids = set()  # ids from CallbackRegistry
         self._msg_cache = deque()  # history of processed msgs for rewinding
+        self._checkpoint_enabled = True  # make scans pauseable by default
         self._plan_stack = deque()  # stack of generators to work off of
         self._response_stack = deque([None])  # resps to send into the plans
         self._exit_status = 'success'  # optimistic default
@@ -1131,6 +1133,7 @@ class RunEngine:
         self._monitor_params[obj] = emit_event, msg.kwargs
         obj.subscribe(emit_event, **msg.kwargs)
         yield from self.emit(DocumentNames.descriptor, desc_doc)
+        yield from self._reset_checkpoint_state()
 
     @asyncio.coroutine
     def _unmonitor(self, msg):
@@ -1148,6 +1151,7 @@ class RunEngine:
         cb, kwargs = self._monitor_params[obj]
         obj.clear_sub(cb)
         del self._monitor_params[obj]
+        yield from self._reset_checkpoint_state()
 
     @asyncio.coroutine
     def _save(self, msg):
@@ -1529,14 +1533,8 @@ class RunEngine:
         if self._bundling:
             raise IllegalMessageSequence("Cannot 'checkpoint' after 'create' "
                                          "and before 'save'. Aborting!")
-        self._msg_cache = deque()
 
-        # Keep a safe separate copy of the sequence counters to use if we
-        # rewind and retake some data points.
-        for key, counter in list(self._sequence_counters.items()):
-            counter_copy1, counter_copy2 = tee(counter)
-            self._sequence_counters[key] = counter_copy1
-            self._teed_sequence_counters[key] = counter_copy2
+        yield from self._reset_checkpoint_state()
 
         if self._deferred_pause_requested:
             # We are at a checkpoint; we are done deferring the pause.
@@ -1545,6 +1543,20 @@ class RunEngine:
             # an abort.
             yield from asyncio.sleep(0.5)
             self.request_pause(defer=False)
+
+    @asyncio.coroutine
+    def _reset_checkpoint_state(self):
+        if self._msg_cache is None:
+            return
+
+        self._msg_cache = deque()
+
+        # Keep a safe separate copy of the sequence counters to use if we
+        # rewind and retake some data points.
+        for key, counter in list(self._sequence_counters.items()):
+            counter_copy1, counter_copy2 = tee(counter)
+            self._sequence_counters[key] = counter_copy1
+            self._teed_sequence_counters[key] = counter_copy2
 
     @asyncio.coroutine
     def _clear_checkpoint(self, msg):
@@ -1603,6 +1615,7 @@ class RunEngine:
             return []
         result = obj.stage()
         self._staged.add(obj)  # add first in case of failure below
+        yield from self._reset_checkpoint_state()
         return result
 
     @asyncio.coroutine
@@ -1620,6 +1633,7 @@ class RunEngine:
         result = obj.unstage()
         # use `discard()` to ignore objects that are not in the staged set.
         self._staged.discard(obj)
+        yield from self._reset_checkpoint_state()
         return result
 
     @asyncio.coroutine
@@ -1652,6 +1666,7 @@ class RunEngine:
         _, obj, args, kwargs = msg
         token = self.subscribe(*args, **kwargs)
         self._temp_callback_ids.add(token)
+        yield from self._reset_checkpoint_state()
         return token
 
     @asyncio.coroutine
@@ -1675,6 +1690,7 @@ class RunEngine:
             token, = args
         self.unsubscribe(token)
         self._temp_callback_ids.remove(token)
+        yield from self._reset_checkpoint_state()
 
     @asyncio.coroutine
     def _input(self, msg):

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -97,7 +97,8 @@ class RunEngine:
 
     state = LoggingPropertyMachine(RunEngineStateMachine)
     _UNCACHEABLE_COMMANDS = ['pause', 'subscribe', 'unsubscribe', 'stage',
-                             'unstage', 'monitor', 'unmonitor']
+                             'unstage', 'monitor', 'unmonitor', 'open_run',
+                             'close_run']
 
     def __init__(self, md=None, *, loop=None, md_validator=None):
         """
@@ -970,6 +971,7 @@ class RunEngine:
         doc = dict(uid=self._run_start_uid, time=ttime.time(), **md)
         yield from self.emit(DocumentNames.start, doc)
         self.log.debug("Emitted RunStart (uid=%r)", doc['uid'])
+        yield from self._reset_checkpoint_state()
 
     @asyncio.coroutine
     def _close_run(self, msg):
@@ -997,6 +999,7 @@ class RunEngine:
         self._clear_run_cache()
         yield from self.emit(DocumentNames.stop, doc)
         self.log.debug("Emitted RunStop (uid=%r)", doc['uid'])
+        yield from self._reset_checkpoint_state()
 
     @asyncio.coroutine
     def _create(self, msg):

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -509,15 +509,6 @@ def test_new_ev_desc():
     assert len(descs) == 1
 
 
-def test_bad_checkpoint():
-    bad_plan = [Msg('open_run'), Msg('checkpoint'), Msg('close_run'),
-                Msg('pause')]
-    RE(bad_plan)
-    # Resuming will cause us to write the same close_run twice.
-    with pytest.raises(IllegalMessageSequence):
-        RE.resume()
-
-
 def test_clear_checkpoint():
     bad_plan = [Msg('checkpoint'),
                 Msg('clear_checkpoint'),


### PR DESCRIPTION
This fixes a subtle bug where there are some messages which are
not (always) safe to replace due to being part of a context pair.

This needs testing / another set of eyes.