### PR TITLE
MNT: Remove too-cute repr for examples objs.

### DIFF
--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -73,9 +73,6 @@ class Base:
                     'precision': self.precision}
                 for k in self._fields}
 
-    def __repr__(self):
-        return '{}: {}'.format(self._klass, self.name)
-
     def read_configuration(self):
         return {'some_configuration':
                    {'value': 'there is a sandwich in the vacuum chamber',


### PR DESCRIPTION
This repr dates back to the original implementation demo, where the RunEngine
printed every message is saw for the purposes of explaining its operation.

The raw repr looks like more like the ones from ophyd and makes a less
confusing example nowadays.