### PR TITLE
Catch up API changes documentation and fix some docstrings.

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -807,6 +807,15 @@ def unsubscribe(token):
 
 
 def run_wrapper(plan, *, md=None):
+    """Enclose in 'open_run' and 'close_run' messages.
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        a generator, list, or similar containing `Msg` objects
+    md : dict, optional
+        metadata to be passed into the 'open_run' message
+    """
     yield from open_run(md)
     yield from plan
     yield from close_run()
@@ -1059,12 +1068,13 @@ def event_context(plan_stack, name='primary'):
 def rewindable_wrapper(plan, rewindable):
     '''Toggle the 'rewindable' state of the RE
 
-    Only strictly
+    Allow or disallow rewinding during the processing of the wrapped messages.
+    Then restore the initial state (rewindable or not rewindable).
 
     Parameters
     ----------
     plan : generator
-        The plan to wrap in a 'rewindable' contextlib
+        The plan to wrap in a 'rewindable' or 'not rewindable' context
     rewindable : bool
 
     '''

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -1,6 +1,66 @@
 API Changes
 ===========
 
+v0.5.4
+------
+
+Enhancements
+^^^^^^^^^^^^
+* Address the situation where plan "rewinding" after a pause or suspension
+  interacted badly with some devices. There are now three ways to temporarily
+  turn off rewinding: a Msg with a new 'rewindable' command; a special
+  attribute on the device that the ``trigger_and_read`` plan looks for;
+  and a special exception that devices can raise when their ``pause`` method
+  is called. All three of these features should be considered experimental.
+  They will likely be consolidated in the future once their usage is tested
+  in the wild.
+* Add new plan wrappers and decorators: ``inject_md_wrapper``, ``run_wrapper``,
+  ``rewindable_wrapper``.
+
+Bug Fixes
+^^^^^^^^^
+* Fix bug where RUnEngine was put in the "running" state, encountered an
+  error before starting the ``_run`` coroutine, and thus never switch back to
+  "idle."
+* Ensure that plans are closed correctly and that, if they fail to close
+  themselves, a warning is printed.
+* Allow plan to run its cleanup messages (``finalize``) when the RunEngine is
+  stopped or aborted.
+* When an exception is raised, give each plan in the plan stack an opportunity
+  to handle it. If it is handled, carry on.
+* The SPEC-style ``tw`` was not passing its parameters through to the
+  underlying ``tweak`` plan.
+
+Cleanup
+^^^^^^^
+* Reduce unneeded usage of ``bluesky.plans.single_gen``.
+* Don't emit create/save messages with no reads in between.
+
+v0.5.3
+------
+
+API Changes
+^^^^^^^^^^^
+* ``LiveTable`` only displays data from one event stream.
+* Remove used global state attribute ``gs.COUNT_TIME``.
+
+Bug Fixes
+^^^^^^^^^
+* Fix "infinite count", ``ct(num=None)``.
+* Allow the same data keys to be present in different event streams. But, as
+  before, a given data key can only appear once per event.
+* Make SPEC-style plan ``ct`` implement baseline readings, referring to
+  ``gs.BASELINE_DETS``.
+* Upon resuming after a deferred pause, clear the deferred pause request.
+* Make ``bluesky.utils.register_transform`` character configurable.
+
+v0.5.2
+------
+* Plans were completely refactored. The API of the exist plans is supported
+  for back-compatibility. See plans documentation to review new capabilities.
+* SPEC-style plans are now proper generators, not bound to the RunEngine.
+
+
 v0.5.0
 ------
 


### PR DESCRIPTION
When bluesky was moving fast, we communicated API changes by word of mouth. This is an attempt to put us on track with format API changes documentation for every version.

attn @hhslepicka @yugangzhang @chiahaoliu 