### PR TITLE
ENH: Add inject_md_wrapper and inject_md_decorator.

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1068,6 +1068,29 @@ def fly(flyers, *, md=None):
     yield from close_run()
 
 
+def inject_md_wrapper(plan, md):
+    """
+    Inject additional metadata into a run.
+
+    This takes precedences over the original metadata dict in the event of
+    overlapping keys, but it does not mutate the original metadata dict.
+    (It uses ChainMap.)
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        a generator, list, or similar containing `Msg` objects
+    md : dict
+        metadata
+    """
+    def _inject_md(msg):
+        if msg.command == 'open_run':
+            msg = msg._replace(kwargs=ChainMap(md, msg.kwargs))
+        return msg
+
+    return (yield from msg_mutator(plan, _inject_md))
+
+
 def fly_during_wrapper(plan, flyers):
     """
     Kickoff and collect "flyer" (asynchronously collect) objects during runs.
@@ -1608,6 +1631,7 @@ reset_positions_decorator = make_decorator(reset_positions_wrapper)
 finalize_decorator = make_decorator(finalize_wrapper)
 lazily_stage_decorator = make_decorator(lazily_stage_wrapper)
 fly_during_decorator = make_decorator(fly_during_wrapper)
+inject_md_decorator = make_decorator(inject_md_wrapper)
 
 
 @planify

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -16,7 +16,8 @@ from bluesky.plans import (create, save, read, monitor, unmonitor, null,
                            configure_count_time_wrapper,
                            subs_wrapper, trigger_and_read,
                            repeater, caching_repeater, count, Count, Scan,
-                           fly_during_decorator, subs_decorator)
+                           fly_during_decorator, subs_decorator,
+                           inject_md_wrapper)
 
 
 class DummyMover:
@@ -211,6 +212,17 @@ def test_subs():
 
     processed_plan = list(subs_decorator(plan, {'all': cb})('test_arg',
                                                             test_kwarg='val'))
+    assert processed_plan == expected
+
+
+def test_md():
+    def plan():
+        yield from open_run(md={'a': 1})
+
+    processed_plan = list(inject_md_wrapper(plan(), {'b': 2}))
+
+    expected = [Msg('open_run', None, a=1, b=2)]
+
     assert processed_plan == expected
 
 


### PR DESCRIPTION
Example of where this is useful:

```python
inject_md_wrapper(multi_run_plan, {'last_dark_frame_uid': '...'})
```