### PR TITLE
FIX: correct all spec names

### DIFF
--- a/bluesky/spec_api.py
+++ b/bluesky/spec_api.py
@@ -14,14 +14,13 @@ http://www.certif.com/downloads/css_docs/spec_man.pdf
 """
 from collections import deque
 import matplotlib.pyplot as plt
-from bluesky import plans, Msg
+from bluesky import plans
 from bluesky.callbacks import LiveTable, LivePlot, LiveRaster
 from bluesky.callbacks.scientific import PeakStats
 from boltons.iterutils import chunked
 from bluesky.global_state import gs
-from bluesky.utils import (normalize_subs_input, Subs, DefaultSubs,
-                           first_key_heuristic, apply_sub_factories,
-                           update_sub_lists)
+from bluesky.utils import (first_key_heuristic)
+
 from bluesky.plans import (subs_context, count, scan,
                            relative_scan, relative_inner_product_scan,
                            outer_product_scan, inner_product_scan,

--- a/bluesky/spec_api.py
+++ b/bluesky/spec_api.py
@@ -29,6 +29,7 @@ from bluesky.plans import (subs_context, count, scan,
                            baseline_mutator)
 import itertools
 from itertools import chain
+from collections import ChainMap
 
 ### Factory functions for generating callbacks
 
@@ -98,6 +99,9 @@ def ct(num=1, delay=None, time=None, *, md=None):
     md : dict, optional
         metadata
     """
+    if md is None:
+        md = {}
+    md = ChainMap(md, {'plan_name': 'ct'})
     subs = {'all': [LiveTable(gs.TABLE_COLS + [gs.PLOT_Y])]}
     if num is not None and num > 1:
         subs['all'].append(setup_plot([]))
@@ -132,6 +136,9 @@ def ascan(motor, start, finish, intervals, time=None, *, md=None):
     md : dict, optional
         metadata
     """
+    if md is None:
+        md = {}
+    md = ChainMap(md, {'plan_name': 'ascan'})
     subs = {'all': [LiveTable([motor] + gs.TABLE_COLS + [gs.PLOT_Y]),
                     setup_plot([motor]),
                     setup_peakstats([motor])]}
@@ -168,7 +175,9 @@ def dscan(motor, start, finish, intervals, time=None, *, md=None):
     subs = {'all': [LiveTable([motor] + gs.TABLE_COLS + [gs.PLOT_Y]),
                     setup_plot([motor]),
                     setup_peakstats([motor])]}
-
+    if md is None:
+        md = {}
+    md = ChainMap(md, {'plan_name': 'dscan'})
     plan_stack = deque()
     with subs_context(plan_stack, subs):
         plan = relative_scan(gs.DETS, motor, start, finish, 1 + intervals,
@@ -196,6 +205,9 @@ def mesh(*args, time=None, md=None):
     md : dict, optional
         metadata
     """
+    if md is None:
+        md = {}
+    md = ChainMap(md, {'plan_name': 'mesh'})
     if len(args) % 4 != 0:
         raise ValueError("wrong number of positional arguments")
     motors = []
@@ -248,6 +260,9 @@ def a2scan(*args, time=None, md=None):
     md : dict, optional
         metadata
     """
+    if md is None:
+        md = {}
+    md = ChainMap(md, {'plan_name': 'a2scan'})
     if len(args) % 3 != 1:
         raise ValueError("wrong number of positional arguments")
     motors = []
@@ -267,8 +282,14 @@ def a2scan(*args, time=None, md=None):
         plan_stack.append(plan)
     return plan_stack
 
+
 # This implementation works for *all* dimensions, but we follow SPEC naming.
-a3scan = a2scan
+def a3scan(*args, time=None, md=None):
+    if md is None:
+        md = {}
+    md = ChainMap(md, {'plan_name': 'a3scan'})
+    return (yield from a2scan(*args, time=time, md=md))
+a3scan.__doc__ = a2scan.__doc__
 
 
 @planify
@@ -288,6 +309,9 @@ def d2scan(*args, time=None, md=None):
     md : dict, optional
         metadata
     """
+    if md is None:
+        md = {}
+    md = ChainMap(md, {'plan_name': 'd2scan'})
     if len(args) % 3 != 1:
         raise ValueError("wrong number of positional arguments")
     motors = []
@@ -307,8 +331,14 @@ def d2scan(*args, time=None, md=None):
         plan_stack.append(plan)
     return plan_stack
 
+
 # This implementation works for *all* dimensions, but we follow SPEC naming.
-d3scan = d2scan
+def d3scan(*args, time=None, md=None):
+    if md is None:
+        md = {}
+    md = ChainMap(md, {'plan_name': 'd3scan'})
+    return (yield from d2scan(*args, time=time, md=md))
+d3scan.__doc__ = d2scan.__doc__
 
 
 @planify
@@ -334,6 +364,9 @@ def th2th(start, finish, intervals, time=None, *, md=None):
     md : dict, optional
         metadata
     """
+    if md is None:
+        md = {}
+    md = ChainMap(md, {'plan_name': 'th2th'})
     plan = d2scan(gs.TTH_MOTOR, start, finish,
                   gs.TH_MOTOR, start/2, finish/2,
                   intervals, time=time, md=md)
@@ -358,6 +391,9 @@ def tw(motor, step, time=None, *, md=None):
     md : dict, optional
         metadata
     """
+    if md is None:
+        md = {}
+    md = ChainMap(md, {'plan_name': 'tw'})
     plan = tweak(gs.MASTER_DET, gs.MASTER_DET_FIELD, md=md)
     plan = baseline_mutator(plan, [motor] + gs.BASELINE_DEVICES)
     plan = configure_count_time(plan, time)
@@ -402,6 +438,9 @@ def afermat(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, factor,
     `bluesky.spec_api.aspiral`
     `bluesky.spec_api.spiral`
     '''
+    if md is None:
+        md = {}
+    md = ChainMap(md, {'plan_name': 'afermat'})
     subs = {'all': [LiveTable([x_motor, y_motor, gs.PLOT_Y] + gs.TABLE_COLS),
                     ]}
 
@@ -450,6 +489,9 @@ def fermat(x_motor, y_motor, x_range, y_range, dr, factor, time=None, *,
     `bluesky.spec_api.aspiral`
     `bluesky.spec_api.spiral`
     '''
+    if md is None:
+        md = {}
+    md = ChainMap(md, {'plan_name': 'fermat'})
     plan = afermat(x_motor, y_motor, x_motor.position, y_motor.position,
                    x_range, y_range, dr, factor, time=time, per_step=per_step,
                    md=md)
@@ -491,6 +533,9 @@ def aspiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth,
     `bluesky.spec_api.afermat`
     `bluesky.spec_api.spiral`
     '''
+    if md is None:
+        md = {}
+    md = ChainMap(md, {'plan_name': 'aspiral'})
     subs = {'all': [LiveTable([x_motor, y_motor, gs.PLOT_Y] + gs.TABLE_COLS),
                     ]}
 
@@ -539,6 +584,9 @@ def spiral(x_motor, y_motor, x_range, y_range, dr, nth, time=None, *,
     `bluesky.spec_api.afermat`
     `bluesky.spec_api.aspiral`
     '''
+    if md is None:
+        md = {}
+    md = ChainMap(md, {'plan_name': 'spiral'})
     plan = aspiral(x_motor, y_motor, x_motor.position, y_motor.position,
                    x_range, y_range, dr, nth, time=time, per_step=per_step,
                    md=md)

--- a/bluesky/tests/test_simple_api.py
+++ b/bluesky/tests/test_simple_api.py
@@ -1,56 +1,70 @@
 from traitlets import TraitError
 from bluesky.examples import motor, motor1, motor2, det, det1, det2, FlyMagic
 import pytest
+from bluesky.spec_api import (ct, ascan, a2scan, a3scan, dscan, d2scan,
+                              d3scan, mesh, th2th, afermat, fermat, spiral,
+                              aspiral)
 
-def test_basic_usage_for_smoke():
-    try:
-        import metadatastore
-    except ImportError as ie:
-        pytest.skip('metadatastore is not installed. Cannot run basic usage '
-                    'test. ImportError: {}'.format(ie))
+
+@pytest.mark.parametrize('pln,name,args,kwargs', [
+    (ct, 'ct', (), {}),
+    (ct, 'ct', (), {'num': 3}),
+    (ascan, 'ascan', (motor, 1, 2, 2), {}),
+    (a2scan, 'a2scan', (motor, 1, 2, 2), {}),
+    (a3scan, 'a3scan', (motor, 1, 2, 2), {}),
+    (dscan, 'dscan', (motor, 1, 2, 2), {}),
+    (d2scan, 'd2scan', (motor, 1, 2, 2), {}),
+    (d3scan, 'd3scan', (motor, 1, 2, 2), {}),
+    (mesh, 'mesh', (motor1, 1, 2, 2, motor2, 1, 2, 3), {}),
+    (th2th, 'th2th', (1, 2, 2), {}),
+    (aspiral, 'aspiral', (motor1, motor2, 0.0, 0.0, 0.1, 0.1, 0.05, 1.0), {}),
+    (spiral, 'spiral', (motor1, motor2, 0.1, 0.1, 0.05, 1.0), {}),
+    (afermat, 'afermat', (motor1, motor2, 0.0, 0.0, 0.1, 0.1, 0.05, 1.0), {}),
+    (fermat, 'fermat', (motor1, motor2, 0.1, 0.1, 0.05, 1.0), {}),
+    # with count time specified as keyword arg
+    (ct, 'ct', (), {'time': 0.1}),
+    (ascan, 'ascan', (motor, 1, 2, 2), {'time': 0.1}),
+    (a2scan, 'a2scan', (motor, 1, 2, 2), {'time': 0.1}),
+    (a3scan, 'a3scan', (motor, 1, 2, 2), {'time': 0.1}),
+    (dscan, 'dscan', (motor, 1, 2, 2), {'time': 0.1}),
+    (d2scan, 'd2scan', (motor, 1, 2, 2), {'time': 0.1}),
+    (d3scan, 'd3scan', (motor, 1, 2, 2), {'time': 0.1}),
+    (mesh, 'mesh', (motor1, 1, 2, 2, motor2, 1, 2, 3), {'time': 0.1}),
+    (th2th, 'th2th', (1, 2, 2), {'time': 0.1}),
+    (aspiral, 'aspiral',
+     (motor1, motor2, 0.0, 0.0, 0.1, 0.1, 0.05, 1.0), {'time': 0.1}),
+    (spiral, 'spiral', (motor1, motor2, 0.1, 0.1, 0.05, 1.0), {'time': 0.1}),
+    (afermat, 'afermat',
+     (motor1, motor2, 0.0, 0.0, 0.1, 0.1, 0.05, 1.0), {'time': 0.1}),
+    (fermat, 'fermat',
+     (motor1, motor2, 0.1, 0.1, 0.05, 1.0), {'time': 0.1})])
+def test_spec_plans(fresh_RE, pln, name, args, kwargs):
     from bluesky.global_state import gs
-    from bluesky.spec_api import (ct, ascan, a2scan, a3scan, dscan, d2scan,
-                                  d3scan, mesh, th2th, afermat, fermat, spiral,
-                                  aspiral)
+
     gs.DETS = [det]
-    with pytest.raises(TraitError):
-        gs.DETS = [det, det]  # no duplicate data keys
     gs.TH_MOTOR = motor1
     gs.TTH_MOTOR = motor2
-    gs.RE.md['owner'] = 'test'
-    gs.RE.md['group'] = 'test'
-    gs.RE.md['beamline_id'] = 'test'
-    gs.RE.md['config'] = {}
-    # without count time specified
-    RE = gs.RE
-    RE(ct())
-    RE(ct(num=3))  # passing kwargs through to scan
-    RE(ascan(motor, 1, 2, 2))
-    RE(a2scan(motor, 1, 2, 2))
-    RE(a3scan(motor, 1, 2, 2))
-    RE(dscan(motor, 1, 2, 2))
-    RE(d2scan(motor, 1, 2, 2))
-    RE(d3scan(motor, 1, 2, 2))
-    RE(mesh(motor1, 1, 2, 2, motor2, 1, 2, 3))
-    RE(th2th(1, 2, 2))
-    RE(aspiral(motor1, motor2, 0.0, 0.0, 0.1, 0.1, 0.05, 1.0))
-    RE(spiral(motor1, motor2, 0.1, 0.1, 0.05, 1.0))
-    RE(afermat(motor1, motor2, 0.0, 0.0, 0.1, 0.1, 0.05, 1.0))
-    RE(fermat(motor1, motor2, 0.1, 0.1, 0.05, 1.0))
-    # with count time specified as keyword arg
-    RE(ct())
-    RE(ascan(motor, 1, 2, 2, time=0.1))
-    RE(a2scan(motor, 1, 2, 2, time=0.1))
-    RE(a3scan(motor, 1, 2, 2, time=0.1))
-    RE(dscan(motor, 1, 2, 2, time=0.1))
-    RE(d2scan(motor, 1, 2, 2, time=0.1))
-    RE(d3scan(motor, 1, 2, 2, time=0.1))
-    RE(mesh(motor1, 1, 2, 2, motor2, 1, 2, 3, time=0.1))
-    RE(th2th(1, 2, 2, time=0.1))
-    RE(aspiral(motor1, motor2, 0.0, 0.0, 0.1, 0.1, 0.05, 1.0, time=0.1))
-    RE(spiral(motor1, motor2, 0.1, 0.1, 0.05, 1.0, time=0.1))
-    RE(afermat(motor1, motor2, 0.0, 0.0, 0.1, 0.1, 0.05, 1.0, time=0.1))
-    RE(fermat(motor1, motor2, 0.1, 0.1, 0.05, 1.0, time=0.1))
+    run_start = None
+
+    def capture_run_start(name, doc):
+        nonlocal run_start
+        if name == 'start':
+            run_start = doc
+
+    fresh_RE(pln(*args, **kwargs), capture_run_start)
+
+    assert run_start['plan_name'] == name
+
+
+def test_flyers(fresh_RE):
+    from bluesky.global_state import gs
+    RE = fresh_RE
     flyer = FlyMagic('wheee', motor, det1, det2)
     gs.FLYERS = [flyer]
     RE(ct())
+
+
+def test_gs_validation():
+    from bluesky.global_state import gs
+    with pytest.raises(TraitError):
+        gs.DETS = [det, det]  # no duplicate data keys


### PR DESCRIPTION
For all of the plans is spec_api make the `plan_name` value in the
run_start metadata match the plan name.

attn @ericdill 