### PR TITLE
FIX: Pass args through to tweak.

### DIFF
--- a/bluesky/spec_api.py
+++ b/bluesky/spec_api.py
@@ -391,8 +391,6 @@ def tw(motor, step, time=None, *, md=None):
 
     Parameters
     ----------
-    target_field : string
-        data field whose output is the focus of the adaptive tuning
     motor : Device
     step : float
         initial suggestion for step size
@@ -403,7 +401,7 @@ def tw(motor, step, time=None, *, md=None):
         md = {}
     md = ChainMap(md, {'plan_name': 'tw',
                        gs.MD_TIME_KEY: time})
-    plan = tweak(gs.MASTER_DET, gs.MASTER_DET_FIELD, md=md)
+    plan = tweak(gs.MASTER_DET, gs.MASTER_DET_FIELD, motor, step, md=md)
     plan = baseline_wrapper(plan, [motor] + gs.BASELINE_DEVICES)
     plan = configure_count_time_wrapper(plan, time)
     return [plan]


### PR DESCRIPTION
The tweak/tw plan was basically written to prove the point that, yes, SPEC's concept of "tweak" is within the scope of the Python language. When I see someone actually use it at a beamline, I'll take the trouble to write a test. ;- )

Closes https://github.com/NSLS-II/bluesky/issues/483