### PR TITLE
Enh re exception handling

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -858,8 +858,6 @@ class RunEngine:
                             else:
                                 raise
                         except Exception as e:
-                            if self._exception is e:
-                                raise
                             self._exception = e
                             continue
 

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -5,7 +5,6 @@ import logging
 from warnings import warn
 from itertools import count, tee
 from collections import deque, defaultdict, ChainMap
-import uuid
 import signal
 from enum import Enum
 import functools
@@ -16,7 +15,6 @@ from event_model import DocumentNames, schemas
 from super_state_machine.machines import StateMachine
 from super_state_machine.extras import PropertyMachine
 from super_state_machine.errors import TransitionError
-import numpy as np
 
 from .utils import (CallbackRegistry, SignalHandler, normalize_subs_input,
                     AsyncInput, new_uid, sanitize_np)

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -716,6 +716,7 @@ class RunEngine:
         if not self.resumable:
             print("No checkpoint; cannot suspend. Aborting...")
             self._exception = FailedPause()
+            self._task.cancel()
         else:
             print("Suspending....To get prompt hit Ctrl-C twice to pause.")
             if justification is not None:
@@ -781,6 +782,7 @@ class RunEngine:
         print("Stopping...")
         self._interrupted = True
         self._exception = RequestStop()
+        self._task.cancel()
         if self.state == 'paused':
             self._resume_event_loop()
 
@@ -1688,7 +1690,7 @@ class RunEngine:
             a status object that has failed
         """
         self._exception = FailedStatus(ret)
-        # self._task.cancel()  # TODO -- should we kill ASAP?
+        self._task.cancel()
 
     @asyncio.coroutine
     def _sleep(self, msg):

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -610,9 +610,9 @@ class RunEngine:
         """
         # The state machine does not capture the whole picture.
         if not self.state.is_paused:
-            raise RuntimeError("The RunEngine is the {0} state. You can only "
-                               "resume for the paused state."
-                               "".format(self.state))
+            raise TransitionError("The RunEngine is the {0} state. "
+                                  "You can only resume for the paused state."
+                                  "".format(self.state))
 
         self._interrupted = False
         self._record_interruption('resume')

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -31,7 +31,7 @@ def expiring_function(func, loop, *args, **kwargs):
     """
     If timeout has not occurred, call func(*args, **kwargs).
 
-    This is meant to used with the event loop's run_in_exector
+    This is meant to used with the event loop's run_in_executor
     method. Outside that context, it doesn't make any sense.
     """
     def dummy(start_time, timeout):
@@ -103,17 +103,17 @@ class RunEngine:
                              'close_run']
 
     def __init__(self, md=None, *, loop=None, md_validator=None):
-        """
-        The Run Engine execute messages and emits Documents.
+        """The Run Engine execute messages and emits Documents.
 
         Parameters
         ----------
         md : dict-like, optional
-            The default is a standard Python dictionary, but fancier objects
-            can be used to store long-term history and persist it between
-            sessions. The standard configuration instantiates a Run Engine with
-            historydict.HistoryDict, a simple interface to a sqlite file. Any object
-            supporting `__getitem__`, `__setitem__`, and `clear` will work.
+            The default is a standard Python dictionary, but fancier
+            objects can be used to store long-term history and persist
+            it between sessions. The standard configuration
+            instantiates a Run Engine with historydict.HistoryDict, a
+            simple interface to a sqlite file. Any object supporting
+            `__getitem__`, `__setitem__`, and `clear` will work.
 
         loop : asyncio event loop
             e.g., ``asyncio.get_event_loop()`` or ``asyncio.new_event_loop()``
@@ -136,7 +136,7 @@ class RunEngine:
             number of seconds before Events yet unprocessed by callbacks are
             skipped
         ignore_callback_exceptions
-            boolean, True by default
+            Boolean, True by default
 
         msg_hook
             callable that receives all messages before they are processed
@@ -161,6 +161,7 @@ class RunEngine:
             Teach the Run Engine a new Message command.
         unregister_command
             Undo register_command.
+
         """
         if loop is None:
             loop = asyncio.get_event_loop()
@@ -211,7 +212,7 @@ class RunEngine:
         self._descriptors = dict()  # cache of {(name, objs_frozen_set): uid}
         self._monitor_params = dict()  # cache of {obj: (cb, kwargs)}
         self._sequence_counters = dict()  # a seq_num counter per Descriptor
-        self._teed_sequence_counters = dict()  # for if we redo datapoints
+        self._teed_sequence_counters = dict()  # for if we redo data-points
         self._suspenders = set()  # set holding suspenders
         self._groups = defaultdict(set)  # sets of objs to wait for
         self._temp_callback_ids = set()  # ids from CallbackRegistry
@@ -264,7 +265,7 @@ class RunEngine:
 
         # private dispatcher of critical callbacks
         # which get a lossless Event stream and abort a run if they raise
-        # Ths subscribe/unsubscribe are exposed through the RunEngine
+        # The subscribe/unsubscribe are exposed through the RunEngine
         # as subscribe_lossless and unsubscribe_lossless, defined below
         # to provide special docstrings.
         self._lossless_dispatcher = Dispatcher()
@@ -528,7 +529,7 @@ class RunEngine:
             - a dictionary, mapping specific subscriptions to callables or
               lists of callables; valid keys are {'all', 'start', 'stop',
               'event', 'descriptor'}
-        raise_if_interrupted : boolean
+        raise_if_interrupted : bool
             If the RunEngine is called from inside a script or a function, it
             can be useful to make it raise an exception to halt further
             execution of the script after a pause or a stop. If True, these
@@ -835,7 +836,7 @@ class RunEngine:
             while True:
                 try:
                     # This 'yield from' must be here to ensure that
-                    # this coroutine breaks out of its current bevior
+                    # this coroutine breaks out of its current behavior
                     # before trying to get the next message from the
                     # top of the generator stack in case there has
                     # been a pause requested.  Without this the next
@@ -861,7 +862,7 @@ class RunEngine:
                             if len(self._plan_stack):
                                 self._exception = e
                                 continue
-                            # no plans left and still an UN-handled
+                            # no plans left and still an unhandled exception
                             # re-raise to exit the infinite loop
                             else:
                                 raise
@@ -925,7 +926,7 @@ class RunEngine:
                         # exceptions (coming in via throw) can be
                         # raised
                         response = yield from coro(msg)
-                    # spacial case `CancelledError` and let the outer
+                    # special case `CancelledError` and let the outer
                     # exception block deal with it.
                     except asyncio.CancelledError:
                         raise
@@ -961,12 +962,12 @@ class RunEngine:
                     pending_cancel_exception = e
         except (StopIteration, RequestStop):
             self._exit_status = 'success'
-            # TODO Is the sleep here necessasry?
+            # TODO Is the sleep here necessary?
             yield from asyncio.sleep(0.001, loop=self.loop)
         except (FailedPause, RequestAbort, asyncio.CancelledError,
                 PlanHalt):
             self._exit_status = 'abort'
-            # TODO Is the sleep here necessasry?
+            # TODO Is the sleep here necessary?
             yield from asyncio.sleep(0.001, loop=self.loop)
             self.log.error("Run aborted")
             self.log.error("%r", self._exception)
@@ -1029,7 +1030,7 @@ class RunEngine:
                           'Please fix your plan.'.format(p))
             self.loop.stop()
             self.state = 'idle'
-        # if the task was canceled
+        # if the task was cancelled
         if pending_cancel_exception is not None:
             raise pending_cancel_exception
 
@@ -1064,7 +1065,7 @@ class RunEngine:
                         ttime.sleep(0.05)
                         if self._sigint_handler.count > 2:
                             self.log.debug("RunEngine detected a third "
-                                            "SIGINT -- aborting.")
+                                           "SIGINT -- aborting.")
                             self.loop.call_soon(self.abort, "SIGINT (Ctrl+C)")
                             break
                     else:
@@ -1491,11 +1492,11 @@ class RunEngine:
     @asyncio.coroutine
     def _complete(self, msg):
         """
-        Tell a flyer, 'stop collecting, whenver you are ready'.
+        Tell a flyer, 'stop collecting, whenever you are ready'.
 
         The flyer returns a status object. Some flyers respond to this
         command by stopping collection and returning a finished status
-        object immedately. Other flyers finish their given course and
+        object immediately. Other flyers finish their given course and
         finish whenever they finish, irrespective of when this command is
         issued.
 
@@ -1614,7 +1615,7 @@ class RunEngine:
         Also, note that the device has been touched so it can be stopped upon
         exit.
 
-        Expected messgage object is
+        Expected message object is
 
             Msg('set', obj, *args, **kwargs)
 
@@ -1731,7 +1732,7 @@ class RunEngine:
             Msg('pause', defer=False, name=None, callback=None)
 
         See RunEngine.request_pause() docstring for explanation of the three
-        keyword arugments in the `Msg` signature
+        keyword arguments in the `Msg` signature
         """
         self.request_pause(*msg.args, **msg.kwargs)
 
@@ -1752,7 +1753,7 @@ class RunEngine:
 
         if self._deferred_pause_requested:
             # We are at a checkpoint; we are done deferring the pause.
-            # Give the _check_for_signals courtine time to look for
+            # Give the _check_for_signals coroutine time to look for
             # additional SIGINTs that would trigger an abort.
             yield from asyncio.sleep(0.5, loop=self.loop)
             self.request_pause(defer=False)
@@ -1894,7 +1895,7 @@ class RunEngine:
         See the docstring of bluesky.run_engine.Dispatcher.subscribe() for more
         information.
         """
-        self.log.debug("Adding subsription %r", msg)
+        self.log.debug("Adding subscription %r", msg)
         _, obj, args, kwargs = msg
         token = self.subscribe(*args, **kwargs)
         self._temp_callback_ids.add(token)
@@ -1927,7 +1928,7 @@ class RunEngine:
     @asyncio.coroutine
     def _input(self, msg):
         """
-        Process a 'input' Msg. Excpected Msg:
+        Process a 'input' Msg. Expected Msg:
 
             Msg('input', None)
             Msg('input', None, prompt='>')  # customize prompt
@@ -2087,8 +2088,8 @@ class PlanHalt(GeneratorExit):
 
 
 def _default_md_validator(md):
-    if 'sample' in md and not (hasattr(md['sample'], 'keys')
-                                or isinstance(md['sample'], str)):
+    if 'sample' in md and not (hasattr(md['sample'], 'keys') or
+                               isinstance(md['sample'], str)):
         raise ValueError(
             "You specified 'sample' metadata. We give this field special "
             "significance in order to make your data easily searchable. "

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -847,14 +847,18 @@ class RunEngine:
                                         raise
                         else:
                             resp = self._response_stack.pop()
-                            msg = self._plan_stack[-1].send(resp)
+                            try:
+                                msg = self._plan_stack[-1].send(resp)
+                            except StopIteration:
+                                self._plan_stack.pop()
+                                if len(self._plan_stack):
+                                    continue
+                                else:
+                                    raise
 
                     except StopIteration:
-                        self._plan_stack.pop()
-                        if len(self._plan_stack):
-                            continue
-                        else:
-                            raise
+                        raise
+
                     # If we are here one of the plans handled the exception
                     # and wants to do something with it
                     self._exception = None

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -715,6 +715,7 @@ class RunEngine:
         """
         if not self.resumable:
             print("No checkpoint; cannot suspend. Aborting...")
+            self._interrupted = True
             self._exception = FailedPause()
             self._task.cancel()
         else:

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -832,21 +832,17 @@ class RunEngine:
                             msg = self._plan_stack[-1].throw(
                                 self._exception)
                         except Exception as e:
-                            # deal with the case where the top
-                            # plan is a re-wind/suspender injected
-                            # plan, all plans in stack get a
-                            # chance to take a bite at this apple.
-
-                            # if the exact same exception comes
-                            # back up, then the plan did not
-                            # handle it and the next plan gets to
-                            # try.
-                            if e is self._exception:
-                                self._plan_stack.pop()
-                                if len(self._plan_stack):
-                                    continue
-                                else:
-                                    raise
+                            # The current plan did not handle it,
+                            # maybe the next plan (if any) would like
+                            # to try
+                            self._plan_stack.pop()
+                            if len(self._plan_stack):
+                                self._exception = e
+                                continue
+                            # no plans left and still an UN-handled
+                            # re-raise to exit the infinite loop
+                            else:
+                                raise
                     else:
                         resp = self._response_stack.pop()
                         try:

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -906,7 +906,8 @@ class RunEngine:
             self._exit_status = 'success'
             # TODO Is the sleep here necessasry?
             yield from asyncio.sleep(0.001, loop=self.loop)
-        except (FailedPause, RequestAbort, asyncio.CancelledError):
+        except (FailedPause, RequestAbort, asyncio.CancelledError,
+                GeneratorExit):
             self._exit_status = 'abort'
             # TODO Is the sleep here necessasry?
             yield from asyncio.sleep(0.001, loop=self.loop)

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -857,7 +857,16 @@ class RunEngine:
                                 continue
                             else:
                                 raise
+                        # Any other exception that comes out of the plan
                         except Exception as e:
+                            # pop the dead plan, stash the exception and
+                            # go to the top of the loop
+                            self._plan_stack.pop()
+                            if len(self._plan_stack):
+                                continue
+                            # or reraise to get out of the infinite loop
+                            else:
+                                raise
                             self._exception = e
                             continue
 

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -808,6 +808,7 @@ class RunEngine:
         - Try to remove any monitoring subscriptions left on by the plan.
         - If interrupting the middle of a run, try to emit a RunStop document.
         """
+        is_canceled = None
         self._reason = ''
         try:
             self.state = 'running'
@@ -937,6 +938,7 @@ class RunEngine:
                     # raised error is not already stashed in _exception
                     if self._exception is None:
                         self._exception = e
+                    is_canceled = e
         except (StopIteration, RequestStop):
             self._exit_status = 'success'
             # TODO Is the sleep here necessasry?
@@ -1007,6 +1009,9 @@ class RunEngine:
                           'Please fix your plan.'.format(p))
             self.loop.stop()
             self.state = 'idle'
+        # if the task was canceled
+        if is_canceled is not None:
+            raise is_canceled
 
     def _check_for_signals(self):
         # Check for pause requests from keyboard.

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -843,6 +843,10 @@ class RunEngine:
                             # re-raise to exit the infinite loop
                             else:
                                 raise
+                        # clear the stashed exception, the top plan
+                        # handled it.
+                        else:
+                            self._exception = None
                     else:
                         resp = self._response_stack.pop()
                         try:
@@ -857,7 +861,6 @@ class RunEngine:
                             self._exception = e
                             continue
 
-                    self._exception = None
                     if self.msg_hook is not None:
                         self.msg_hook(msg)
                     self._objs_seen.add(msg.obj)

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -794,7 +794,7 @@ class RunEngine:
             raise TransitionError("RunEngine is already idle.")
         print("HALTING...")
         self._interrupted = True
-        self._exception = GeneratorExit()
+        self._exception = PlanHalt()
         self._task.cancel()
         if self.state == 'paused':
             self._resume_event_loop()
@@ -959,7 +959,7 @@ class RunEngine:
             # TODO Is the sleep here necessasry?
             yield from asyncio.sleep(0.001, loop=self.loop)
         except (FailedPause, RequestAbort, asyncio.CancelledError,
-                GeneratorExit):
+                PlanHalt):
             self._exit_status = 'abort'
             # TODO Is the sleep here necessasry?
             yield from asyncio.sleep(0.001, loop=self.loop)
@@ -2074,6 +2074,10 @@ Pro Tip: Next time, if you want to abort, tap Ctrl+C three times quickly.
 
 
 class InvalidCommand(KeyError):
+    pass
+
+
+class PlanHalt(GeneratorExit):
     pass
 
 

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -422,7 +422,9 @@ class RunEngine:
         self._record_interruption('pause')
         if not self.resumable:
             # cannot resume, so we cannot pause.  Abort the scan
-            print("No checkpoint; cannot pause. Aborting...")
+            print("No checkpoint; cannot pause.")
+            print("Aborting: running cleanup and marking "
+                  "exit_status as 'abort'...")
             self._exception = FailedPause()
             self._task.cancel()
             for task in self._failed_status_tasks:
@@ -712,7 +714,9 @@ class RunEngine:
             explanation of why the suspension has been requested
         """
         if not self.resumable:
-            print("No checkpoint; cannot suspend. Aborting...")
+            print("No checkpoint; cannot suspend.")
+            print("Aborting: running cleanup and marking "
+                  "exit_status as 'abort'...")
             self._interrupted = True
             self._exception = FailedPause()
             self._task.cancel()
@@ -762,7 +766,8 @@ class RunEngine:
         """
         if self.state.is_idle:
             raise TransitionError("RunEngine is already idle.")
-        print("Aborting....")
+        print("Aborting: running cleanup and marking "
+              "exit_status as 'abort'...")
         self._interrupted = True
         self._reason = reason
         self._exception = RequestAbort()
@@ -778,7 +783,8 @@ class RunEngine:
         """
         if self.state.is_idle:
             raise TransitionError("RunEngine is already idle.")
-        print("Stopping...")
+        print("Stopping: running cleanup and marking exit_status "
+              "as 'success'...")
         self._interrupted = True
         self._exception = RequestStop()
         self._task.cancel()
@@ -790,7 +796,8 @@ class RunEngine:
         '''
         if self.state.is_idle:
             raise TransitionError("RunEngine is already idle.")
-        print("HALTING...")
+        print("Halting: skipping cleanup and marking exit_status as "
+              "'abort'...")
         self._interrupted = True
         self._exception = PlanHalt()
         self._task.cancel()

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -855,6 +855,11 @@ class RunEngine:
                                     continue
                                 else:
                                     raise
+                            except Exception as e:
+                                if self._exception is e:
+                                    raise
+                                self._exception = e
+                                continue
 
                     except StopIteration:
                         raise

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -894,13 +894,15 @@ class RunEngine:
                         # exceptions (coming in via throw) can be
                         # raised
                         response = yield from coro(msg)
-                        self._response_stack.append(response)
                     except asyncio.CancelledError:
                         # spacial case `CancelledError` and let the outer
                         # exception block deal with it.
                         raise
                     except Exception as e:
                         self._exception = e
+                        continue
+                    else:
+                        self._response_stack.append(response)
                         continue
                 except KeyboardInterrupt:
                     # This only happens if some external code captures SIGINT

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -868,12 +868,11 @@ class RunEngine:
                             # go to the top of the loop
                             self._plan_stack.pop()
                             if len(self._plan_stack):
+                                self._exception = e
                                 continue
                             # or reraise to get out of the infinite loop
                             else:
                                 raise
-                            self._exception = e
-                            continue
 
                     # if we have a message hook, call it
                     if self.msg_hook is not None:
@@ -2015,6 +2014,7 @@ def _rearrange_into_parallel_dicts(readings):
         timestamps[key] = payload['timestamp']
     return data, timestamps
 
+
 class RequestAbort(Exception):
     pass
 
@@ -2052,8 +2052,10 @@ resume()  --> will resume the scan
 Pro Tip: Next time, if you want to abort, tap Ctrl+C three times quickly.
 """
 
+
 class InvalidCommand(KeyError):
     pass
+
 
 def _default_md_validator(md):
     if 'sample' in md and not (hasattr(md['sample'], 'keys')

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -823,7 +823,7 @@ class RunEngine:
         - Try to remove any monitoring subscriptions left on by the plan.
         - If interrupting the middle of a run, try to emit a RunStop document.
         """
-        is_canceled = None
+        pending_cancel_exception = None
         self._reason = ''
         try:
             self.state = 'running'
@@ -953,7 +953,7 @@ class RunEngine:
                     # raised error is not already stashed in _exception
                     if self._exception is None:
                         self._exception = e
-                    is_canceled = e
+                    pending_cancel_exception = e
         except (StopIteration, RequestStop):
             self._exit_status = 'success'
             # TODO Is the sleep here necessasry?
@@ -1025,8 +1025,8 @@ class RunEngine:
             self.loop.stop()
             self.state = 'idle'
         # if the task was canceled
-        if is_canceled is not None:
-            raise is_canceled
+        if pending_cancel_exception is not None:
+            raise pending_cancel_exception
 
     def _check_for_signals(self):
         # Check for pause requests from keyboard.

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -786,6 +786,18 @@ class RunEngine:
         if self.state == 'paused':
             self._resume_event_loop()
 
+    def halt(self):
+        '''Stop the running plan and do not allow the plan a chance to clean up
+        '''
+        if self.state.is_idle:
+            raise TransitionError("RunEngine is already idle.")
+        print("HALTING...")
+        self._interrupted = True
+        self._exception = GeneratorExit()
+        self._task.cancel()
+        if self.state == 'paused':
+            self._resume_event_loop()
+
     def _stop_movable_objects(self):
         "Call obj.stop() for all objects we have moved. Log any exceptions."
         for obj in self._movable_objs_touched:

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -889,3 +889,12 @@ def test_prompt_stop(fresh_RE, cancel_func):
     assert .1 < stop - start < .2
     assert except_hit
     assert [m.command for m in m_coll.msgs] == ['sleep', 'null']
+
+
+@pytest.mark.parametrize('stop_func', [lambda RE: RE.stop(),
+                                       lambda RE: RE.abort(),
+                                       lambda RE: RE.halt(),
+                                       lambda RE: RE.request_pause()])
+def test_bad_from_idle_transitions(fresh_RE, stop_func):
+    with pytest.raises(TransitionError):
+        stop_func(fresh_RE)

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -536,7 +536,7 @@ def test_cleanup_pathological_plans(fresh_RE, motor_det, plan):
         if RE.state == 'paused':
             assert motor.position != 1024
             RE.resume()
-    except:
+    except Exception:
         pass
     assert motor.position == 1024
 
@@ -608,7 +608,7 @@ def test_exception_cascade_REside(fresh_RE):
             yield Msg('null')
         try:
             yield Msg('pause')
-        except:
+        except Exception:
             except_hit = True
             raise
 
@@ -638,7 +638,7 @@ def test_exception_cascade_planside(fresh_RE):
             yield Msg('null')
         try:
             yield Msg('pause')
-        except:
+        except Exception:
             except_hit = True
             raise
 

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -573,7 +573,7 @@ def test_invalid_plan(fresh_RE, motor_det):
 
     def pre_suspend_plan():
         yield Msg('set', motor, 5)
-        raise RuntimeError()
+        raise GeneratorExit()
 
     def make_plan():
         return patho_finalize_wrapper(base_plan(motor),
@@ -584,7 +584,7 @@ def test_invalid_plan(fresh_RE, motor_det):
         RE.request_suspend(None, pre_plan=pre_suspend_plan())
         try:
             RE.resume()
-        except RuntimeError:
+        except GeneratorExit:
             pass
 
     fout.seek(0)

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -891,10 +891,11 @@ def test_prompt_stop(fresh_RE, cancel_func):
     assert [m.command for m in m_coll.msgs] == ['sleep', 'null']
 
 
-@pytest.mark.parametrize('stop_func', [lambda RE: RE.stop(),
-                                       lambda RE: RE.abort(),
-                                       lambda RE: RE.halt(),
-                                       lambda RE: RE.request_pause()])
-def test_bad_from_idle_transitions(fresh_RE, stop_func):
+@pytest.mark.parametrize('change_func', [lambda RE: RE.stop(),
+                                         lambda RE: RE.abort(),
+                                         lambda RE: RE.halt(),
+                                         lambda RE: RE.request_pause(),
+                                         lambda RE: RE.resume()])
+def test_bad_from_idle_transitions(fresh_RE, change_func):
     with pytest.raises(TransitionError):
-        stop_func(fresh_RE)
+        change_func(fresh_RE)

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -678,7 +678,7 @@ def test_sideband_cancel(fresh_RE):
 
     RE(scan)
     assert RE.state == 'idle'
-
+    assert RE._task.cancelled()
     stop = ttime.time()
 
     assert .5 < (stop - start) < 2

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -552,11 +552,13 @@ def test_finalizer_closeable():
     plan.close()
 
 
-def test_invalid_plan(fresh_RE, motor_det):
+def test_invalid_generator(fresh_RE, motor_det):
 
     RE = fresh_RE
     motor, det = motor_det
 
+    # this is not a valid generator as it will try to yield if it
+    # is throw a GeneratorExit
     def patho_finalize_wrapper(plan, post):
         try:
             yield from plan

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -857,7 +857,7 @@ def test_halt_async(fresh_RE):
     start = ttime.time()
     RE(sleeping_plan())
     stop = ttime.time()
-    assert .1 < stop - start < .2
+    assert .09 < stop - start < .2
     assert not except_hit
     assert [m.command for m in m_coll.msgs] == ['sleep']
 
@@ -886,7 +886,7 @@ def test_prompt_stop(fresh_RE, cancel_func):
     stop = ttime.time()
     if RE.state != 'idle':
         RE.abort()
-    assert .1 < stop - start < .2
+    assert 0.09 < stop - start < .2
     assert except_hit
     assert [m.command for m in m_coll.msgs] == ['sleep', 'null']
 


### PR DESCRIPTION
This still needs 

  - more evil tests
  - There is now a path to `halt` and for a plan to kill the RE dead as `GeneratorExit` is not a sub-class of `Exception` for exactly this reason.