### PR TITLE
FIX: infinite count

### DIFF
--- a/bluesky/spec_api.py
+++ b/bluesky/spec_api.py
@@ -90,7 +90,9 @@ def ct(num=1, delay=None, time=None, *, md=None):
     Parameters
     ----------
     num : integer, optional
-        number of readings to take; default is 1
+        number of readings to take; default is 1.
+
+        If None, capture data until canceled
     delay : iterable or scalar, optional
         time delay between successive readings; default is 0
     time : float, optional


### PR DESCRIPTION
Refactor the infinite count.

The previous implementation was
interacting badly with `planify` which resulted in the infinite loop
while building the list of plans to return (rather than an infinite
generator being handed to the RE).

Closes https://github.com/NSLS-II/Bug-Reports/issues/112