### PR TITLE
SNIP: remove lossy subscriptions

### DIFF
--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -358,6 +358,9 @@ class LiveRaster(CallbackBase):
         cb.set_label(self.I)
 
     def event(self, doc):
+        if self.I not in doc['data']:
+            return
+
         seq_num = doc['seq_num'] - 1
         pos = list(np.unravel_index(seq_num, self.raster_shape))
         if self.snaking[1] and (pos[0] % 2):

--- a/bluesky/register_mds.py
+++ b/bluesky/register_mds.py
@@ -61,4 +61,4 @@ def _register_md(runengine, mds):
 
     # actually attach the callbacks to the RunEngine
     for name in insert_funcs.keys():
-        runengine._subscribe_lossless(name, insert_funcs[name])
+        runengine.subscribe(name, insert_funcs[name])

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -10,7 +10,6 @@ from enum import Enum
 import functools
 
 
-
 import jsonschema
 from event_model import DocumentNames, schemas
 from super_state_machine.machines import StateMachine
@@ -23,22 +22,6 @@ from .utils import (CallbackRegistry, SignalHandler, normalize_subs_input,
                     IllegalMessageSequence, FailedPause, FailedStatus,
                     InvalidCommand, PlanHalt, Msg, ensure_generator,
                     single_gen)
-
-
-def expiring_function(func, loop, *args, **kwargs):
-    """
-    If timeout has not occurred, call func(*args, **kwargs).
-
-    This is meant to used with the event loop's run_in_executor
-    method. Outside that context, it doesn't make any sense.
-    """
-    def dummy(start_time, timeout):
-        if loop.time() > start_time + timeout:
-            return
-        func(*args, **kwargs)
-        return
-
-    return dummy
 
 
 class RunEngineStateMachine(StateMachine):

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -105,9 +105,9 @@ def test_unknown_cb_raises():
         pass
     with pytest.raises(KeyError):
         RE.subscribe('not a thing', f)
+    # back-compat alias for subscribe
     with pytest.raises(KeyError):
         RE.subscribe_lossless('not a thing', f)
-    # back-compat alias for subscribe_lossless
     with pytest.raises(KeyError):
         RE._subscribe_lossless('not a thing', f)
 

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -287,34 +287,6 @@ def test_stage_and_unstage_are_optional_methods(fresh_RE):
     fresh_RE([Msg('stage', dummy), Msg('unstage', dummy)])
 
 
-def test_lossiness(fresh_RE):
-    mutable = {}
-
-    def plan():
-        yield Msg('open_run')
-        for i in range(10):
-            yield from trigger_and_read([det])
-
-        yield Msg('close_run')
-
-    def slow_callback(name, doc):
-        mutable['count'] += 1
-        ttime.sleep(0.5)
-
-    fresh_RE.subscribe_lossless('event', slow_callback)
-    mutable['count'] = 0
-    # All events should be recieved by the callback.
-    fresh_RE(plan())
-    assert mutable['count'] == 10
-
-    fresh_RE._lossless_dispatcher.unsubscribe_all()
-    mutable['count'] = 0
-    fresh_RE.subscribe('event', slow_callback)
-    # Some events should be skipped.
-    fresh_RE(plan())
-    assert mutable['count'] < 10
-
-
 def test_pause_resume_devices(fresh_RE):
     paused = {}
     resumed = {}

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -787,3 +787,19 @@ def sanitize_np(val):
             return val.item()
         return val.tolist()
     return val
+
+
+def expiring_function(func, loop, *args, **kwargs):
+    """
+    If timeout has not occurred, call func(*args, **kwargs).
+
+    This is meant to used with the event loop's run_in_executor
+    method. Outside that context, it doesn't make any sense.
+    """
+    def dummy(start_time, timeout):
+        if loop.time() > start_time + timeout:
+            return
+        func(*args, **kwargs)
+        return
+
+    return dummy


### PR DESCRIPTION
After a discussion with @tacaswell. Anything that's slow should be subscribed on a separate process somehow (outside of the scope of this PR).

Proof-of-concept / seeing what this looks like / seeing what tests fail