### PR TITLE
ENH: return values from co-routines/generators

### DIFF
--- a/bluesky/global_state.py
+++ b/bluesky/global_state.py
@@ -2,7 +2,7 @@
 This module creates a singleton object to store settings such as which
 RunEngine and detectors the simple scan interface should invoke.
 """
-from traitlets import HasTraits, TraitType, Unicode, List, Float, Bool, link
+from traitlets import HasTraits, TraitType, Unicode, List, Bool, link, Dict
 import itertools
 from collections import Iterable
 from bluesky import RunEngine
@@ -130,6 +130,8 @@ class GlobalState(HasTraits):
     PLOT_Y = Unicode()
     OVERPLOT = Bool(True)
     MD_TIME_KEY = Unicode('count_time')
+    PS_CONFIG = Dict(default_value=dict(edge_count=None))
+    SUB_FACTORIES = Dict(default_value={})
 
 
 gs = GlobalState()  # a singleton instance

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -799,9 +799,10 @@ def run_wrapper(plan, *, md=None):
     md : dict, optional
         metadata to be passed into the 'open_run' message
     """
-    yield from open_run(md)
+    ret = yield from open_run(md)
     yield from plan
     yield from close_run()
+    return ret
 
 
 def subs_wrapper(plan, subs):

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1319,7 +1319,7 @@ def stage_context(plan_stack, devices):
     `bluesky.plans.lazily_stage`
     """
     # Resolve unique devices, avoiding redundant staging.
-    devices = separate_devices([device.root for device in devices])
+    devices = separate_devices(device.root for device in devices)
 
     def stage():
         # stage devices explicitly passed to 'devices' argument
@@ -1335,7 +1335,7 @@ def stage_context(plan_stack, devices):
 
 
 def stage_wrapper(plan, devices):
-    devices = separate_devices([device.root for device in devices])
+    devices = separate_devices(device.root for device in devices)
 
     def stage_devices():
         for d in devices:

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -52,8 +52,7 @@ def make_decorator(wrapper):
 
 
 def planify(func):
-    """
-    Turn a function that returns a list of generators into a coroutine.
+    """Turn a function that returns a list of generators into a coroutine.
 
     Parameters
     ----------
@@ -64,8 +63,10 @@ def planify(func):
     Returns
     -------
     gen : generator
-        a single generator that yields messages. The return value from the generator
-        is the return of the last plan in the plan stack.
+        a single generator that yields messages. The return value from
+        the generator is the return of the last plan in the plan
+        stack.
+
     """
     @wraps(func)
     def wrapped(*args, **kwargs):

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2541,7 +2541,7 @@ def tweak(detector, target_field, motor, step, *, md=None):
     md : dict, optional
         metadata
     """
-    prompt_str = '{0}, {1:.3}, {2}, ({3}) '
+    prompt_str = '{0}, {1:.3}, {2:.3}, ({3}) '
 
     if md is None:
         md = {}
@@ -2579,7 +2579,8 @@ def tweak(detector, target_field, motor, step, *, md=None):
             reading = yield Msg('read', d)
             val = reading[target_field]['value']
             yield Msg('save')
-            prompt = prompt_str.format(motor.name, pos, val, step)
+            prompt = prompt_str.format(motor.name, float(pos),
+                                       float(val), step)
             new_step = yield Msg('input', prompt=prompt)
             if new_step:
                 try:

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1345,7 +1345,7 @@ def stage_wrapper(plan, devices):
             yield Msg('stage', d)
 
     def unstage_devices():
-        for d in devices:
+        for d in reversed(devices):
             yield Msg('unstage', d)
 
     def inner():

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1755,6 +1755,7 @@ fly_during_decorator = make_decorator(fly_during_wrapper)
 monitor_during_decorator = make_decorator(monitor_during_wrapper)
 inject_md_decorator = make_decorator(inject_md_wrapper)
 run_decorator = make_decorator(run_wrapper)
+configure_count_time_decorator = make_decorator(configure_count_time_wrapper)
 
 
 def count(detectors, num=1, delay=None, *, md=None):

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1926,8 +1926,8 @@ def relative_list_scan(detectors, motor, steps, *, per_step=None, md=None):
         md = {}
     md = ChainMap(md, {'plan_name': 'relative_list_scan'})
 
-    @reset_positions_decorator()
-    @relative_set_decorator()
+    @reset_positions_decorator([motor])
+    @relative_set_decorator([motor])
     def inner_relative_list_scan():
         return (yield from list_scan(detectors, motor, steps,
                                      per_step=per_step, md=md))
@@ -2507,9 +2507,11 @@ def relative_outer_product_scan(detectors, *args, per_step=None, md=None):
     if md is None:
         md = {}
     md = ChainMap(md, {'plan_name': 'relative_outer_product_scan'})
+    chunk_args = list(plan_patterns.chunk_outer_product_args(args))
+    motors = [m[0] for m in chunk_args]
 
-    @reset_positions_decorator()
-    @relative_set_decorator()
+    @reset_positions_decorator(motors)
+    @relative_set_decorator(motors)
     def inner_relative_outer_product_scan():
         return (yield from outer_product_scan(detectors, *args,
                                               per_step=per_step, md=md))
@@ -2546,9 +2548,11 @@ def relative_inner_product_scan(detectors, num, *args, per_step=None, md=None):
     if md is None:
         md = {}
     md = ChainMap(md, {'plan_name': 'relative_inner_product_scan'})
+    chunk_args = list(plan_patterns.chunk_outer_product_args(args))
+    motors = [m[0] for m in chunk_args]
 
-    @reset_positions_decorator()
-    @relative_set_decorator()
+    @reset_positions_decorator(motors)
+    @relative_set_decorator(motors)
     def inner_relative_inner_product_scan():
         return (yield from inner_product_scan(detectors, num, *args,
                                               per_step=per_step, md=md))

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -62,16 +62,16 @@ def planify(func):
     Returns
     -------
     gen : generator
-        a single generator that yields messages
+        a single generator that yields messages. The return value from the generator
+        is the return of the last plan in the plan stack.
     """
     @wraps(func)
     def wrapped(*args, **kwargs):
         gen_stack = func(*args, **kwargs)
-        ret = []
+        ret = None
         for g in gen_stack:
-            res = yield from g
-            ret.append(res)
-        return tuple(ret)
+            ret = yield from g
+        return ret
 
     return wrapped
 
@@ -799,10 +799,10 @@ def run_wrapper(plan, *, md=None):
     md : dict, optional
         metadata to be passed into the 'open_run' message
     """
-    ret = yield from open_run(md)
+    yield from open_run(md)
     yield from plan
-    yield from close_run()
-    return ret
+    rs_uid = yield from close_run()
+    return rs_uid
 
 
 def subs_wrapper(plan, subs):

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2,6 +2,7 @@ import uuid
 import sys
 from functools import wraps
 import itertools
+from itertools import chain
 from contextlib import contextmanager
 from collections import OrderedDict, Iterable, defaultdict, deque, ChainMap
 
@@ -2388,8 +2389,8 @@ def inner_product_scan(detectors, num, *args, per_step=None, md=None):
     if md is None:
         md = {}
 
-    md_args = list(itertools.chain(*((repr(motor), start, stop)
-                                   for motor, start, stop in chunked(args, 3))))
+    md_args = list(chain(*((repr(motor), start, stop)
+                           for motor, start, stop in chunked(args, 3))))
 
     md = ChainMap(
         md,
@@ -2508,8 +2509,8 @@ def relative_outer_product_scan(detectors, *args, per_step=None, md=None):
     if md is None:
         md = {}
     md = ChainMap(md, {'plan_name': 'relative_outer_product_scan'})
-    chunk_args = list(plan_patterns.chunk_outer_product_args(args))
-    motors = [m[0] for m in chunk_args]
+    motors = [m[0] for m in
+              plan_patterns.chunk_outer_product_args(args)]
 
     @reset_positions_decorator(motors)
     @relative_set_decorator(motors)
@@ -2549,8 +2550,7 @@ def relative_inner_product_scan(detectors, num, *args, per_step=None, md=None):
     if md is None:
         md = {}
     md = ChainMap(md, {'plan_name': 'relative_inner_product_scan'})
-    chunk_args = list(plan_patterns.chunk_outer_product_args(args))
-    motors = [m[0] for m in chunk_args]
+    motors = [motor for motor, start, stop in chunked(args, 3)]
 
     @reset_positions_decorator(motors)
     @relative_set_decorator(motors)

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -67,8 +67,11 @@ def planify(func):
     @wraps(func)
     def wrapped(*args, **kwargs):
         gen_stack = func(*args, **kwargs)
+        ret = []
         for g in gen_stack:
-            yield from g
+            res = yield from g
+            ret.append(res)
+        return tuple(ret)
 
     return wrapped
 

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1167,6 +1167,8 @@ class RunEngine:
                                       run_start=self._run_start_uid)
             yield from self.emit(DocumentNames.descriptor, interruptions_desc)
 
+        return self._run_start_uid
+
     @asyncio.coroutine
     def _close_run(self, msg):
         """Instruct the RunEngine to write the RunStop document

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1196,6 +1196,7 @@ class RunEngine:
         yield from self.emit(DocumentNames.stop, doc)
         self.log.debug("Emitted RunStop (uid=%r)", doc['uid'])
         yield from self._reset_checkpoint_state_coro()
+        return doc['run_start']
 
     @asyncio.coroutine
     def _create(self, msg):

--- a/bluesky/spec_api.py
+++ b/bluesky/spec_api.py
@@ -290,9 +290,7 @@ def ascan(motor, start, finish, intervals, time=None, *, md=None):
     """
     motors = [motor]
 
-    @inner_spec_decorator('ascan', time, motors)
-    def inner(*args, **kwargs):
-        return (yield from scan(*args, **kwargs))
+    inner = inner_spec_decorator('ascan', time, motors)(scan)
 
     return (yield from inner(gs.DETS, motor, start, finish,
                              1 + intervals, md=md))
@@ -322,9 +320,7 @@ def dscan(motor, start, finish, intervals, time=None, *, md=None):
     """
     motors = [motor]
 
-    @inner_spec_decorator('dscan', time, motors)
-    def inner(*args, **kwargs):
-        return (yield from relative_scan(*args, **kwargs))
+    inner = inner_spec_decorator('dscan', time, motors)(relative_scan)
 
     return (yield from inner(gs.DETS, motor, start, finish, 1 + intervals,
                              md=md))
@@ -367,10 +363,10 @@ def mesh(*args, time=None, md=None):
 
     # shape goes in (rr, cc)
     # extents go in (x, y)
-    @inner_spec_decorator('mesh', time, motors=motors, shape=shape,
-                          extent=list(chain(*extents[::-1])))
-    def inner(*args, **kwargs):
-        return (yield from outer_product_scan(*args, **kwargs))
+    inner = inner_spec_decorator('mesh', time, motors=motors,
+                                 shape=shape,
+                                 extent=list(chain(*extents[::-1])))(
+                                     outer_product_scan)
 
     return (yield from inner(gs.DETS, *new_args, md=md))
 gs.SUB_FACTORIES['mesh'] = [setup_livetable, setup_liveraster]
@@ -401,9 +397,8 @@ def a2scan(*args, time=None, md=None):
     intervals = list(args)[-1]
     num = 1 + intervals
 
-    @inner_spec_decorator('a2scan', time, motors=motors)
-    def inner(*args, **kwargs):
-        return (yield from inner_product_scan(*args, **kwargs))
+    inner = inner_spec_decorator('a2scan', time,
+                                 motors=motors)(inner_product_scan)
 
     return (yield from inner(gs.DETS, num, *args[:-1], md=md))
 
@@ -447,9 +442,8 @@ def d2scan(*args, time=None, md=None):
     intervals = list(args)[-1]
     num = 1 + intervals
 
-    @inner_spec_decorator('d2scan', time, motors=motors)
-    def inner(*args, **kwargs):
-        return (yield from relative_inner_product_scan(*args, **kwargs))
+    inner = inner_spec_decorator('d2scan', time, motors=motors)(
+        relative_inner_product_scan)
 
     return (yield from inner(gs.DETS, num, *(args[:-1]), md=md))
 
@@ -515,9 +509,7 @@ def tw(motor, step, time=None, *, md=None):
     md : dict, optional
         metadata
     """
-    @inner_spec_decorator('tw', time, motors=[motor])
-    def inner(*args, **kwargs):
-        return (yield from tweak(*args, **kwargs))
+    inner = inner_spec_decorator('tw', time, motors=[motor])(tweak)
 
     return (yield from inner(gs.MASTER_DET, gs.MASTER_DET_FIELD, motor,
                              step, md=md))
@@ -562,9 +554,8 @@ def afermat(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, factor,
     '''
     motors = [x_motor, y_motor]
 
-    @inner_spec_decorator('afermat', time, motors=motors)
-    def inner(*args, **kwargs):
-        return (yield from plans.spiral_fermat(*args, **kwargs))
+    inner = inner_spec_decorator('afermat', time, motors=motors)(
+        plans.spiral_fermat)
 
     return (yield from inner(gs.DETS, x_motor, y_motor, x_start, y_start,
                              x_range, y_range, dr, factor,
@@ -651,9 +642,7 @@ def aspiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth,
     '''
     motors = [x_motor, y_motor]
 
-    @inner_spec_decorator('aspiral', time, motors=motors)
-    def inner(*args, **kwargs):
-        return (yield from plans.spiral(*args, **kwargs))
+    inner = inner_spec_decorator('aspiral', time, motors=motors)(plans.spiral)
 
     return (yield from inner(gs.DETS, x_motor, y_motor, x_start, y_start,
                              x_range, y_range, dr, nth, per_step=per_step,

--- a/bluesky/spec_api.py
+++ b/bluesky/spec_api.py
@@ -12,7 +12,8 @@ changes the behavior of these plans.
 Page numbers in the code comments refer to the SPEC manual at
 http://www.certif.com/downloads/css_docs/spec_man.pdf
 """
-from collections import deque
+from collections import deque, OrderedDict
+
 import matplotlib.pyplot as plt
 from bluesky import plans
 from bluesky.callbacks import LiveTable, LivePlot, LiveRaster
@@ -25,12 +26,14 @@ from bluesky.plans import (subs_context, count, scan,
                            relative_scan, relative_inner_product_scan,
                            outer_product_scan, inner_product_scan,
                            tweak, configure_count_time_wrapper, planify,
-                           baseline_wrapper)
+                           baseline_wrapper, subs_wrapper)
 import itertools
 from itertools import chain
 from collections import ChainMap
+from inspect import signature, Parameter
+import warnings
 
-### Factory functions for generating callbacks
+# ## Factory functions for generating callbacks
 
 
 def _figure_name(base_name):
@@ -54,7 +57,7 @@ def _figure_name(base_name):
     return base_name
 
 
-def setup_plot(motors):
+def setup_plot(*, motors, gs):
     """Setup a LivePlot by inspecting motors and gs.
 
     If motors is empty, use sequence number.
@@ -71,19 +74,176 @@ def setup_plot(motors):
         return LivePlot(y_key, fig=fig)
 
 
-def setup_peakstats(motors):
+def setup_ct_plot(*, num, motors, gs):
+    if num is not None and num > 1:
+        return setup_plot(motors=motors, gs=gs)
+    return None
+
+
+def setup_peakstats(*, motors, gs):
     "Set up peakstats"
-    key = first_key_heuristic(list(motors)[0])
-    ps = PeakStats(key, gs.MASTER_DET_FIELD, edge_count=3)
+    motor = list(motors)[0]
+    key = first_key_heuristic(motor)
+    ps = PeakStats(key, gs.MASTER_DET_FIELD, **gs.PS_CONFIG)
     gs.PS = ps
+    ps.motor = motor
     return ps
 
 
-### Counts (p. 140) ###
+def setup_livetable(*, motors,  gs):
+    return LiveTable(motors + [gs.PLOT_Y] + gs.TABLE_COLS)
 
 
-@planify
-def ct(num=1, delay=None, time=None, *, md=None):
+def setup_liveraster(*, motors, gs, shape, extent):
+    if len(motors) != 2:
+        return None
+    ylab, xlab = [first_key_heuristic(m) for m in motors]
+    raster = LiveRaster(shape, gs.MASTER_DET_FIELD, xlabel=xlab,
+                        ylabel=ylab, extent=extent, clim=[0, 1])
+    return raster
+
+
+def construct_subs(plan_name, **kwargs):
+    '''Construct the subscriptions functions from factories.
+
+
+    This is a small dependency injection tool to construct subscriptions
+    based on `plan_name` by consulting `gs.SUB_FACTORIES` and combining
+    `'common'` and `plan_name` lists.
+
+    The values in `**kwargs` are injected into the factories as needed
+    by consulting the signature.
+
+    Parameters
+    ----------
+    plan_name : str
+        The key used to get the subscription factories
+
+    Returns
+    -------
+    subs : dict
+       A dictionary suitable for handing to the RE or to the sub_wrapper
+       plan.
+    '''
+    factories = gs.SUB_FACTORIES.get('common', [])
+    factories.extend(gs.SUB_FACTORIES.get(plan_name, []))
+    subs = []
+    kwargs.setdefault('gs', gs)
+
+    for factory in factories:
+        # TODO, support positional injection
+        sig = signature(factory)
+        fact_kwargs = {}
+        missing_kwargs = set()
+        missing_args = set()
+        for k, v in sig.parameters.items():
+            if v.kind is Parameter.POSITIONAL_ONLY:
+                if v.defaut is Parameter.empty:
+                    missing_args.add(k)
+            else:
+                if k in kwargs:
+                    fact_kwargs[k] = kwargs[k]
+                else:
+                    if v.default is Parameter.empty:
+                        missing_kwargs.add(k)
+
+        if missing_kwargs:
+            warnings.warn('The factory {fn} could not be run due to missing '
+                          'mandatory kwargs {missing!r}'.format(
+                              fn=factory.__name__, missing=missing_kwargs))
+        elif missing_args:
+            warnings.warn('The factory {fn} could not be run due to having '
+                          'positional only args {missing!r}'.format(
+                              fn=factory.__name__, missing=missing_kwargs))
+        else:
+            l_sub = factory(**fact_kwargs)
+            if l_sub is None:
+                continue
+            elif callable(l_sub):
+                subs.append(l_sub)
+            else:
+                subs.extend(l_sub)
+
+    return {'all': subs}
+
+
+# TODO rename this
+def plan_sub_factory_input(plan_name):
+    '''Helper function for introspecting sub_factories
+
+    Assume this will be re-written, do not program against.
+    '''
+    factories = gs.SUB_FACTORIES.get('common', [])
+    factories.extend(gs.SUB_FACTORIES.get(plan_name, []))
+    opt = set()
+    req = set()
+    by_fac = OrderedDict()
+    for fac in factories:
+        try:
+            ret = get_sub_factory_input(fac)
+        except InvalidFactory as e:
+            by_fac[fac.__name__] = e
+        else:
+            opt.update(ret['opt'])
+            req.update(ret['req'])
+            by_fac[fac.__name__] = ret
+
+    return {'opt': opt, 'req': req}, by_fac
+
+
+class InvalidFactory(TypeError):
+    ...
+
+
+# TODO rename this
+def get_sub_factory_input(factory):
+    '''Helper function to re-organize signature information
+
+    Assume this will be re-written, do not program against.
+    '''
+    sig = signature(factory)
+    reqed = set()
+    optional = set()
+    for k, v in sig.parameters.items():
+        if v.kind is Parameter.POSITIONAL_ONLY:
+            # TODO make this nice?
+            raise InvalidFactory()
+        elif v.default is Parameter.empty:
+            reqed.add(k)
+        else:
+            optional.add(k)
+    return {'req': reqed, 'opt': optional}
+
+
+def inner_spec_decorator(plan_name, time, motors, **subs_kwargs):
+    subs = construct_subs(plan_name, motors=motors, **subs_kwargs)
+
+    # create the paramterized decorator
+    def outer(func):
+        # create the decorated function to return
+        def inner(*args, md=None, **kwargs):
+            # inject the plan name + time into the metadata
+            if md is None:
+                md = {}
+            md = ChainMap(md, {'plan_name': plan_name,
+                               gs.MD_TIME_KEY: time})
+            # get the 'base' plan
+            plan = func(*args, md=md, **kwargs)
+            # set up the baseline measurements
+            plan = baseline_wrapper(plan, list(gs.BASELINE_DEVICES) + motors)
+            # set up the 'count time' measurements'
+            plan = configure_count_time_wrapper(plan, time)
+            # set up the subscriptions
+            plan = subs_wrapper(plan, subs)
+            # yield from the whole thing
+            return (yield from plan)
+        return inner
+    return outer
+
+# ## Counts (p. 140) ###
+
+
+def ct(num=1, delay=None, time=None, *, md=None, **kwargs):
     """
     Take one or more readings from the global detectors.
 
@@ -100,26 +260,17 @@ def ct(num=1, delay=None, time=None, *, md=None):
     md : dict, optional
         metadata
     """
-    if md is None:
-        md = {}
-    md = ChainMap(md, {'plan_name': 'ct',
-                       gs.MD_TIME_KEY: time})
-    subs = {'all': [LiveTable(gs.TABLE_COLS + [gs.PLOT_Y])]}
-    if num is not None and num > 1:
-        subs['all'].append(setup_plot([]))
 
-    plan_stack = deque()
-    with subs_context(plan_stack, subs):
-        plan = count(gs.DETS, num, delay, md=md)
-        plan = baseline_wrapper(plan, gs.BASELINE_DEVICES)
-        plan = configure_count_time_wrapper(plan, time)
-        plan_stack.append(plan)
-    return plan_stack
+    @inner_spec_decorator('ct', time, [], num=num, **kwargs)
+    def inner(*args, **kwargs):
+        return (yield from count(*args, **kwargs))
+
+    return (yield from inner(gs.DETS, num, delay, md=md))
+gs.SUB_FACTORIES['ct'] = [setup_livetable, setup_ct_plot]
 
 
-### Motor Scans (p. 146) ###
+# ## Motor Scans (p. 146) ###
 
-@planify
 def ascan(motor, start, finish, intervals, time=None, *, md=None):
     """
     Scan over one variable in equally spaced steps.
@@ -139,24 +290,19 @@ def ascan(motor, start, finish, intervals, time=None, *, md=None):
     md : dict, optional
         metadata
     """
-    if md is None:
-        md = {}
-    md = ChainMap(md, {'plan_name': 'ascan',
-                       gs.MD_TIME_KEY: time})
-    subs = {'all': [LiveTable([motor] + gs.TABLE_COLS + [gs.PLOT_Y]),
-                    setup_plot([motor]),
-                    setup_peakstats([motor])]}
+    motors = [motor]
 
-    plan_stack = deque()
-    with subs_context(plan_stack, subs):
-        plan = scan(gs.DETS, motor, start, finish, 1 + intervals, md=md)
-        plan = baseline_wrapper(plan, [motor] + gs.BASELINE_DEVICES)
-        plan = configure_count_time_wrapper(plan, time)
-        plan_stack.append(plan)
-        return plan_stack
+    @inner_spec_decorator('ascan', time, motors)
+    def inner(*args, **kwargs):
+        return (yield from scan(*args, **kwargs))
+
+    return (yield from inner(gs.DETS, motor, start, finish,
+                             1 + intervals, md=md))
+gs.SUB_FACTORIES['ascan'] = [setup_livetable,
+                             setup_plot,
+                             setup_peakstats]
 
 
-@planify
 def dscan(motor, start, finish, intervals, time=None, *, md=None):
     """
     Scan over one variable in equally spaced steps relative to current pos.
@@ -176,24 +322,19 @@ def dscan(motor, start, finish, intervals, time=None, *, md=None):
     md : dict, optional
         metadata
     """
-    subs = {'all': [LiveTable([motor] + gs.TABLE_COLS + [gs.PLOT_Y]),
-                    setup_plot([motor]),
-                    setup_peakstats([motor])]}
-    if md is None:
-        md = {}
-    md = ChainMap(md, {'plan_name': 'dscan',
-                       gs.MD_TIME_KEY: time})
-    plan_stack = deque()
-    with subs_context(plan_stack, subs):
-        plan = relative_scan(gs.DETS, motor, start, finish, 1 + intervals,
-                             md=md)
-        plan = baseline_wrapper(plan, [motor] + gs.BASELINE_DEVICES)
-        plan = configure_count_time_wrapper(plan, time)
-        plan_stack.append(plan)
-    return plan_stack
+    motors = [motor]
+
+    @inner_spec_decorator('dscan', time, motors)
+    def inner(*args, **kwargs):
+        return (yield from relative_scan(*args, **kwargs))
+
+    return (yield from inner(gs.DETS, motor, start, finish, 1 + intervals,
+                             md=md))
+gs.SUB_FACTORIES['dscan'] = [setup_livetable,
+                             setup_plot,
+                             setup_peakstats]
 
 
-@planify
 def mesh(*args, time=None, md=None):
     """
     Scan over a mesh; each motor is on an independent trajectory.
@@ -210,10 +351,6 @@ def mesh(*args, time=None, md=None):
     md : dict, optional
         metadata
     """
-    if md is None:
-        md = {}
-    md = ChainMap(md, {'plan_name': 'mesh',
-                       gs.MD_TIME_KEY: time})
     if len(args) % 4 != 0:
         raise ValueError("wrong number of positional arguments")
     motors = []
@@ -224,32 +361,23 @@ def mesh(*args, time=None, md=None):
         shape.append(num)
         extents.append([start, stop])
 
-    subs = {'all': [LiveTable(gs.DETS + motors)]}
-    if len(motors) == 2:
-        # first motor is 'slow' -> Y axis
-        ylab, xlab = [first_key_heuristic(m) for m in motors]
-        # shape goes in (rr, cc)
-        # extents go in (x, y)
-        raster = LiveRaster(shape, gs.MASTER_DET_FIELD, xlabel=xlab,
-                            ylabel=ylab, extent=list(chain(*extents[::-1])))
-        subs['all'].append(raster)
-
     # outer_product_scan expects a 'snake' param for all but fist motor
     chunked_args = iter(chunked(args, 4))
     new_args = list(next(chunked_args))
     for chunk in chunked_args:
         new_args.extend(list(chunk) + [False])
 
-    plan_stack = deque()
-    with subs_context(plan_stack, subs):
-        plan = outer_product_scan(gs.DETS, *new_args, md=md)
-        plan = baseline_wrapper(plan, motors + gs.BASELINE_DEVICES)
-        plan = configure_count_time_wrapper(plan, time)
-        plan_stack.append(plan)
-    return plan_stack
+    # shape goes in (rr, cc)
+    # extents go in (x, y)
+    @inner_spec_decorator('mesh', time, motors=motors, shape=shape,
+                          extent=list(chain(*extents[::-1])))
+    def inner(*args, **kwargs):
+        return (yield from outer_product_scan(*args, **kwargs))
+
+    return (yield from inner(gs.DETS, *new_args, md=md))
+gs.SUB_FACTORIES['mesh'] = [setup_livetable, setup_liveraster]
 
 
-@planify
 def a2scan(*args, time=None, md=None):
     """
     Scan over one multi-motor trajectory.
@@ -266,28 +394,24 @@ def a2scan(*args, time=None, md=None):
     md : dict, optional
         metadata
     """
-    if md is None:
-        md = {}
-    md = ChainMap(md, {'plan_name': 'a2scan',
-                       gs.MD_TIME_KEY: time})
     if len(args) % 3 != 1:
         raise ValueError("wrong number of positional arguments")
     motors = []
     for motor, start, stop, in chunked(args[:-1], 3):
         motors.append(motor)
-        subs = {'all': [LiveTable(gs.DETS + motors),
-                        setup_plot(motors),
-                        setup_peakstats(motors)]}
+
     intervals = list(args)[-1]
     num = 1 + intervals
 
-    plan_stack = deque()
-    with subs_context(plan_stack, subs):
-        plan = inner_product_scan(gs.DETS, num, *args[:-1], md=md)
-        plan = baseline_wrapper(plan, motors + gs.BASELINE_DEVICES)
-        plan = configure_count_time_wrapper(plan, time)
-        plan_stack.append(plan)
-    return plan_stack
+    @inner_spec_decorator('a2scan', time, motors=motors)
+    def inner(*args, **kwargs):
+        return (yield from inner_product_scan(*args, **kwargs))
+
+    return (yield from inner(gs.DETS, num, *args[:-1], md=md))
+
+gs.SUB_FACTORIES['a2scan'] = [setup_livetable,
+                              setup_plot,
+                              setup_peakstats]
 
 
 # This implementation works for *all* dimensions, but we follow SPEC naming.
@@ -297,9 +421,9 @@ def a3scan(*args, time=None, md=None):
     md = ChainMap(md, {'plan_name': 'a3scan'})
     return (yield from a2scan(*args, time=time, md=md))
 a3scan.__doc__ = a2scan.__doc__
+gs.SUB_FACTORIES['a3scan'] = gs.SUB_FACTORIES['a2scan']
 
 
-@planify
 def d2scan(*args, time=None, md=None):
     """
     Scan over one multi-motor trajectory relative to current positions.
@@ -316,28 +440,24 @@ def d2scan(*args, time=None, md=None):
     md : dict, optional
         metadata
     """
-    if md is None:
-        md = {}
-    md = ChainMap(md, {'plan_name': 'd2scan',
-                       gs.MD_TIME_KEY: time})
     if len(args) % 3 != 1:
         raise ValueError("wrong number of positional arguments")
     motors = []
     for motor, start, stop, in chunked(args[:-1], 3):
         motors.append(motor)
-    subs = {'all': [LiveTable(gs.DETS + motors),
-                    setup_plot(motors),
-                    setup_peakstats(motors)]}
+
     intervals = list(args)[-1]
     num = 1 + intervals
 
-    plan_stack = deque()
-    with subs_context(plan_stack, subs):
-        plan = relative_inner_product_scan(gs.DETS, num, *(args[:-1]), md=md)
-        plan = baseline_wrapper(plan, motors + gs.BASELINE_DEVICES)
-        plan = configure_count_time_wrapper(plan, time)
-        plan_stack.append(plan)
-    return plan_stack
+    @inner_spec_decorator('d2scan', time, motors=motors)
+    def inner(*args, **kwargs):
+        return (yield from relative_inner_product_scan(*args, **kwargs))
+
+    return (yield from inner(gs.DETS, num, *(args[:-1]), md=md))
+
+gs.SUB_FACTORIES['d2scan'] = [setup_livetable,
+                              setup_plot,
+                              setup_peakstats]
 
 
 # This implementation works for *all* dimensions, but we follow SPEC naming.
@@ -347,9 +467,9 @@ def d3scan(*args, time=None, md=None):
     md = ChainMap(md, {'plan_name': 'd3scan'})
     return (yield from d2scan(*args, time=time, md=md))
 d3scan.__doc__ = d2scan.__doc__
+gs.SUB_FACTORIES['d3scan'] = gs.SUB_FACTORIES['d2scan']
 
 
-@planify
 def th2th(start, finish, intervals, time=None, *, md=None):
     """
     Scan the theta and two-theta motors together.
@@ -378,10 +498,10 @@ def th2th(start, finish, intervals, time=None, *, md=None):
     plan = d2scan(gs.TTH_MOTOR, start, finish,
                   gs.TH_MOTOR, start/2, finish/2,
                   intervals, time=time, md=md)
-    return [plan]
+    return (yield from plan)
+gs.SUB_FACTORIES['th2th'] = gs.SUB_FACTORIES['d2scan']
 
 
-@planify
 def tw(motor, step, time=None, *, md=None):
     """
     Move and motor and read a detector with an interactive prompt.
@@ -397,17 +517,14 @@ def tw(motor, step, time=None, *, md=None):
     md : dict, optional
         metadata
     """
-    if md is None:
-        md = {}
-    md = ChainMap(md, {'plan_name': 'tw',
-                       gs.MD_TIME_KEY: time})
-    plan = tweak(gs.MASTER_DET, gs.MASTER_DET_FIELD, motor, step, md=md)
-    plan = baseline_wrapper(plan, [motor] + gs.BASELINE_DEVICES)
-    plan = configure_count_time_wrapper(plan, time)
-    return [plan]
+    @inner_spec_decorator('tw', time, motors=[motor])
+    def inner(*args, **kwargs):
+        return (yield from tweak(*args, **kwargs))
+
+    return (yield from inner(gs.MASTER_DET, gs.MASTER_DET_FIELD, motor,
+                             step, md=md))
 
 
-@planify
 def afermat(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, factor,
             time=None, *, per_step=None, md=None):
     '''Absolute fermat spiral scan, centered around (0, 0)
@@ -445,25 +562,18 @@ def afermat(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, factor,
     `bluesky.spec_api.aspiral`
     `bluesky.spec_api.spiral`
     '''
-    if md is None:
-        md = {}
-    md = ChainMap(md, {'plan_name': 'afermat',
-                       gs.MD_TIME_KEY: time})
-    subs = {'all': [LiveTable([x_motor, y_motor, gs.PLOT_Y] + gs.TABLE_COLS),
-                    ]}
+    motors = [x_motor, y_motor]
 
-    plan_stack = deque()
-    with plans.subs_context(plan_stack, subs):
-        plan = plans.spiral_fermat(gs.DETS, x_motor, y_motor, x_start, y_start,
-                                   x_range, y_range, dr, factor,
-                                   per_step=per_step, md=md)
-        plan = baseline_wrapper(plan, [x_motor, y_motor] + gs.BASELINE_DEVICES)
-        plan = configure_count_time_wrapper(plan, time)
-        plan_stack.append(plan)
-    return plan_stack
+    @inner_spec_decorator('afermat', time, motors=motors)
+    def inner(*args, **kwargs):
+        return (yield from plans.spiral_fermat(*args, **kwargs))
+
+    return (yield from inner(gs.DETS, x_motor, y_motor, x_start, y_start,
+                             x_range, y_range, dr, factor,
+                             per_step=per_step, md=md))
+gs.SUB_FACTORIES['afermat'] = [setup_livetable]
 
 
-@planify
 def fermat(x_motor, y_motor, x_range, y_range, dr, factor, time=None, *,
            per_step=None, md=None):
     '''Relative fermat spiral scan
@@ -499,16 +609,15 @@ def fermat(x_motor, y_motor, x_range, y_range, dr, factor, time=None, *,
     '''
     if md is None:
         md = {}
-    md = ChainMap(md, {'plan_name': 'fermat',
-                       gs.MD_TIME_KEY: time})
+    md = ChainMap(md, {'plan_name': 'fermat'})
     plan = afermat(x_motor, y_motor, x_motor.position, y_motor.position,
                    x_range, y_range, dr, factor, time=time, per_step=per_step,
                    md=md)
     plan = plans.reset_positions_wrapper(plan)  # return motors to starting pos
-    return [plan]
+    return (yield from plan)
+gs.SUB_FACTORIES['fermat'] = gs.SUB_FACTORIES['afermat']
 
 
-@planify
 def aspiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth,
             time=None, *, per_step=None, md=None):
     '''Spiral scan, centered around (x_start, y_start)
@@ -542,25 +651,18 @@ def aspiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth,
     `bluesky.spec_api.afermat`
     `bluesky.spec_api.spiral`
     '''
-    if md is None:
-        md = {}
-    md = ChainMap(md, {'plan_name': 'aspiral',
-                       gs.MD_TIME_KEY: time})
-    subs = {'all': [LiveTable([x_motor, y_motor, gs.PLOT_Y] + gs.TABLE_COLS),
-                    ]}
+    motors = [x_motor, y_motor]
 
-    plan_stack = deque()
-    with plans.subs_context(plan_stack, subs):
-        plan = plans.spiral(gs.DETS, x_motor, y_motor, x_start, y_start,
-                            x_range, y_range, dr, nth, per_step=per_step,
-                            md=md)
-        plan = baseline_wrapper(plan, [x_motor, y_motor] + gs.BASELINE_DEVICES)
-        plan = configure_count_time_wrapper(plan, time)
-        plan_stack.append(plan)
-    return plan_stack
+    @inner_spec_decorator('aspiral', time, motors=motors)
+    def inner(*args, **kwargs):
+        return (yield from plans.spiral(*args, **kwargs))
+
+    return (yield from inner(gs.DETS, x_motor, y_motor, x_start, y_start,
+                             x_range, y_range, dr, nth, per_step=per_step,
+                             md=md))
+gs.SUB_FACTORIES['aspiral'] = [setup_livetable]
 
 
-@planify
 def spiral(x_motor, y_motor, x_range, y_range, dr, nth, time=None, *,
            per_step=None, md=None):
     '''Relative spiral scan
@@ -596,10 +698,10 @@ def spiral(x_motor, y_motor, x_range, y_range, dr, nth, time=None, *,
     '''
     if md is None:
         md = {}
-    md = ChainMap(md, {'plan_name': 'spiral',
-                       gs.MD_TIME_KEY: time})
+    md = ChainMap(md, {'plan_name': 'spiral'})
     plan = aspiral(x_motor, y_motor, x_motor.position, y_motor.position,
                    x_range, y_range, dr, nth, time=time, per_step=per_step,
                    md=md)
     plan = plans.reset_positions_wrapper(plan)  # return to starting pos
-    return [plan]
+    return (yield from plan)
+gs.SUB_FACTORIES['spiral'] = gs.SUB_FACTORIES['aspiral']

--- a/bluesky/spec_api.py
+++ b/bluesky/spec_api.py
@@ -241,7 +241,7 @@ def inner_spec_decorator(plan_name, time, motors, **subs_kwargs):
 # ## Counts (p. 140) ###
 
 
-def ct(num=1, delay=None, time=None, *, md=None, **kwargs):
+def ct(num=1, delay=None, time=None, *, md=None):
     """
     Take one or more readings from the global detectors.
 
@@ -259,9 +259,7 @@ def ct(num=1, delay=None, time=None, *, md=None, **kwargs):
         metadata
     """
 
-    @inner_spec_decorator('ct', time, [], num=num, **kwargs)
-    def inner(*args, **kwargs):
-        return (yield from count(*args, **kwargs))
+    inner = inner_spec_decorator('ct', time, [], num=num)(count)
 
     return (yield from inner(gs.DETS, num, delay, md=md))
 gs.SUB_FACTORIES['ct'] = [setup_livetable, setup_ct_plot]

--- a/bluesky/tests/test_simple_api.py
+++ b/bluesky/tests/test_simple_api.py
@@ -2,10 +2,11 @@ import bson
 from traitlets import TraitError
 from bluesky.examples import motor, motor1, motor2, det, det1, det2, FlyMagic
 import pytest
-from bluesky.spec_api import (ct, ascan, a2scan, a3scan, dscan, d2scan,
-                              d3scan, mesh, th2th, afermat, fermat, spiral,
-                              aspiral, get_sub_factory_input, plan_sub_factory_input,
-                              InvalidFactory)
+from bluesky.spec_api import (ct, ascan, a2scan, a3scan, dscan,
+                              d2scan, d3scan, mesh, th2th, afermat,
+                              fermat, spiral, aspiral,
+                              get_factory_input,
+                              plan_sub_factory_input, InvalidFactory)
 
 
 @pytest.mark.parametrize('pln,name,args,kwargs', [
@@ -91,19 +92,18 @@ def test_factory_tools_smoke():
     failer.__signature__ = Signature((Parameter('fail',
                                                 Parameter.POSITIONAL_ONLY), ))
     with pytest.raises(InvalidFactory):
-        get_sub_factory_input(failer)
+        get_factory_input(failer)
 
     for pln in ['ct', 'ascan', 'dscan']:
         merge, by_fac = plan_sub_factory_input(pln)
         opt = set()
         req = set()
         for k, v in by_fac.items():
-            assert set(('opt', 'req')) == set(v.keys())
-            opt.update(v['opt'])
-            req.update(v['req'])
+            opt.update(v.opt)
+            req.update(v.req)
 
-        assert opt == merge['opt']
-        assert req == merge['req']
+        assert opt == merge.opt
+        assert req == merge.req
 
     gs.SUB_FACTORIES['TST_DUMMY'] = [failer]
 

--- a/bluesky/tests/test_simple_api.py
+++ b/bluesky/tests/test_simple_api.py
@@ -4,7 +4,8 @@ from bluesky.examples import motor, motor1, motor2, det, det1, det2, FlyMagic
 import pytest
 from bluesky.spec_api import (ct, ascan, a2scan, a3scan, dscan, d2scan,
                               d3scan, mesh, th2th, afermat, fermat, spiral,
-                              aspiral)
+                              aspiral, get_sub_factory_input, plan_sub_factory_input,
+                              InvalidFactory)
 
 
 @pytest.mark.parametrize('pln,name,args,kwargs', [
@@ -78,3 +79,34 @@ def test_gs_validation():
     from bluesky.global_state import gs
     with pytest.raises(TraitError):
         gs.DETS = [det, det]  # no duplicate data keys
+
+
+def test_factory_tools_smoke():
+    from bluesky.global_state import gs
+    from inspect import Signature, Parameter
+
+    def failer(*args, **kwargs):
+        ...
+
+    failer.__signature__ = Signature((Parameter('fail',
+                                                Parameter.POSITIONAL_ONLY), ))
+    with pytest.raises(InvalidFactory):
+        get_sub_factory_input(failer)
+
+    for pln in ['ct', 'ascan', 'dscan']:
+        merge, by_fac = plan_sub_factory_input(pln)
+        opt = set()
+        req = set()
+        for k, v in by_fac.items():
+            assert set(('opt', 'req')) == set(v.keys())
+            opt.update(v['opt'])
+            req.update(v['req'])
+
+        assert opt == merge['opt']
+        assert req == merge['req']
+
+    gs.SUB_FACTORIES['TST_DUMMY'] = [failer]
+
+    merge, by_fac = plan_sub_factory_input('TST_DUMMY')
+    for k, v in by_fac.items():
+        assert isinstance(v, InvalidFactory)

--- a/bluesky/tests/test_simple_api.py
+++ b/bluesky/tests/test_simple_api.py
@@ -53,8 +53,9 @@ def test_spec_plans(fresh_RE, pln, name, args, kwargs):
         nonlocal run_start
         if name == 'start':
             run_start = doc
-
-    fresh_RE(pln(*args, **kwargs), capture_run_start)
+    gs.SUB_FACTORIES[pln.__name__].append(lambda: capture_run_start)
+    fresh_RE(pln(*args, **kwargs))
+    gs.SUB_FACTORIES[pln.__name__].pop()
 
     assert run_start['plan_name'] == name
     assert gs.MD_TIME_KEY in run_start

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -114,7 +114,7 @@ def single_gen(msg):
     msg : Msg
         the input message
     '''
-    yield msg
+    return (yield msg)
 
 
 class SignalHandler:

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -185,52 +185,11 @@ Here are a couple more useful recipes:
     "Run a plan several times, changing the step size each time."
 
     def make_master_plan():
-        for num in range(5, 10):
+         for num in range(5, 10):
             # Change the number of steps in the plan in each loop
             plan1 = scan([det1, det2], motor, 1, 5, num)
             yield from plan1
 
-Plan Context Managers
----------------------
-
-These context managers provide a sunninct, readable syntax for inserting plans
-before and after other plans.
-
-.. autosummary::
-   :nosignatures:
-   :toctree:
-
-    baseline_context
-    monitor_context
-    subs_context
-    run_context
-    event_context
-    stage_context
-
-For example, the ``baseline_context`` reads a list of detectors at the
-beginning and end of an experiment.
-
-.. code-block:: python
-
-    from bluesky.plans import baseline_context, count
-    from bluesky.examples import det
-
-    plans = []
-    with baseline_context(plans, [det]):
-        plans.append(count([det]))
-
-Use with the ``planify`` decorator to join the list of plans into one plan.
-
-.. code-block:: python
-
-    from bluesky.plans import planify
-
-    @planify
-    def count_with_baseline_readings():
-        plans = []
-        with baseline_context(plans, [det]):
-            plans.append(count([det]))
-        return plans
 
 Plan Preprocessors
 ------------------
@@ -266,16 +225,6 @@ functions that operate on a generator *function*. They are named
         relative = relative_set(absolute, [motor])
         yield from relative
 
-Or, equivalently, using the ``planify`` decorator:
-
-.. code-block:: python
-
-    @planify
-    def relative_scan(detectors, motor, start, stop, num):
-        absolute = scan(detectors, motor, start, stop, num)
-        relative = relative_set(absolute, [motor])
-        return [relative]
-
 Plan Utilities
 --------------
 
@@ -285,7 +234,6 @@ Plan Utilities
     msg_mutator
     plan_mutator
     single_gen
-    planify
     broadcast_msg
     repeater
     caching_repeater

--- a/doc/source/simple_api.rst
+++ b/doc/source/simple_api.rst
@@ -97,10 +97,18 @@ There are other settings which control the output of the scans --
 ``gs.TABLE_COLS`` and ``gs.PLOT_Y``  for example. Explore the contents of
 ``gs`` by typing ``gs.<TAB>``.
 
+Peak Stats
+----------
+
+
+
+Live Plotting
+-------------
+
 Count
 -----
 
-A ``ct`` ("count") scan reads all the detectors in the list ``DETS`` for 
+A ``ct`` ("count") scan reads all the detectors in the list ``DETS`` for
 a given acquisition time. If no time is specified, 1 second is the default.
 
 .. code-block:: python
@@ -137,7 +145,7 @@ trajectories.)
 
 .. code-block:: python
 
-    a3scan(motor1, start1, finish1, motor2, start2, finish2, motor3, 
+    a3scan(motor1, start1, finish1, motor2, start2, finish2, motor3,
            start3, finish3, intervals, time)
 
 We provide ``a2scan`` and ``a3scan`` for convenience, but in fact both of them


### PR DESCRIPTION
 - return runstart uid from `open_run`
 - bounce returned values through single_gen
 - planify returns a tuple of collected results


This needs some tests and maybe a re-think of what `planify` returns.