### PR TITLE
MNT: Don't emit create/save with no reads between.

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1498,6 +1498,9 @@ def trigger_and_read(devices, name='primary'):
     msg : Msg
         messages to 'trigger', 'wait' and 'read'
     """
+    # If devices is empty, don't emit 'create'/'save' messages.
+    if not devices:
+        return []
     devices = separate_devices(devices)  # remove redundant entries
     grp = _short_uid('trigger')
     plan_stack = deque()


### PR DESCRIPTION
Very minor change that removed some no-op messages, just to make things cleaner in a basic example that I find myself using a lot when teaching about plans.

Before:

```python
In [2]: list(count([]))
Out[2]:
[open_run: (None), (), {'plan_name': 'count', 'num_steps': 1, 'plan_args': {'detectors': [], 'num': 1}, 'detectors': []},
 checkpoint: (None), (), {},
 create: (None), (), {'name': 'primary'},
 save: (None), (), {},
 close_run: (None), (), {}]
```

After:

```python
In [2]: list(count([]))
Out[2]:
[open_run: (None), (), {'detectors': [], 'plan_args': {'detectors': [], 'num': 1}, 'plan_name': 'count', 'num_steps': 1},
 checkpoint: (None), (), {},
 close_run: (None), (), {}]
```