### PR TITLE
Subs wrapper

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -855,17 +855,7 @@ def subs_wrapper(plan, subs):
         for token in tokens:
             yield Msg('unsubscribe', None, token=token)
 
-    first_msg = True
-
-    def insert_subscribe(msg):
-        nonlocal first_msg
-        if first_msg:
-            first_msg = False
-            return pchain(_subscribe(), single_gen(msg)), None
-        else:
-            return None, None
-
-    return (yield from finalize_wrapper(plan_mutator(plan, insert_subscribe),
+    return (yield from finalize_wrapper(pchain(_subscribe(), plan),
                                         _unsubscribe()))
 
 

--- a/bluesky/tests/test_generators.py
+++ b/bluesky/tests/test_generators.py
@@ -5,7 +5,7 @@ from itertools import zip_longest
 from bluesky import Msg
 
 from bluesky.plans import (msg_mutator, plan_mutator, pchain,
-                           single_gen as single_message_gen, finalize)
+                           single_gen as single_message_gen, finalize_wrapper)
 
 from bluesky.plan_tools import ensure_generator
 
@@ -153,8 +153,8 @@ def test_finialize_fail():
 
     num = 5
     cmd = 'echo'
-    plan = finalize(erroring_plan(),
-                    echo_plan(command=cmd, num=num))
+    plan = finalize_wrapper(erroring_plan(),
+                            echo_plan(command=cmd, num=num))
     msgs = list()
     try:
         EchoRE(plan, msg_list=msgs)
@@ -173,8 +173,8 @@ def test_finialize_success():
 
     num = 5
     cmd = 'echo'
-    plan = finalize(single_message_gen(Msg(suc_cmd, None)),
-                    echo_plan(command=cmd, num=num))
+    plan = finalize_wrapper(single_message_gen(Msg(suc_cmd, None)),
+                            echo_plan(command=cmd, num=num))
     msgs = list()
     try:
         EchoRE(plan, msg_list=msgs)

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -13,6 +13,7 @@ from bluesky.plans import (create, save, read, monitor, unmonitor, null,
                            stage_context, planify, finalize, fly_during,
                            lazily_stage, relative_set, reset_positions,
                            configure_count_time, trigger_and_read,
+                           subs_wrapper,
                            repeater, caching_repeater, count, Count, Scan)
 
 
@@ -177,6 +178,22 @@ def test_lazily_stage():
     expected = [Msg('stage', det1), Msg('read', det1), Msg('read', det1),
                 Msg('stage', det2), Msg('read', det2), Msg('unstage', det2),
                 Msg('unstage', det1)]
+
+    assert processed_plan == expected
+
+
+def test_subs_wrapper():
+
+    def cb(name, doc):
+        pass
+
+    def plan():
+        yield from [Msg('null')]
+
+    processed_plan = list(subs_wrapper(plan(), {'all': cb}))
+    
+    expected = [Msg('subscribe', None, 'all', cb), Msg('null'),
+                Msg('unsubscribe', token=None)]
 
     assert processed_plan == expected
 

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -242,12 +242,12 @@ These "preprocessors" take in a plan and modify its contents on the fly.
    :toctree:
 
     subs_wrapper
-    baseline
-    relative_set
-    reset_positions
-    lazily_stage
-    fly_during
-    finalize
+    baseline_wrapper
+    relative_set_wrapper
+    reset_positions_wrapper
+    lazily_stage_wrapper
+    fly_during_wrapper
+    finalize_wrapper
 
 For example, ``relative_set`` rewrites all positions to be relative to the
 initial position.

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -241,6 +241,7 @@ These "preprocessors" take in a plan and modify its contents on the fly.
    :nosignatures:
    :toctree:
 
+    subs_wrapper
     baseline
     relative_set
     reset_positions


### PR DESCRIPTION
* Rename all the generator instance preprocessors to end with `_wrapper`.
* Add a `make_decorator` utility function that converts a generator instance wrapper to a generator function decorator.
* Ship a `*_decorator` variant of each `*_wrapper`. These are not yet documented, but they will be once I have the time to explain them carefully.