### PR TITLE
API: changes to count time in global state

### DIFF
--- a/bluesky/global_state.py
+++ b/bluesky/global_state.py
@@ -123,8 +123,7 @@ class GlobalState(HasTraits):
     TABLE_COLS = List()
     PLOT_Y = Unicode()
     OVERPLOT = Bool(True)
-    COUNT_TIME = Float(1.0)
-    MD_TIME_KEY = Unicode('exposure_time')
+    MD_TIME_KEY = Unicode('count_time')
 
 
 gs = GlobalState()  # a singleton instance


### PR DESCRIPTION
- Remove unused gs.COUNT_TIME.
- Change default of gs.MD_TIME_KEY to a name that does not collide with any
  official AreaDetector jargon.