### PR TITLE
FIX: separate_devices iteration bug

### DIFF
--- a/bluesky/tests/test_devices.py
+++ b/bluesky/tests/test_devices.py
@@ -156,6 +156,20 @@ def test_overlapping_read(fresh_RE):
               [Msg('close_run')]), collect)
     assert len(docs['descriptor']) == 1
 
+    docs = defaultdict(list)
+    fresh_RE(([Msg('open_run')] +
+              list(trigger_and_read([dcm.th, dcm.x, dcm])) +
+              list(trigger_and_read([dcm])) +
+              [Msg('close_run')]), collect)
+    assert len(docs['descriptor']) == 1
+
+    docs = defaultdict(list)
+    fresh_RE(([Msg('open_run')] +
+              list(trigger_and_read([dcm, dcm.th, dcm.x])) +
+              list(trigger_and_read([dcm])) +
+              [Msg('close_run')]), collect)
+    assert len(docs['descriptor']) == 1
+
 
 @requires_ophyd
 def test_read_clash(fresh_RE):

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -569,7 +569,7 @@ def separate_devices(devices):
     """
     result = []
     for det in devices:
-        for existing_det in result:
+        for existing_det in result[:]:
             if existing_det in ancestry(det):
                 # known issue: here we assume that det is in the read_attrs
                 # of existing_det -- to be addressed after plans.py refactor


### PR DESCRIPTION
Removing an item during a list traversal is a no-no, @tacaswell 