### PR TITLE
ENH/TST/DOC: Add `monitor_wrapper`

### DIFF
--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -474,7 +474,7 @@ def test_cleanup_after_pause(fresh_RE, unpause_func, motor_det):
     motor, det = motor_det
     motor.set(1024)
 
-    @bp.reset_positions_decorator
+    @bp.reset_positions_decorator()
     def simple_plan(motor):
         for j in range(15):
             yield Msg('set', motor, j)
@@ -489,32 +489,32 @@ def test_cleanup_after_pause(fresh_RE, unpause_func, motor_det):
 
 
 def _make_plan_marker():
-    @bp.reset_positions_decorator
+    @bp.reset_positions_decorator()
     def raiser(motor):
         for j in range(15):
             yield Msg('set', motor, j)
         raise RuntimeError()
 
-    @bp.reset_positions_decorator
+    @bp.reset_positions_decorator()
     def pausing_raiser(motor):
         for j in range(15):
             yield Msg('set', motor, j)
         yield Msg('pause')
         raise RuntimeError()
 
-    @bp.reset_positions_decorator
+    @bp.reset_positions_decorator()
     def bad_set(motor):
         for j in range(15):
             yield Msg('set', motor, j)
             yield Msg('set', None, j)
 
-    @bp.reset_positions_decorator
+    @bp.reset_positions_decorator()
     def bad_msg(motor):
         for j in range(15):
             yield Msg('set', motor, j)
         yield Msg('aardvark')
 
-    @bp.reset_positions_decorator
+    @bp.reset_positions_decorator()
     def cannot_pauser(motor):
         yield Msg('clear_checkpoint')
         for j in range(15):

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -28,6 +28,7 @@ Bug Fixes
   stopped or aborted.
 * When an exception is raised, give each plan in the plan stack an opportunity
   to handle it. If it is handled, carry on.
+* Make ``make_decorator`` return proper generators.
 * The SPEC-style ``tw`` was not passing its parameters through to the
   underlying ``tweak`` plan.
 * Silenced un-needed suspenders warnings

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -1,5 +1,19 @@
-API Changes
-===========
+Release Notes
+=============
+
+v0.6.2
+------
+
+Bug Fixes
+^^^^^^^^^
+* Make ``make_decorator`` return proper decorators. The original implementation
+  returned functions that could not actually be used as decorators.
+
+v0.6.1
+------
+
+This release contained only a minor UX fix involving more informative error
+reporting.
 
 v0.6.0
 ------
@@ -28,7 +42,6 @@ Bug Fixes
   stopped or aborted.
 * When an exception is raised, give each plan in the plan stack an opportunity
   to handle it. If it is handled, carry on.
-* Make ``make_decorator`` return proper generators.
 * The SPEC-style ``tw`` was not passing its parameters through to the
   underlying ``tweak`` plan.
 * Silenced un-needed suspenders warnings

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -64,3 +64,4 @@ Robustness
    state-machine
    metadata 
    simple_api
+   api_changes

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -236,21 +236,28 @@ Plan Preprocessors
 ------------------
 
 These "preprocessors" take in a plan and modify its contents on the fly.
+For example, ``relative_set`` rewrites all positions to be relative to the
+initial position.
 
 .. autosummary::
    :nosignatures:
    :toctree:
 
+    finalize_wrapper
     subs_wrapper
+    inject_md_wrapper
+    run_wrapper
+    monitor_during_wrapper
+    fly_during_wrapper
     baseline_wrapper
     relative_set_wrapper
     reset_positions_wrapper
     lazily_stage_wrapper
-    fly_during_wrapper
-    finalize_wrapper
 
-For example, ``relative_set`` rewrites all positions to be relative to the
-initial position.
+
+These wrappers operate on a generator *instance*. There are corresponding
+functions that operate on a generator *function*. They are named
+``*_decorator``, corresponding to each ``*_wrapper`` above.
 
 .. code-block:: python
 
@@ -274,14 +281,15 @@ Plan Utilities
 
 .. autosummary::
 
-    planify
+    pchain
     msg_mutator
     plan_mutator
-    pchain
     single_gen
+    planify
     broadcast_msg
     repeater
     caching_repeater
+    make_decorator
 
 Object-Oriented Standard Plans
 ------------------------------


### PR DESCRIPTION
- Add `monitor_wrapper` and `monitor_decorator`.
- Document `make_decorator` and `run_wrapper`.
- Document the difference between _wrapper and _decorator funcs.
- Rename `fly_during_wrapper` -> `fly_wrapper` but keep back-compat.
- Bike-shed order functions are listed in API docs.
- Change `make_decorator` to return proper decorators.