### PR TITLE
MNT: handle switching state to 'running' carefully

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -550,7 +550,6 @@ class RunEngine:
 
         self._clear_call_cache()
         self._clear_run_cache()  # paranoia, in case of previous bad exit
-        self.state = 'running'
 
         for name, funcs in normalize_subs_input(subs).items():
             for func in funcs:
@@ -788,6 +787,7 @@ class RunEngine:
         """
         self._reason = ''
         try:
+            self.state = 'running'
             while True:
                 try:
                     # This 'yield from' must be here to ensure that this

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -272,7 +272,7 @@ def test_dispatcher_unsubscribe_all(fresh_RE):
         pass
 
     fresh_RE.subscribe('all', cb)
-    assert count_callbacks(fresh_RE) == 5 
+    assert count_callbacks(fresh_RE) == 5
     fresh_RE.dispatcher.unsubscribe_all()
     assert count_callbacks(fresh_RE) == 0
 
@@ -335,6 +335,13 @@ def test_pause_resume_devices(fresh_RE):
     fresh_RE.resume()
     assert 'dummy' in paused
     assert 'dummy' in resumed
+
+
+def test_bad_call_args(fresh_RE):
+    RE = fresh_RE
+    with pytest.raises(Exception):
+        RE(53)
+    assert RE.state == 'idle'
 
 
 def test_record_interruptions(fresh_RE):


### PR DESCRIPTION
Move the idle -> running transition into `_run` to prevent the case
where the RE would be in a running state, but the code between where it
was flipped and where the `_run` coro was actually started raised.

This left the RE in a state where it was 'running', but had to task,
thus no part of the API (which relies on the finally block of the coro
to flip the RE back to idle) would be able to return the RE to an idle state.

attn @klauer I think this is the issue Yong had.

@cmazzoli @ambarb I think this also fixes an issue you have seen.