### PR TITLE
Fix motor reset

### DIFF
--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -205,7 +205,7 @@ class SynGauss(Reader):
     _klass = 'reader'
 
     def __init__(self, name, motor, motor_field, center, Imax, sigma=1,
-                 noise=None, noise_multiplier=1):
+                 noise=None, noise_multiplier=1, exposure_time=0.05):
         super(SynGauss, self).__init__(name, [name, ])
         self.ready = True
         self._motor = motor
@@ -216,6 +216,7 @@ class SynGauss(Reader):
         self.noise = noise
         self.noise_multiplier = noise_multiplier
         self._data = {self.name: {'value': 0, 'timestamp': ttime.time()}}
+        self.exposure_time = exposure_time
         if noise not in ('poisson', 'uniform', None):
             raise ValueError("noise must be one of 'poisson', 'uniform', None")
 
@@ -228,7 +229,8 @@ class SynGauss(Reader):
         elif self.noise == 'uniform':
             v += np.random.uniform(-1, 1) * self.noise_multiplier
         self._data = {self.name: {'value': v, 'timestamp': ttime.time()}}
-        ttime.sleep(0.05)  # simulate exposure time
+        if self.exposure_time:
+            ttime.sleep(self.exposure_time)  # simulate exposure time
         self.ready = True
         return self
 

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -922,8 +922,15 @@ class RunEngine:
 
             for task in asyncio.Task.all_tasks(self.loop):
                 task.cancel()
+            for p in self._plan_stack:
+                try:
+                    p.close()
+                except RuntimeError as e:
+                    print('The plan {!r} tried to yield a value on close.  '
+                          'Please fix your plan.')
             self.loop.stop()
             self.state = 'idle'
+        print('exited run loop')
 
     def _check_for_signals(self):
         # Check for pause requests from keyboard.

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -802,7 +802,7 @@ class RunEngine:
                     # get new message but don't process it yet.
                     try:
                         if self._exception is not None:
-                            # throw the message at the current plan
+                            # throw the exception at the current plan
                             try:
                                 msg = self._plan_stack[-1].throw(
                                     self._exception)

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -859,6 +859,15 @@ class RunEngine:
                           "a hard pause instead.")
                     self.loop.call_soon(self.request_pause, False)
                     print(PAUSE_MSG)
+                except asyncio.CancelledError as e:
+                    # if we are handling this twice, raise and leave the plans
+                    # alone
+                    if self._exception is e:
+                        raise e
+                    # the case where FailedPause, RequestAbort or a coro
+                    # raised error is not already stashed in _exception
+                    if self._exception is None:
+                        self._exception = e
         except (StopIteration, RequestStop):
             self._exit_status = 'success'
             # TODO Is the sleep here necessasry?

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -846,6 +846,10 @@ class RunEngine:
                         coro = self._command_registry[msg.command]
                         response = yield from coro(msg)
                         self._response_stack.append(response)
+                    except asyncio.CancelledError:
+                        # spacial case `CancelledError` and let the outer
+                        # exception block deal with it.
+                        raise
                     except Exception as e:
                         self._exception = e
                         continue

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -934,10 +934,9 @@ class RunEngine:
                     p.close()
                 except RuntimeError as e:
                     print('The plan {!r} tried to yield a value on close.  '
-                          'Please fix your plan.')
+                          'Please fix your plan.'.format(p))
             self.loop.stop()
             self.state = 'idle'
-        print('exited run loop')
 
     def _check_for_signals(self):
         # Check for pause requests from keyboard.

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -849,9 +849,8 @@ class RunEngine:
                     except KeyboardInterrupt:
                         raise
                     except Exception as e:
-                        msg = self._plan_stack[-1].throw(e)
-                        self._plan_stack.append(single_gen(msg))
-                        self._response_stack.append(None)
+                        self._exception = e
+                        continue
                 except KeyboardInterrupt:
                     # This only happens if some external code captures SIGINT
                     # -- overriding the RunEngine -- and then raises instead

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -846,8 +846,6 @@ class RunEngine:
                         coro = self._command_registry[msg.command]
                         response = yield from coro(msg)
                         self._response_stack.append(response)
-                    except KeyboardInterrupt:
-                        raise
                     except Exception as e:
                         self._exception = e
                         continue

--- a/bluesky/tests/conftest.py
+++ b/bluesky/tests/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 from bluesky.run_engine import RunEngine
+from bluesky.examples import Mover, SynGauss
 import pytest
 
 
@@ -10,3 +11,11 @@ def fresh_RE(request):
     RE = RunEngine({}, loop=loop)
     RE.ignore_callback_exceptions = False
     return RE
+
+
+@pytest.fixture(scope='function')
+def motor_det(request):
+    motor = Mover('motor', ['motor'])
+    det = SynGauss('det', motor, 'motor', center=0, Imax=1,
+                   sigma=1, exposure_time=0)
+    return motor, det

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -4,9 +4,7 @@ from bluesky.plans import AdaptiveAbsScanPlan, AbsScanPlan
 from bluesky.callbacks import (CallbackCounter, LiveTable)
 from bluesky.spec_api import mesh
 from bluesky.tests.utils import setup_test_run_engine
-import contextlib
-import sys
-import tempfile
+from bluesky.tests.utils import _print_redirect
 import pytest
 # import numpy as numpy
 RE = setup_test_run_engine()
@@ -112,17 +110,6 @@ def test_unknown_cb_raises():
     # back-compat alias for subscribe_lossless
     with pytest.raises(KeyError):
         RE._subscribe_lossless('not a thing', f)
-
-
-@contextlib.contextmanager
-def _print_redirect():
-    old_stdout = sys.stdout
-    try:
-        fout = tempfile.TemporaryFile(mode='w+', encoding='utf-8')
-        sys.stdout = fout
-        yield fout
-    finally:
-        sys.stdout = old_stdout
 
 
 def test_table():

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -2,7 +2,7 @@ import asyncio
 from collections import defaultdict
 import time as ttime
 import pytest
-from bluesky.run_engine import (RunEngine, RunEngineStateMachine,
+from bluesky.run_engine import (RunEngineStateMachine,
                                 TransitionError, IllegalMessageSequence)
 from bluesky import Msg
 from bluesky.examples import det, Mover, Flyer
@@ -15,7 +15,7 @@ def test_states():
 
 def test_verbose(fresh_RE):
     fresh_RE.verbose = True
-    fresh_RE.verbose == True
+    assert fresh_RE.verbose is True
     # Emit all four kinds of document, exercising the logging.
     fresh_RE([Msg('open_run'), Msg('create'), Msg('read', det), Msg('save'),
               Msg('close_run')])
@@ -23,9 +23,9 @@ def test_verbose(fresh_RE):
 
 def test_reset(fresh_RE):
     fresh_RE([Msg('open_run'), Msg('pause')])
-    assert fresh_RE._run_start_uid != None
+    assert fresh_RE._run_start_uid is not None
     fresh_RE.reset()
-    assert fresh_RE._run_start_uid == None
+    assert fresh_RE._run_start_uid is None
 
 
 def test_running_from_paused_state_raises(fresh_RE):
@@ -97,7 +97,6 @@ def test_stop_motors_and_log_any_errors(fresh_RE):
             stopped[self.name] = True
             raise Exception
 
-
     motor = MoverWithFlag('a', ['a'])
     broken_motor = BrokenMoverWithFlag('b', ['b'])
 
@@ -125,7 +124,6 @@ def test_collect_uncollected_and_log_any_errors(fresh_RE):
         def collect(self):
             super().collect()
             raise Exception
-
 
     flyer1 = DummyFlyerWithFlag()
     flyer1.name = 'flyer1'
@@ -272,7 +270,7 @@ def test_dispatcher_unsubscribe_all(fresh_RE):
         pass
 
     fresh_RE.subscribe('all', cb)
-    assert count_callbacks(fresh_RE) == 5 
+    assert count_callbacks(fresh_RE) == 5
     fresh_RE.dispatcher.unsubscribe_all()
     assert count_callbacks(fresh_RE) == 0
 

--- a/bluesky/tests/utils.py
+++ b/bluesky/tests/utils.py
@@ -1,4 +1,7 @@
 from bluesky.run_engine import RunEngine
+import contextlib
+import tempfile
+import sys
 
 
 def setup_test_run_engine():
@@ -10,3 +13,14 @@ def setup_test_run_engine():
     RE.md['config'] = {'detector_model': 'XYZ', 'pixel_size': 10}
     RE.md['beamline_id'] = 'test_beamline'
     return RE
+
+
+@contextlib.contextmanager
+def _print_redirect():
+    old_stdout = sys.stdout
+    try:
+        fout = tempfile.TemporaryFile(mode='w+', encoding='utf-8')
+        sys.stdout = fout
+        yield fout
+    finally:
+        sys.stdout = old_stdout


### PR DESCRIPTION
 - do we want to try to reset motors on abort? The last commit makes it so that we do, but we might want to replace `CanceledError` with a custom one to catch a la `GeneratorExit` in `finalize_wrapper` to by-pass the clean up
 - we probably want to re-think how pausing works.  Instead of stopping the loop in `request_pause` we stash an exception in `self._exception` and then once it bounces through the plans and then stop from with in the `_run` co-routine 
 - `_exception` can now get clobbered a couple of ways, should maybe make it a stack?