### PR TITLE
ENH: ct should also read gs.BASELINE_DETS

### DIFF
--- a/bluesky/spec_api.py
+++ b/bluesky/spec_api.py
@@ -109,6 +109,7 @@ def ct(num=1, delay=None, time=None, *, md=None):
     plan_stack = deque()
     with subs_context(plan_stack, subs):
         plan = count(gs.DETS, num, delay, md=md)
+        plan = baseline_wrapper(plan, gs.BASELINE_DEVICES)
         plan = configure_count_time_wrapper(plan, time)
         plan_stack.append(plan)
     return plan_stack


### PR DESCRIPTION
In #455, `ct` was left out. I'm not sure whether that was intentional, but I think `ct` should also implement baseline.