### PR TITLE
Fix finalize dec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ coverage.xml
 
 # Sphinx documentation
 doc/build/
+doc/source/bluesky.*
 
 # PyBuilder
 target/

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -929,9 +929,10 @@ def finalize_wrapper(plan, final_plan):
     ----------
     plan : iterable or iterator
         a generator, list, or similar containing `Msg` objects
-    final_plan : iterable or iterator
-        a generator, list, or similar containing `Msg` objects; attempted to be
-        run no matter what happens in the first plan
+    final_plan : callable, iterable or iterator
+        a generator, list, or similar containing `Msg` objects or a callable
+        that reurns one; attempted to be run no matter what happens in the
+        first plan
 
     Yields
     ------
@@ -939,6 +940,12 @@ def finalize_wrapper(plan, final_plan):
         messages from `plan` until it terminates or an error is raised, then
         messages from `final_plan`
     '''
+    # If final_plan is a generator *function* (as opposed to a generator
+    # *instance*), call it.
+    if callable(final_plan):
+        final_plan_instance = final_plan()
+    else:
+        final_plan_instance = final_plan
     cleanup = True
     try:
         ret = yield from plan

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -18,6 +18,8 @@ Bug Fixes
 * Minor fix in the tilt computation for spiral scans.
 * Expost 'tilt' option through SPEC-like API
 * The "infinite count" (``ct`` with ``num=None``) should spawn a LivePlot.
+* ``finalize_decorator`` accepts a callable (e.g., generator function)
+  and does not accept an iterable (e.g., generator instance)
 
 v0.6.3
 ------


### PR DESCRIPTION
Discussed offline. To summarize, `finalize_decorator` accepted generator *instance* and did not accept a generator *function*, which means it would work only the first time it was used. After that, the `final_plan` generator instance would be exhuasted, and the decorator would silently do nothing.

It turns out that no other preprocessors we have written so far have this problem, so the cleanest fix is just to write out a special `finalize_decorator`, not using `make_decorator(finalize_wrapper)`.

Obviously, this is thoroughly tested.