### PR TITLE
ENH: plan patterns

### DIFF
--- a/bluesky/plan_patterns.py
+++ b/bluesky/plan_patterns.py
@@ -1,0 +1,213 @@
+import functools
+import operator
+
+import numpy as np
+from cycler import cycler
+from boltons.iterutils import chunked
+
+from .utils import snake_cyclers
+
+
+def spiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth):
+    '''Spiral scan, centered around (x_start, y_start)
+
+    Parameters
+    ----------
+    x_motor : object, optional
+        any 'setable' object (motor, temp controller, etc.)
+    y_motor : object, optional
+        any 'setable' object (motor, temp controller, etc.)
+    x_start : float
+        x center
+    y_start : float
+        y center
+    x_range : float
+        x width of spiral
+    y_range : float
+        y width of spiral
+    dr : float
+        Delta radius
+    nth : float
+        Number of theta steps
+
+    Returns
+    -------
+    cyc : cycler
+    '''
+    half_x = x_range / 2
+    half_y = y_range / 2
+
+    r_max = np.sqrt(half_x ** 2 + half_y ** 2)
+    num_ring = 1 + int(r_max / dr)
+
+    x_points = []
+    y_points = []
+    for i_ring in range(1, num_ring + 2):
+        radius = i_ring * dr
+        angle_step = 2. * np.pi / (i_ring * nth)
+
+        for i_angle in range(int(i_ring * nth)):
+            angle = i_angle * angle_step
+            x = radius * np.cos(angle)
+            y = radius * np.sin(angle)
+            if abs(x) <= half_x and abs(y) <= half_y:
+                x_points.append(x_start + x)
+                y_points.append(y_start + y)
+
+    cyc = cycler(x_motor, x_points)
+    cyc += cycler(y_motor, y_points)
+    return cyc
+
+
+def spiral_fermat(x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
+                  factor):
+    '''Absolute fermat spiral scan, centered around (x_start, y_start)
+
+    Parameters
+    ----------
+    x_motor : object, optional
+        any 'setable' object (motor, temp controller, etc.)
+    y_motor : object, optional
+        any 'setable' object (motor, temp controller, etc.)
+    x_start : float
+        x center
+    y_start : float
+        y center
+    x_range : float
+        x width of spiral
+    y_range : float
+        y width of spiral
+    dr : float
+        delta radius
+    factor : float
+        radius gets divided by this
+    per_step : callable, optional
+        hook for cutomizing action of inner loop (messages per step)
+        See docstring of bluesky.plans.one_nd_step (the default) for
+        details.
+
+    Returns
+    -------
+    cyc : cycler
+    '''
+    phi = 137.508 * np.pi / 180.
+
+    half_x = x_range / 2
+    half_y = y_range / 2
+
+    x_points, y_points = [], []
+
+    diag = np.sqrt(half_x ** 2 + half_y ** 2)
+    num_rings = int((1.5 * diag / (dr / factor)) ** 2)
+    for i_ring in range(1, num_rings):
+        radius = np.sqrt(i_ring) * dr / factor
+        angle = phi * i_ring
+        x = radius * np.cos(angle)
+        y = radius * np.sin(angle)
+
+        if abs(x) <= half_x and abs(y) <= half_y:
+            x_points.append(x_start + x)
+            y_points.append(y_start + y)
+
+    cyc = cycler(x_motor, x_points)
+    cyc += cycler(y_motor, y_points)
+    return cyc
+
+
+def inner_product(num, args):
+    '''Scan over one multi-motor trajectory.
+
+    Parameters
+    ----------
+    num : integer
+        number of steps
+    args : list of {Positioner, Positioner, int}
+        patterned like (``motor1, start1, stop1, ..., motorN, startN, stopN``)
+        Motors can be any 'setable' object (motor, temp controller, etc.)
+
+    Returns
+    -------
+    cyc : cycler
+    '''
+    if len(args) % 3 != 0:
+        raise ValueError("wrong number of positional arguments")
+
+    cyclers = []
+    for motor, start, stop, in chunked(args, 3):
+        steps = np.linspace(start, stop, num=num, endpoint=True)
+        c = cycler(motor, steps)
+        cyclers.append(c)
+    return functools.reduce(operator.add, cyclers)
+
+
+def chunk_outer_product_args(args):
+    '''Scan over a mesh; each motor is on an independent trajectory.
+
+    Parameters
+    ----------
+    args
+        patterned like (``motor1, start1, stop1, num1,```
+                        ``motor2, start2, stop2, num2, snake2,``
+                        ``motor3, start3, stop3, num3, snake3,`` ...
+                        ``motorN, startN, stopN, numN, snakeN``)
+
+        The first motor is the "slowest", the outer loop. For all motors
+        except the first motor, there is a "snake" argument: a boolean
+        indicating whether to following snake-like, winding trajectory or a
+        simple left-to-right trajectory.
+
+    See Also
+    --------
+    `bluesky.plan_patterns.outer_product`
+
+    Yields
+    ------
+    (motor, start, stop, num, snake)
+    '''
+    args = list(args)
+    # The first (slowest) axis is never "snaked." Insert False to
+    # make it easy to iterate over the chunks or args..
+    args.insert(4, False)
+    if len(args) % 5 != 0:
+        raise ValueError("wrong number of positional arguments")
+
+    yield from chunked(args, 5)
+
+
+def outer_product(args):
+    '''Scan over a mesh; each motor is on an independent trajectory.
+
+    Parameters
+    ----------
+    args
+        patterned like (``motor1, start1, stop1, num1,```
+                        ``motor2, start2, stop2, num2, snake2,``
+                        ``motor3, start3, stop3, num3, snake3,`` ...
+                        ``motorN, startN, stopN, numN, snakeN``)
+
+        The first motor is the "slowest", the outer loop. For all motors
+        except the first motor, there is a "snake" argument: a boolean
+        indicating whether to following snake-like, winding trajectory or a
+        simple left-to-right trajectory.
+
+    See Also
+    --------
+    `bluesky.plan_patterns.inner_product`
+
+    Returns
+    -------
+    cyc : cycler
+    '''
+    shape = []
+    extents = []
+    snaking = []
+    cyclers = []
+    for motor, start, stop, num, snake in chunk_outer_product_args(args):
+        shape.append(num)
+        extents.append([start, stop])
+        snaking.append(snake)
+        steps = np.linspace(start, stop, num=num, endpoint=True)
+        c = cycler(motor, steps)
+        cyclers.append(c)
+
+    return snake_cyclers(cyclers, snaking)

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1634,14 +1634,12 @@ def list_scan(detectors, motor, steps, *, per_step=None, md=None):
                        'motor': repr(motor), 'steps': steps,
                        'per_step': repr(per_step)},
          'plan_name': 'list_scan',
-
-         # TODO what to do in this case?
-         'plan_pattern': 'list',
-         'plan_pattern_module': '__builtin__',
+         'plan_pattern': 'array',
+         'plan_pattern_module': 'numpy',
          }
     )
 
-    md['plan_pattern_args'] = [steps]
+    md['plan_pattern_args'] = dict(object=steps)
     if per_step is None:
         per_step = one_1d_step
 

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1546,7 +1546,8 @@ def count(detectors, num=1, delay=None, *, md=None):
     md = ChainMap(
         md,
         {'detectors': [det.name for det in detectors],
-         'plan_args':{'detectors': list(map(repr, detectors)), 'num': num},
+         'num_steps': num,
+         'plan_args': {'detectors': list(map(repr, detectors)), 'num': num},
          'plan_name': 'count'})
 
     if num is None:
@@ -1631,10 +1632,13 @@ def list_scan(detectors, motor, steps, *, per_step=None, md=None):
         md,
         {'detectors': [det.name for det in detectors],
          'motors': [motor.name],
+         'num_steps': len(steps),
          'plan_args': {'detectors': list(map(repr, detectors)),
                        'motor': repr(motor), 'steps': steps,
                        'per_step': repr(per_step)},
-                       'plan_name': 'list_scan'})
+         'plan_name': 'list_scan',
+         }
+    )
     if per_step is None:
         per_step = one_1d_step
 
@@ -1712,6 +1716,7 @@ def scan(detectors, motor, start, stop, num, *, per_step=None, md=None):
         md,
         {'detectors': [det.name for det in detectors],
          'motors': [motor.name],
+         'num_steps': num,
          'plan_args': {'detectors': list(map(repr, detectors)), 'num': num,
                        'motor': repr(motor),
                        'start': start, 'stop': stop,
@@ -1802,6 +1807,7 @@ def log_scan(detectors, motor, start, stop, num, *, per_step=None, md=None):
         md,
         {'detectors': [det.name for det in detectors],
          'motors': [motor.name],
+         'num_steps': num,
          'plan_args': {'detectors': list(map(repr, detectors)), 'num': num,
                        'start': start, 'stop': stop, 'motor': repr(motor),
                        'per_step': repr(per_step)},
@@ -1901,6 +1907,7 @@ def adaptive_scan(detectors, target_field, motor, start, stop,
         md,
         {'detectors': [det.name for det in detectors],
          'motors': [motor.name],
+         # 'num_steps': 'adaptive',
          'plan_args':{'detectors': list(map(repr, detectors)),
                       'motor': repr(motor),
                       'start': start,
@@ -2070,6 +2077,7 @@ def scan_nd(detectors, cycler, *, per_step=None, md=None):
         md,
         {'detectors': [det.name for det in detectors],
          'motors': [motor.name for motor in cycler.keys],
+         'num_steps': len(cycler),
          'plan_args': {'detectors': list(map(repr, detectors)),
                        'cycler': repr(cycler),
                        'per_step': repr(per_step)},
@@ -2204,7 +2212,8 @@ def outer_product_scan(detectors, *args, per_step=None, md=None):
     md = ChainMap(
         md,
         {'shape': tuple(shape), 'extents': tuple(extents),
-         'snaking': tuple(snaking), 'num': len(full_cycler),
+         'snaking': tuple(snaking),
+         # 'num_steps': inserted by scan_nd
          'plan_args': {'detectors': list(map(repr, detectors)),
                        'args': mds_args,
                        'per_step': repr(per_step)},
@@ -2313,6 +2322,7 @@ def tweak(detector, target_field, motor, step, *, md=None):
         md,
         {'detectors': [detector.name],
          'motors': [motor.name],
+         # 'num_steps': 'adaptive',
          'plan_args': {'detector': repr(detector),
                        'target_field': target_field,
                        'motor': repr(motor),
@@ -2405,8 +2415,9 @@ def spiral_fermat(detectors, x_motor, y_motor, x_start, y_start, x_range,
         md = {}
     md = ChainMap(
         md,
-        {'detectors': [detector.name for detector in detectors],
-         'motors': [motor.name for motor in [x_motor, y_motor]],
+        {# 'detectors': inserted by scan_nd
+         # 'motors': inserted by scan_nd
+         # 'num_steps': inserted by scan_nd
          'plan_args': {'detectors': list(map(repr, detectors)),
                        'x_motor': repr(x_motor), 'y_motor': repr(y_motor),
                        'x_start': x_start, 'y_start': y_start,
@@ -2517,8 +2528,9 @@ def spiral(detectors, x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
         md = {}
     md = ChainMap(
         md,
-        {'detectors': [detector.name for detector in detectors],
-         'motors': [motor.name for motor in [x_motor, y_motor]],
+        {# 'detectors': inserted by scan_nd
+         # 'motors': inserted by scan_nd
+         # 'num_steps': inserted by scan_nd
          'plan_args': {'detectors': list(map(repr, detectors)),
                        'x_motor': repr(x_motor), 'y_motor': repr(y_motor),
                        'x_start': x_start, 'y_start': y_start,

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2,19 +2,16 @@ import uuid
 import sys
 from functools import wraps
 import itertools
-import functools
-import operator
 from contextlib import contextmanager
 from collections import OrderedDict, Iterable, defaultdict, deque, ChainMap
 
 import numpy as np
-from cycler import cycler
 from boltons.iterutils import chunked
 
-from . import Msg
+from . import (Msg, plan_patterns)
 
 from .plan_tools import ensure_generator
-from .utils import (Struct, snake_cyclers, Subs, normalize_subs_input,
+from .utils import (Struct, Subs, normalize_subs_input,
                     separate_devices, apply_sub_factories, update_sub_lists)
 
 
@@ -1637,8 +1634,14 @@ def list_scan(detectors, motor, steps, *, per_step=None, md=None):
                        'motor': repr(motor), 'steps': steps,
                        'per_step': repr(per_step)},
          'plan_name': 'list_scan',
+
+         # TODO what to do in this case?
+         'plan_pattern': 'list',
+         'plan_pattern_module': '__builtin__',
          }
     )
+
+    md['plan_pattern_args'] = [steps]
     if per_step is None:
         per_step = one_1d_step
 
@@ -1721,12 +1724,16 @@ def scan(detectors, motor, start, stop, num, *, per_step=None, md=None):
                        'motor': repr(motor),
                        'start': start, 'stop': stop,
                        'per_step': repr(per_step)},
-         'plan_name': 'scan'})
+         'plan_name': 'scan',
+         'plan_pattern': 'linspace',
+         'plan_pattern_module': 'numpy',
+         })
 
     if per_step is None:
         per_step = one_1d_step
 
-    steps = np.linspace(start, stop, num)
+    md['plan_pattern_args'] = dict(start=start, stop=stop, num=num)
+    steps = np.linspace(**md['plan_pattern_args'])
 
     plan_stack = deque()
     with stage_context(plan_stack, list(detectors) + [motor]):
@@ -1811,12 +1818,16 @@ def log_scan(detectors, motor, start, stop, num, *, per_step=None, md=None):
          'plan_args': {'detectors': list(map(repr, detectors)), 'num': num,
                        'start': start, 'stop': stop, 'motor': repr(motor),
                        'per_step': repr(per_step)},
-         'plan_name': 'log_scan'})
+         'plan_name': 'log_scan',
+         'plan_pattern': 'logspace',
+         'plan_pattern_module': 'numpy',
+         })
 
     if per_step is None:
         per_step = one_1d_step
 
-    steps = np.logspace(start, stop, num)
+    md['plan_pattern_args'] = dict(start=start, stop=stop, num=num)
+    steps = np.logspace(**md['plan_pattern_args'])
 
     plan_stack = deque()
     with stage_context(plan_stack, list(detectors) + [motor]):
@@ -2136,16 +2147,16 @@ def inner_product_scan(detectors, num, *args, per_step=None, md=None):
         {'plan_args': {'detectors': list(map(repr, detectors)),
                        'num': num, 'args': mds_args,
                        'per_step': repr(per_step)},
-         'plan_name': 'inner_product_scan'})
+         'plan_name': 'inner_product_scan',
+         'plan_pattern': 'inner_product',
+         'plan_pattern_module': plan_patterns.__name__,
+         }
+    )
     if len(args) % 3 != 0:
         raise ValueError("wrong number of positional arguments")
-    cyclers = []
-    for motor, start, stop, in chunked(args, 3):
-        steps = np.linspace(start, stop, num=num, endpoint=True)
-        c = cycler(motor, steps)
-        cyclers.append(c)
-    full_cycler = functools.reduce(operator.add, cyclers)
 
+    md['plan_pattern_args'] = dict(num=num, args=list(args))
+    full_cycler = plan_patterns.inner_product(**md['plan_pattern_args'])
     plan = scan_nd(detectors, full_cycler, per_step=per_step, md=md)
     return [plan]
 
@@ -2182,25 +2193,6 @@ def outer_product_scan(detectors, *args, per_step=None, md=None):
     `bluesky.plans.inner_product_scan`
     `bluesky.plans.scan_nd`
     """
-    args = list(args)
-    # The first (slowest) axis is never "snaked." Insert False to
-    # make it easy to iterate over the chunks or args..
-    args.insert(4, False)
-    if len(args) % 5 != 0:
-        raise ValueError("wrong number of positional arguments")
-    shape = []
-    extents = []
-    snaking = []
-    cyclers = []
-    for motor, start, stop, num, snake in chunked(args, 5):
-        shape.append(num)
-        extents.append([start, stop])
-        snaking.append(snake)
-        steps = np.linspace(start, stop, num=num, endpoint=True)
-        c = cycler(motor, steps)
-        cyclers.append(c)
-    full_cycler = snake_cyclers(cyclers, snaking)
-
     if md is None:
         md = {}
 
@@ -2209,10 +2201,18 @@ def outer_product_scan(detectors, *args, per_step=None, md=None):
     mds_args = [repr(arg) if hasattr(arg, 'name') else arg
                 for arg in args]
 
+    md['plan_pattern_args'] = dict(args=list(args))
+    full_cycler = plan_patterns.outer_product(**md['plan_pattern_args'])
+
+    chunk_args = list(plan_patterns.chunk_outer_product_args(args))
     md = ChainMap(
         md,
-        {'shape': tuple(shape), 'extents': tuple(extents),
-         'snaking': tuple(snaking),
+        {'shape': tuple(num for motor, start, stop, num, snake
+                        in chunk_args),
+         'extents': tuple([start, stop] for motor, start, stop, num, snake
+                          in chunk_args),
+         'snaking': tuple(snake for motor, start, stop, num, snake
+                          in chunk_args),
          # 'num_steps': inserted by scan_nd
          'plan_args': {'detectors': list(map(repr, detectors)),
                        'args': mds_args,
@@ -2415,36 +2415,22 @@ def spiral_fermat(detectors, x_motor, y_motor, x_start, y_start, x_range,
         md = {}
     md = ChainMap(
         md,
-        {# 'detectors': inserted by scan_nd
-         # 'motors': inserted by scan_nd
-         # 'num_steps': inserted by scan_nd
-         'plan_args': {'detectors': list(map(repr, detectors)),
+        {'plan_args': {'detectors': list(map(repr, detectors)),
                        'x_motor': repr(x_motor), 'y_motor': repr(y_motor),
                        'x_start': x_start, 'y_start': y_start,
                        'x_range': x_range, 'y_range': y_range,
                        'dr': dr, 'factor': factor, 'per_step': repr(per_step)},
-         'plan_name': 'spiral_fermat'})
-    phi = 137.508 * np.pi / 180.
+         'plan_name': 'spiral_fermat',
+         'plan_pattern': 'spiral_fermat',
+         'plan_pattern_module': plan_patterns.__name__,
+         })
 
-    half_x = x_range / 2
-    half_y = y_range / 2
+    md['plan_pattern_args'] = dict(x_motor=x_motor, y_motor=y_motor,
+                                   x_start=x_start, y_start=y_start,
+                                   x_range=x_range, y_range=y_range, dr=dr,
+                                   factor=factor)
 
-    x_points, y_points = [], []
-
-    diag = np.sqrt(half_x ** 2 + half_y ** 2)
-    num_rings = int((1.5 * diag / (dr / factor)) ** 2)
-    for i_ring in range(1, num_rings):
-        radius = np.sqrt(i_ring) * dr / factor
-        angle = phi * i_ring
-        x = radius * np.cos(angle)
-        y = radius * np.sin(angle)
-
-        if abs(x) <= half_x and abs(y) <= half_y:
-            x_points.append(x_start + x)
-            y_points.append(y_start + y)
-
-    cyc = cycler(x_motor, x_points)
-    cyc += cycler(y_motor, y_points)
+    cyc = plan_patterns.spiral_fermat(**md['plan_pattern_args'])
     yield from scan_nd(detectors, cyc, per_step=per_step, md=md)
 
 
@@ -2528,37 +2514,21 @@ def spiral(detectors, x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
         md = {}
     md = ChainMap(
         md,
-        {# 'detectors': inserted by scan_nd
-         # 'motors': inserted by scan_nd
-         # 'num_steps': inserted by scan_nd
-         'plan_args': {'detectors': list(map(repr, detectors)),
+        {'plan_args': {'detectors': list(map(repr, detectors)),
                        'x_motor': repr(x_motor), 'y_motor': repr(y_motor),
                        'x_start': x_start, 'y_start': y_start,
                        'x_range': x_range, 'y_range': y_range,
                        'dr': dr, 'nth': nth, 'per_step': repr(per_step)},
-         'plan_name': 'spiral'})
-    half_x = x_range / 2
-    half_y = y_range / 2
+         'plan_name': 'spiral',
+         'plan_pattern': 'spiral',
+         'plan_pattern_module': plan_patterns.__name__,
+         })
 
-    r_max = np.sqrt(half_x ** 2 + half_y ** 2)
-    num_ring = 1 + int(r_max / dr)
-
-    x_points = []
-    y_points = []
-    for i_ring in range(1, num_ring + 2):
-        radius = i_ring * dr
-        angle_step = 2. * np.pi / (i_ring * nth)
-
-        for i_angle in range(int(i_ring * nth)):
-            angle = i_angle * angle_step
-            x = radius * np.cos(angle)
-            y = radius * np.sin(angle)
-            if abs(x) <= half_x and abs(y) <= half_y:
-                x_points.append(x_start + x)
-                y_points.append(y_start + y)
-
-    cyc = cycler(x_motor, x_points)
-    cyc += cycler(y_motor, y_points)
+    md['plan_pattern_args'] = dict(x_motor=x_motor, y_motor=y_motor,
+                                   x_start=x_start, y_start=y_start,
+                                   x_range=x_range, y_range=y_range, dr=dr,
+                                   nth=nth)
+    cyc = plan_patterns.spiral(**md['plan_pattern_args'])
     yield from scan_nd(detectors, cyc, per_step=per_step, md=md)
 
 


### PR DESCRIPTION
Allows motor trajectories to be determined purely from scan metadata.

Supercedes #454, which will require the tweaks mentioned in that PR - after we agree on this implementation.