### PR TITLE
When LiveTable skips an unrecognized dtype, warn

### DIFF
--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -2,6 +2,7 @@
 Useful callbacks for the Run Engine
 """
 from itertools import count
+import warnings
 from collections import deque, namedtuple, OrderedDict
 import time as ttime
 
@@ -460,6 +461,9 @@ class LiveTable(CallbackBase):
                 continue
 
             if dk_entry['dtype'] not in self._FMT_MAP:
+                warnings.warn("The key {} will be skipped because LiveTable "
+                              "does not know how to display the dtype {}"
+                              "".format(k, dk_entry['dtype']))
                 continue
 
             prec = patch_up_precision(dk_entry.get('precision',

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -112,6 +112,14 @@ def test_unknown_cb_raises():
         RE._subscribe_lossless('not a thing', f)
 
 
+def test_table_warns():
+    table = LiveTable(['field'])
+    table('start', {})
+    with pytest.warns(UserWarning):
+        table('descriptor', {'uid': 'asdf', 'name': 'primary',
+                            'data_keys': {'field': {'dtype': 'array'}}})
+
+
 def test_table():
     with _print_redirect() as fout:
         det.precision = 2


### PR DESCRIPTION
Example: If a user adds a field with an 'array' dtype, LiveTable silently skips it. This confused me for a minute earlier this week.