### PR TITLE
FIX: improve the name reported in mds

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2482,22 +2482,26 @@ class Plan(Struct):
         update_sub_lists(subs, apply_sub_factories(self.sub_factories, self))
         flyers = getattr(self, 'flyers', [])
 
-        current_settings = {}
-        for key, val in kwargs.items():
-            current_settings[key] = getattr(self, key)
-            setattr(self, key, val)
-        try:
-            plan_stack = deque()
-            with stage_context(plan_stack, flyers):
-                with subs_context(plan_stack, subs):
-                    plan = self._gen()
-                    plan_stack.append(fly_during(plan, flyers))
-
-            for gen in plan_stack:
-                yield from gen
-        finally:
-            for key, val in current_settings.items():
+        def cls_plan():
+            current_settings = {}
+            for key, val in kwargs.items():
+                current_settings[key] = getattr(self, key)
                 setattr(self, key, val)
+            try:
+                plan_stack = deque()
+                with stage_context(plan_stack, flyers):
+                    with subs_context(plan_stack, subs):
+                        plan = self._gen()
+                        plan_stack.append(fly_during(plan, flyers))
+
+                for gen in plan_stack:
+                    yield from gen
+            finally:
+                for key, val in current_settings.items():
+                    setattr(self, key, val)
+        cls_plan.__name__ = self.__class__.__name__
+
+        return cls_plan()
 
     def _gen(self):
         "Subclasses override this to provide the main plan content."


### PR DESCRIPTION
This fix only works on py3.5, on py3.4 this improves the reported name
from `__call__` to `cls_plan`.