### PR TITLE
Overhaul examples

### DIFF
--- a/bluesky/broker_examples.py
+++ b/bluesky/broker_examples.py
@@ -12,40 +12,22 @@ class SynGauss2D(Reader):
 
     Example
     -------
-    motor = Mover('motor', ['motor'])
-    det = SynGauss('det', motor, 'motor', center=0, Imax=1, sigma=1)
+    motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
+    det = SynGauss2D('det', motor, 'motor', center=0, Imax=1, sigma=1)
     """
-    _klass = 'reader'
-
     def __init__(self, name, motor, motor_field, center, Imax=1000, sigma=1,
                  nx=250, ny=250, img_sigma=50):
-        super(SynGauss2D, self).__init__(name, [name, ])
-        self.ready = True
-        self._motor = motor
-        self._motor_field = motor_field
-        self.center = center
-        self.Imax = Imax
-        self.sigma = sigma
-        self.dims = (nx, ny)
-        self.img_sigma = img_sigma
-        # stash these things in a temp directory. This might cause an
+        def func():
+            dims = (nx, ny)
+            m = motor.read()[motor_field]['value']
+            v = Imax * np.exp(-(m - center)**2 / (2 * sigma**2))
+            arr = self.gauss(dims, img_sigma) * v + np.random.random(dims) * .01
+            fs_uid = save_ndarray(arr, self.output_dir)
+            return fs_uid
+
         # exception to be raised if/when the file system cleans its temp files
         self.output_dir = tempfile.gettempdir()
-
-    def trigger(self, *, group=True):
-        self.ready = False
-        m = self._motor._data[self._motor_field]['value']
-        v = self.Imax * np.exp(-(m - self.center)**2 / (2 * self.sigma**2))
-        arr = self.gauss(self.dims, self.img_sigma) * v + np.random.random(
-            self.dims) * .01
-        fs_uid = save_ndarray(arr, self.output_dir)
-        self._data = {self.name: {'value': fs_uid, 'timestamp': ttime.time()}}
-        ttime.sleep(0.05)  # simulate exposure time
-        self.ready = True
-        return self
-
-    def read(self):
-        return self._data
+        super().__init__(name, {name: func})
 
     def _dist(self, dims):
         """

--- a/bluesky/broker_examples.py
+++ b/bluesky/broker_examples.py
@@ -17,8 +17,11 @@ class SynGauss2D(Reader):
     """
     def __init__(self, name, motor, motor_field, center, Imax=1000, sigma=1,
                  nx=250, ny=250, img_sigma=50):
+        dims = (nx, ny)
+        self.dims = dims
+        self.name = name
+
         def func():
-            dims = (nx, ny)
             m = motor.read()[motor_field]['value']
             v = Imax * np.exp(-(m - center)**2 / (2 * sigma**2))
             arr = self.gauss(dims, img_sigma) * v + np.random.random(dims) * .01

--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -63,7 +63,6 @@ class Base:
                 # hotfix 2016 -- revisit this!
                 setattr(self, field, MockSignal(field))
         self.success = True
-        self.root = self
         self.precision = 3
 
     def describe(self):

--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -132,14 +132,19 @@ class Mover(Reader):
 
     Example
     -------
+    A motor with one field.
+    >>> motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
+
     A motor that simply goes where it is set.
-    >>> motor = Positioner('motor', {'readback': lambda x: x},
-    ...                              'setpoint': lambda x: x})
+    >>> motor = Mover('motor', {'readback': lambda x: x},
+    ...                         'setpoint': lambda x: x},
+    ...               {'x': 0})
 
     A motor that adds jitter.
     >>> import numpy as np
-    >>> motor = Positioner('motor', {'readback': lambda x: x + np.random.randn()},
-    ...                              'setpoint': lambda x: x})
+    >>> motor = Mover('motor', {'readback': lambda x: x + np.random.randn()},
+    ...                         'setpoint': lambda x: x},
+    ...               {'x': 0})
     """
     def __init__(self, name, read_fields, initial_set, conf_fields=None, *,
                  fake_sleep=0):
@@ -156,6 +161,7 @@ class Mover(Reader):
         self._state = {field: {'value': func(*args, **kwargs),
                                'timestamp': ttime.time()}
                        for field, func in self._read_fields.items()}
+        # TODO Do this asynchronously and return a status object immediately.
         if self._fake_sleep:
             ttime.sleep(self._fake_sleep)
         return NullStatus()
@@ -207,6 +213,7 @@ class SynGauss(Reader):
         super().__init__(name, {name: func})
 
     def trigger(self):
+        # TODO Do this asynchronously and return a status object immediately.
         if self.exposure_time:
             ttime.sleep(self.exposure_time)
         return super().trigger()
@@ -272,6 +279,7 @@ class Syn2DGauss(Reader):
         super().__init__(name, {name: func})
 
     def trigger(self):
+        # TODO Do this asynchronously and return a status object immediately.
         if self.exposure_time:
             ttime.sleep(self.exposure_time)
         return super().trigger()
@@ -495,11 +503,11 @@ motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
 motor1 = Mover('motor1', {'motor1': lambda x: x}, {'x': 0})
 motor2 = Mover('motor2', {'motor2': lambda x: x}, {'x': 0})
 motor3 = Mover('motor3', {'motor3': lambda x: x}, {'x': 0})
-jittery_motor1 = ('jittery_motor1',
-                  {'jiterry_motor1': lambda x: x + np.random.randn()},
+jittery_motor1 = Mover('jittery_motor1',
+                  {'jittery_motor1': lambda x: x + np.random.randn()},
                   {'x': 0})
-jittery_motor2 = ('jittery_motor2',
-                  {'jiterry_motor2': lambda x: x + np.random.randn()},
+jittery_motor2 = Mover('jittery_motor2',
+                  {'jittery_motor2': lambda x: x + np.random.randn()},
                   {'x': 0})
 noisy_det = SynGauss('noisy_det', motor, 'motor', center=0, Imax=1,
                      noise='uniform', sigma=1)

--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -47,15 +47,15 @@ class Reader:
         Like `read_fields`, but providing slow-changing configuration data.
         If `None`, the configuration will simply be an empty dict.
 
-    Example
-    -------
+    Examples
+    --------
     A detector that always returns 5.
-    >>> det = Detector('det', {'intensity': lambda: 5})
+    >>> det = Readable('det', {'intensity': lambda: 5})
 
     A detector that is coupled to a motor, such that measured insensity
     varies with motor position.
-    >>> motor = Motor('motor')
-    >>> det = Detector('det',
+    >>> motor = Mover('motor')
+    >>> det = Readable('det',
     ...                {'intensity': lambda: 2 * motor.read()['value']})
     """
     def __init__(self, name, read_fields, conf_fields=None):
@@ -130,8 +130,8 @@ class Mover(Reader):
     fake_sleep : float
         simulate moving time
 
-    Example
-    -------
+    Examples
+    --------
     A motor with one field.
     >>> motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
 

--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -259,7 +259,7 @@ class Syn2DGauss(Reader):
         self.exposure_time = exposure_time
 
         def func():
-            x = motor.read()[motor_field0]['value']
+            x = motor0.read()[motor_field0]['value']
             y = motor1.read()[motor_field1]['value']
             m = np.array([x, y])
             v = Imax * np.exp(-np.sum((m - center)**2) / (2 * sigma**2))
@@ -495,6 +495,12 @@ motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
 motor1 = Mover('motor1', {'motor1': lambda x: x}, {'x': 0})
 motor2 = Mover('motor2', {'motor2': lambda x: x}, {'x': 0})
 motor3 = Mover('motor3', {'motor3': lambda x: x}, {'x': 0})
+jittery_motor1 = ('jittery_motor1',
+                  {'jiterry_motor1': lambda x: x + np.random.randn()},
+                  {'x': 0})
+jittery_motor2 = ('jittery_motor2',
+                  {'jiterry_motor2': lambda x: x + np.random.randn()},
+                  {'x': 0})
 noisy_det = SynGauss('noisy_det', motor, 'motor', center=0, Imax=1,
                      noise='uniform', sigma=1)
 det = SynGauss('det', motor, 'motor', center=0, Imax=1, sigma=1)
@@ -503,6 +509,8 @@ det2 = SynGauss('det2', motor2, 'motor2', center=1, Imax=2, sigma=2)
 det3 = SynGauss('det3', motor3, 'motor3', center=-1, Imax=2, sigma=1)
 det4 = Syn2DGauss('det4', motor1, 'motor1', motor2, 'motor2',
                   center=(0, 0), Imax=1)
+det5 = Syn2DGauss('det4', jittery_motor1, 'jittery_motor1', jittery_motor2,
+                  'jittery_motor2', center=(0, 0), Imax=1)
 
 
 def simple_scan(motor):

--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -34,155 +34,142 @@ class NullStatus:
         self._cb = cb
 
 
-class Flyer:
-    def kickoff(self):
-        return NullStatus()
+class Reader:
+    """
 
-    def describe_collect(self):
-        return {'stream_name': {}}
+    Parameters
+    ----------
+    name : string
+    read_fields : dict
+        Mapping field names to functions that return simulated data. The
+        function will be passed no arguments.
+    conf_fields : dict, optional
+        Like `read_fields`, but providing slow-changing configuration data.
+        If `None`, the configuration will simply be an empty dict.
 
-    def complete(self):
-        return NullStatus()
+    Example
+    -------
+    A detector that always returns 5.
+    >>> det = Detector('det', {'intensity': lambda: 5})
 
-    def collect(self):
-        for i in range(100):
-            yield {'data': {}, 'timestamps': {}, 'time': i, 'seq_num': i}
-
-
-class Base:
-    def __init__(self, name, fields):
+    A detector that is coupled to a motor, such that measured insensity
+    varies with motor position.
+    >>> motor = Motor('motor')
+    >>> det = Detector('det',
+    ...                {'intensity': lambda: 2 * motor.read()['value']})
+    """
+    def __init__(self, name, read_fields, conf_fields=None):
         self.name = name
         self.parent = None
-        self._fields = fields
-        self._cb = None
-        self._ready = False
-        self.configuration_attrs = []
-        for field in fields:
-            if isinstance(field, str):
-                # Flyers pass objects in as fields, not names.
-                # hotfix 2016 -- revisit this!
-                setattr(self, field, MockSignal(field))
-        self.success = True
-        self.precision = 3
-
-    def describe(self):
-        return {k: {'source': self.name, 'dtype': 'number', 'shape': None,
-                    'precision': self.precision}
-                for k in self._fields}
-
-    def __repr__(self):
-        return '{}: {}'.format(self._klass, self.name)
-
-    def read_configuration(self):
-        return {'some_configuration':
-                   {'value': 'there is a sandwich in the vacuum chamber',
-                    'timestamp': 0}}
-
-    def describe_configuration(self):
-        return {}
-
-    def configure(self, d):
-        return {}, {}
-
-    def stage(self):
-        pass
-
-    def unstage(self):
-        pass
-
-    @property
-    def done(self):
-        return self.ready
-
-    @property
-    def finished_cb(self):
-        """
-        Callback to be run when the status is marked as finished
-
-        The call back has no arguments
-        """
-        return self._cb
-
-    @finished_cb.setter
-    def finished_cb(self, cb):
-        if self._cb is not None:
-            raise RuntimeError("Can not change the call back")
-        if self.done:
-            cb()
-        else:
-            self._cb = cb
-
-    def _finish(self):
-        self.ready = True
-        if self._cb is not None:
-            self._cb()
-            self._cb = None
-
-
-class Reader(Base):
-    _klass = 'reader'
-
-    def __init__(self, *args, **kwargs):
-        super(Reader, self).__init__(*args, **kwargs)
-        self._cnt = 0
-
-    def read(self):
-        data = dict()
-        for k in self._fields:
-            data[k] = {'value': self._cnt, 'timestamp': ttime.time()}
-            self._cnt += 1
-
-        return data
+        self._read_fields = read_fields
+        if conf_fields is None:
+            conf_fields = {}
+        self._conf_fields = conf_fields
 
     def trigger(self):
-        return self
-
-
-class Mover(Base):
-    _klass = 'mover'
-
-    def __init__(self, name, fields, *, sleep_time=0, jitter=0, **kwargs):
-        super(Mover, self).__init__(name, fields, **kwargs)
-        self._data = {f: {'value': 0, 'timestamp': ttime.time()}
-                      for f in self._fields}
-        self.ready = True
-        self._fake_sleep = sleep_time
-        self._fake_jitter = jitter
+        "No-op: returns a status object immediately marked 'done'."
+        return NullStatus()
 
     def read(self):
-        return self._data
+        """
+        Simulate readings by calling functions.
 
-    def set(self, val, *, trigger=True, group=None):
-        # If trigger is False, wait for a separate 'trigger' command to move.
-        if not trigger:
-            raise NotImplementedError
-        # group is handled by the RunEngine
-        self.ready = False
+        The readings are collated with timestamps.
+        """
+        return {field: {'value': func(), 'timestamp': ttime.time()}
+                        for field, func in self._read_fields.items()}
+
+    def describe(self):
+        """
+        Provide metadata for each of the fields returned by `read`.
+
+        In this simple example, the metadata is hard-coded: we assume all
+        readings are numeric and scalar.
+        """
+        return {field: {'source': 'simulated using bluesky.examples',
+                        'dtype': 'number',
+                        'shape': [],
+                        'precision': 2}
+                for field in self._read_fields}
+
+    def read_configuration(self):
+        """
+        Like `read`, but providing slow-changing configuration readings.
+        """
+        return {field: {'value': func(), 'timestamp': ttime.time()}
+                        for field, func in self._conf_fields.items()}
+
+    def describe_configuration(self):
+        return {field: {'source': 'simulated using bluesky.examples',
+                        'dtype': 'number',
+                        'shape': [],
+                        'precision': 2}
+                for field in self._conf_fields}
+
+    def configure(self, *args, **kwargs):
+        old_conf = self.read_configuration()
+        # Update configuration here.
+        new_conf = self.read_configuration()
+        return old_conf, new_conf
+
+
+class Mover(Reader):
+    """
+
+    Parameters
+    ----------
+    name : string
+    read_fields : dict
+        Mapping field names to functions that return simulated data. The
+        function will be passed the last set of argument given to ``set()``.
+    conf_fields : dict, optional
+        Like `read_fields`, but providing slow-changing configuration data.
+        If `None`, the configuration will simply be an empty dict.
+    initial_set : dict
+        passed to ``set`` as ``set(**initial_set)`` to initialize readings
+    fake_sleep : float
+        simulate moving time
+
+    Example
+    -------
+    A motor that simply goes where it is set.
+    >>> motor = Positioner('motor', {'readback': lambda x: x},
+    ...                              'setpoint': lambda x: x})
+
+    A motor that adds jitter.
+    >>> import numpy as np
+    >>> motor = Positioner('motor', {'readback': lambda x: x + np.random.randn()},
+    ...                              'setpoint': lambda x: x})
+    """
+    def __init__(self, name, read_fields, initial_set, conf_fields=None, *,
+                 fake_sleep=0):
+        super().__init__(name, read_fields, conf_fields)
+        # Do initial set without any fake sleep.
+        self._fake_sleep = 0
+        self.set(**initial_set)
+        self._fake_sleep = fake_sleep
+
+    def set(self, *args, **kwargs):
+        """
+        Pass the arguments to the functions to create the next reading.
+        """
+        self._state = {field: {'value': func(*args, **kwargs),
+                               'timestamp': ttime.time()}
+                       for field, func in self._read_fields.items()}
         if self._fake_sleep:
-            ttime.sleep(self._fake_sleep)  # simulate moving time
-        if isinstance(val, dict):
-            for k, v in val.items():
-                self._data[k] = v + self._fake_jitter * np.random.randn()
-        else:
-            self._data = {f: {'value': (val +
-                                        self._fake_jitter * np.random.randn()),
-                              'timestamp': ttime.time()}
-                          for f in self._fields}
-        self.ready = True
-        return self
+            ttime.sleep(self._fake_sleep)
+        return NullStatus()
+
+    def read(self):
+        return self._state
 
     @property
     def position(self):
-        return self._data[self._fields[0]]['value']
-
-    def settle(self):
-        pass
+        "A heuristic that picks a single scalar out of the `read` dict."
+        return self.read()[list(self._read_fields)[0]]['value']
 
     def stop(self):
         pass
-
-    def trigger(self):
-        return self
 
 
 class SynGauss(Reader):
@@ -199,43 +186,30 @@ class SynGauss(Reader):
 
     Example
     -------
-    motor = Mover('motor', ['motor'])
+    motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
     det = SynGauss('det', motor, 'motor', center=0, Imax=1, sigma=1)
     """
-    _klass = 'reader'
-
     def __init__(self, name, motor, motor_field, center, Imax, sigma=1,
                  noise=None, noise_multiplier=1, exposure_time=0):
-        super(SynGauss, self).__init__(name, [name, ])
-        self.ready = True
-        self._motor = motor
-        self._motor_field = motor_field
-        self.center = center
-        self.Imax = Imax
-        self.sigma = sigma
-        self.noise = noise
-        self.noise_multiplier = noise_multiplier
-        self._data = {self.name: {'value': 0, 'timestamp': ttime.time()}}
-        self.exposure_time = exposure_time
         if noise not in ('poisson', 'uniform', None):
             raise ValueError("noise must be one of 'poisson', 'uniform', None")
+        self.exposure_time = exposure_time
 
-    def trigger(self, *, group=True):
-        self.ready = False
-        m = self._motor.read()[self._motor_field]['value']
-        v = self.Imax * np.exp(-(m - self.center)**2 / (2 * self.sigma**2))
-        if self.noise == 'poisson':
-            v = int(np.random.poisson(np.round(v), 1))
-        elif self.noise == 'uniform':
-            v += np.random.uniform(-1, 1) * self.noise_multiplier
-        self._data = {self.name: {'value': v, 'timestamp': ttime.time()}}
+        def func():
+            m = motor.read()[motor_field]['value']
+            v = Imax * np.exp(-(m - center)**2 / (2 * sigma**2))
+            if noise == 'poisson':
+                v = int(np.random.poisson(np.round(v), 1))
+            elif noise == 'uniform':
+                v += np.random.uniform(-1, 1) * noise_multiplier
+            return v
+
+        super().__init__(name, {name: func})
+
+    def trigger(self):
         if self.exposure_time:
-            ttime.sleep(self.exposure_time)  # simulate exposure time
-        self.ready = True
-        return self
-
-    def read(self):
-        return self._data
+            ttime.sleep(self.exposure_time)
+        return super().trigger()
 
 
 class Syn2DGauss(Reader):
@@ -276,50 +250,61 @@ class Syn2DGauss(Reader):
     motor = Mover('motor', ['motor'])
     det = SynGauss('det', motor, 'motor', center=0, Imax=1, sigma=1)
     """
-    _klass = 'reader'
-
     def __init__(self, name, motor0, motor_field0, motor1, motor_field1,
-                 center=(0,0), Imax=1, sigma=1,
-                 noise=None, noise_multiplier=1):
-        super().__init__(name, [name, ])
-        self.ready = True
-        self._motor = motor0
-        self._motor_field0 = motor_field0
-        self._motor1 = motor1
-        self._motor_field1 = motor_field1
-        self.center = np.asarray(center)
-        self.Imax = Imax
-        self.sigma = sigma
-        self.noise = noise
-        self.noise_multiplier = noise_multiplier
-        self._data = {self.name: {'value': None, 'timestamp': None}}
+                 center, Imax, sigma=1, noise=None, noise_multiplier=1,
+                 exposure_time=0):
+
         if noise not in ('poisson', 'uniform', None):
             raise ValueError("noise must be one of 'poisson', 'uniform', None")
+        self.exposure_time = exposure_time
 
-    def trigger(self, *, group=True):
-        self.ready = False
-        x = self._motor.read()[self._motor_field0]['value']
-        y = self._motor1.read()[self._motor_field1]['value']
-        m = np.array([x, y])
-        v = self.Imax * np.exp(
-            -np.sum((m - self.center)**2) / (2 * self.sigma**2))
-        if self.noise == 'poisson':
-            v = int(np.random.poisson(np.round(v), 1))
-        elif self.noise == 'uniform':
-            v += np.random.uniform(-1, 1) * self.noise_multiplier
-        self._data = {self.name: {'value': v, 'timestamp': ttime.time()}}
-        ttime.sleep(0.05)  # simulate exposure time
-        self.ready = True
-        return self
+        def func():
+            x = motor.read()[motor_field0]['value']
+            y = motor1.read()[motor_field1]['value']
+            m = np.array([x, y])
+            v = Imax * np.exp(-np.sum((m - center)**2) / (2 * sigma**2))
+            if noise == 'poisson':
+                v = int(np.random.poisson(np.round(v), 1))
+            elif noise == 'uniform':
+                v += np.random.uniform(-1, 1) * noise_multiplier
+            return v
 
-    def read(self):
-        return self._data
+        super().__init__(name, {name: func})
+
+    def trigger(self):
+        if self.exposure_time:
+            ttime.sleep(self.exposure_time)
+        return super().trigger()
+
+
+class Flyer:
+    """Flyer that complies to the API but returns empty data."""
+    def kickoff(self):
+        return NullStatus()
+
+    def describe_collect(self):
+        return {'stream_name': {}}
+
+    def complete(self):
+        return NullStatus()
+
+    def collect(self):
+        for i in range(100):
+            yield {'data': {}, 'timestamps': {}, 'time': i, 'seq_num': i}
+
+    def stop(self):
+        pass
 
 
 class MockFlyer:
     """
     Class for mocking a flyscan API implemented with stepper motors.
 
+    warning::
+    
+        This is old and should be not used as a reference for current good
+        practice. Specifically, it is its own status object, which is
+        confusing.
     """
     def __init__(self, detector, motor, loop):
         self._mot = motor
@@ -425,12 +410,22 @@ class MockFlyer:
             self._cb()
             self._cb = None
 
+    def stop(self):
+        pass
 
-class FlyMagic(Base):
-    _klass = 'flyer'
 
+class FlyMagic:
+    """
+    Another old flyer example
+
+    warning::
+    
+        This is old and should be not used as a reference for current good
+        practice. Specifically, it is its own status object, which is
+        confusing.
+    """
     def __init__(self, name, motor, det, det2, scan_points=15):
-        super(FlyMagic, self).__init__(name, [motor, det, det2])
+        self.name = name
         self._motor = motor
         self._det = det
         self._det2 = det2
@@ -489,14 +484,17 @@ class FlyMagic(Base):
             ttime.sleep(0.01)
         self._time = None
 
+    def complete(self):
+        return NullStatus()
+
     def stop(self):
         pass
 
 
-motor = Mover('motor', ['motor'])
-motor1 = Mover('motor1', ['motor1'])
-motor2 = Mover('motor2', ['motor2'])
-motor3 = Mover('motor3', ['motor3'])
+motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
+motor1 = Mover('motor1', {'motor1': lambda x: x}, {'x': 0})
+motor2 = Mover('motor2', {'motor2': lambda x: x}, {'x': 0})
+motor3 = Mover('motor3', {'motor3': lambda x: x}, {'x': 0})
 noisy_det = SynGauss('noisy_det', motor, 'motor', center=0, Imax=1,
                      noise='uniform', sigma=1)
 det = SynGauss('det', motor, 'motor', center=0, Imax=1, sigma=1)

--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -517,7 +517,7 @@ det2 = SynGauss('det2', motor2, 'motor2', center=1, Imax=2, sigma=2)
 det3 = SynGauss('det3', motor3, 'motor3', center=-1, Imax=2, sigma=1)
 det4 = Syn2DGauss('det4', motor1, 'motor1', motor2, 'motor2',
                   center=(0, 0), Imax=1)
-det5 = Syn2DGauss('det4', jittery_motor1, 'jittery_motor1', jittery_motor2,
+det5 = Syn2DGauss('det5', jittery_motor1, 'jittery_motor1', jittery_motor2,
                   'jittery_motor2', center=(0, 0), Imax=1)
 
 

--- a/bluesky/global_state.py
+++ b/bluesky/global_state.py
@@ -111,8 +111,8 @@ validate_movable = method_validator_factory('Movable',
                                             ['read', 'describe', 'trigger',
                                              'set', 'stop'])
 validate_flyable = method_validator_factory('Flyable',
-                                            ['kickoff', 'collect', 'stop',
-                                             'describe'])
+                                            ['kickoff', 'collect', 'complete',
+                                             'describe_collect', 'stop'])
 
 
 class GlobalState(HasTraits):

--- a/bluesky/tests/conftest.py
+++ b/bluesky/tests/conftest.py
@@ -17,7 +17,7 @@ RE = fresh_RE
 
 @pytest.fixture(scope='function')
 def motor_det(request):
-    motor = Mover('motor', ['motor'])
+    motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
     det = SynGauss('det', motor, 'motor', center=0, Imax=1,
                    sigma=1, exposure_time=0)
     return motor, det

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -329,7 +329,7 @@ def test_finalize_runs_after_error(fresh_RE):
 
 
 def test_reset_positions(fresh_RE):
-    motor = Mover('a', ['a'])
+    motor = Mover('a', {'a': lambda x: x}, {'x': 0})
     motor.set(5)
 
     msgs = []
@@ -378,7 +378,7 @@ def test_reset_positions_no_position_attr(fresh_RE):
 
 
 def test_relative_set(fresh_RE):
-    motor = Mover('a', ['a'])
+    motor = Mover('a', {'a': lambda x: x}, {'x': 0})
     motor.set(5)
 
     msgs = []

--- a/bluesky/tests/test_ramp_plan.py
+++ b/bluesky/tests/test_ramp_plan.py
@@ -31,7 +31,7 @@ def test_ramp(RE, db):
         yield from trigger_and_read([dd])
 
     g = ramp_plan(kickoff(), tt, inner_plan, period=0.04)
-    RE._subscribe_lossless('all', db.mds.insert)
+    RE.subscribe('all', db.mds.insert)
     RE.msg_hook = MsgCollector()
     rs_uid, = RE(g)
     hdr = db[-1]

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -151,11 +151,19 @@ def test_unstage_and_log_errors(fresh_RE):
     unstaged = {}
 
     class MoverWithFlag(Mover):
+
+        def stage(self):
+            return [self]
+
         def unstage(self):
             unstaged[self.name] = True
             return [self]
 
     class BrokenMoverWithFlag(Mover):
+
+        def stage(self):
+            return [self]
+
         def unstage(self):
             unstaged[self.name] = True
             return [self]

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -103,8 +103,8 @@ def test_stop_motors_and_log_any_errors(fresh_RE):
             stopped[self.name] = True
             raise Exception
 
-    motor = MoverWithFlag('a', ['a'], {'x': 0})
-    broken_motor = BrokenMoverWithFlag('b', ['b'], {'x': 0})
+    motor = MoverWithFlag('a', {'a': lambda x: x}, {'x': 0})
+    broken_motor = BrokenMoverWithFlag('b', {'b': lambda x: x}, {'x': 0})
 
     fresh_RE([Msg('set', broken_motor, 1), Msg('set', motor, 1), Msg('pause')])
     assert 'a' in stopped
@@ -160,8 +160,8 @@ def test_unstage_and_log_errors(fresh_RE):
             unstaged[self.name] = True
             return [self]
 
-    a = MoverWithFlag('a', ['a'])
-    b = BrokenMoverWithFlag('b', ['b'])
+    a = MoverWithFlag('a', {'a': lambda x: x}, {'x': 0})
+    b = BrokenMoverWithFlag('b', {'b': lambda x: x}, {'x': 0})
 
     unstaged.clear()
     fresh_RE([Msg('stage', a), Msg('stage', b)])
@@ -356,7 +356,7 @@ def _make_unrewindable_marker():
         def pause(self):
             raise NoReplayAllowed()
 
-    motor = Mover('motor', ['motor'], {'x': 0})
+    motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
 
     def test_plan(motor, det):
         yield Msg('set', motor, 0)
@@ -398,7 +398,7 @@ def _make_unrewindable_suspender_marker():
         def pause(self):
             raise NoReplayAllowed()
 
-    motor = Mover('motor', ['motor'], {'x': 0})
+    motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
 
     def test_plan(motor, det):
         yield Msg('set', motor, 0)

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -103,8 +103,8 @@ def test_stop_motors_and_log_any_errors(fresh_RE):
             stopped[self.name] = True
             raise Exception
 
-    motor = MoverWithFlag('a', ['a'])
-    broken_motor = BrokenMoverWithFlag('b', ['b'])
+    motor = MoverWithFlag('a', ['a'], {'x': 0})
+    broken_motor = BrokenMoverWithFlag('b', ['b'], {'x': 0})
 
     fresh_RE([Msg('set', broken_motor, 1), Msg('set', motor, 1), Msg('pause')])
     assert 'a' in stopped
@@ -356,7 +356,7 @@ def _make_unrewindable_marker():
         def pause(self):
             raise NoReplayAllowed()
 
-    motor = Mover('motor', ['motor'])
+    motor = Mover('motor', ['motor'], {'x': 0})
 
     def test_plan(motor, det):
         yield Msg('set', motor, 0)
@@ -398,7 +398,7 @@ def _make_unrewindable_suspender_marker():
         def pause(self):
             raise NoReplayAllowed()
 
-    motor = Mover('motor', ['motor'])
+    motor = Mover('motor', ['motor'], {'x': 0})
 
     def test_plan(motor, det):
         yield Msg('set', motor, 0)

--- a/bluesky/tests/test_scans.py
+++ b/bluesky/tests/test_scans.py
@@ -335,10 +335,9 @@ def _get_spiral_data(start_x, start_y):
 
 
 def test_absolute_spiral(fresh_RE):
-    motor = Mover('motor', ['motor'])
-    motor.set(0)
-    motor1 = Mover('motor1', ['motor1'])
-    motor2 = Mover('motor2', ['motor2'])
+    motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
+    motor1 = Mover('motor1', {'motor1': lambda x: x}, {'x': 0})
+    motor2 = Mover('motor2', {'motor2': lambda x: x}, {'x': 0})
 
     det = SynGauss('det', motor, 'motor', center=0, Imax=1, sigma=1)
     motor1.set(1.0)
@@ -353,10 +352,9 @@ def test_absolute_spiral(fresh_RE):
 
 
 def test_relative_spiral(fresh_RE):
-    motor = Mover('motor', ['motor'])
-    motor.set(0)
-    motor1 = Mover('motor1', ['motor1'])
-    motor2 = Mover('motor2', ['motor2'])
+    motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
+    motor1 = Mover('motor1', {'motor1': lambda x: x}, {'x': 0})
+    motor2 = Mover('motor2', {'motor2': lambda x: x}, {'x': 0})
     det = SynGauss('det', motor, 'motor', center=0, Imax=1, sigma=1)
 
     start_x = 1.0
@@ -411,10 +409,9 @@ def _get_fermat_data(x_start, y_start):
 
 
 def test_absolute_fermat_spiral(fresh_RE):
-    motor = Mover('motor', ['motor'])
-    motor.set(0)
-    motor1 = Mover('motor1', ['motor1'])
-    motor2 = Mover('motor2', ['motor2'])
+    motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
+    motor1 = Mover('motor1', {'motor1': lambda x: x}, {'x': 0})
+    motor2 = Mover('motor2', {'motor2': lambda x: x}, {'x': 0})
 
     det = SynGauss('det', motor, 'motor', center=0, Imax=1, sigma=1)
 
@@ -435,10 +432,9 @@ def test_relative_fermat_spiral(fresh_RE):
     start_x = 1.0
     start_y = 1.0
 
-    motor = Mover('motor', ['motor'])
-    motor.set(0)
-    motor1 = Mover('motor1', ['motor1'])
-    motor2 = Mover('motor2', ['motor2'])
+    motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
+    motor1 = Mover('motor1', {'motor1': lambda x: x}, {'x': 0})
+    motor2 = Mover('motor2', {'motor2': lambda x: x}, {'x': 0})
 
     det = SynGauss('det', motor, 'motor', center=0, Imax=1, sigma=1)
 

--- a/bluesky/tests/test_simple_api.py
+++ b/bluesky/tests/test_simple_api.py
@@ -48,7 +48,7 @@ def test_spec_plans(fresh_RE, pln, name, args, kwargs):
     gs.TH_MOTOR = motor1
     gs.TTH_MOTOR = motor2
     run_start = None
-    gs.MASTER_DET_FIELD = det._fields[0]
+    gs.MASTER_DET_FIELD = list(det._read_fields)[0]
     gs.MD_TIME_KEY = 'exposure_time'
 
     def capture_run_start(name, doc):

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -537,6 +537,22 @@ def ancestry(obj):
         ancestor = ancestor.parent
 
 
+def root_ancestor(obj):
+    """
+    Traverse ancestry to obtain root ancestor.
+
+    Parameters
+    ----------
+    obj : object
+        must have a `parent` attribute
+
+    Returns
+    -------
+    root : object
+    """
+    return ancestry(obj)[-1]
+
+
 def share_ancestor(obj1, obj2):
     """
     Check whether obj1 and obj2 have a common ancestor.

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -11,6 +11,8 @@ Enhancements
 * Add ``aspect`` argument to ``LiveRaster``.
 * Add ``install_nb_kicker`` to get live-updating matplotlib figures in the
   notebook while the RunEngine is running.
+* Simulated hardware devices ``Reader`` and ``Mover`` can be easily customized
+  to mock a wider range of behaviors, for testing and demos.
 
 Bug Fixes
 ^^^^^^^^^
@@ -20,6 +22,12 @@ Bug Fixes
 * The "infinite count" (``ct`` with ``num=None``) should spawn a LivePlot.
 * ``finalize_decorator`` accepts a callable (e.g., generator function)
   and does not accept an iterable (e.g., generator instance)
+
+API Changes
+^^^^^^^^^^^
+
+* The API for the simulated hardware example devices ``Reader`` and ``Mover``
+  has been changed to make them more general.
 
 v0.6.3
 ------

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -38,7 +38,7 @@ Enhancements
   through global state.
 * Make PeakStats configurable through global state.
 * Add an experimental utility for passing documents over a network and
-  processing them on a separate process or host, using 0MZ.
+  processing them on a separate process or host, using 0MQ.
 * Add ``monitor_during_wrapper`` and corresponding decorator.
 * Add ``stage_wrapper`` and corresponding decorator.
 * Built-in plans return the run uid that they generated.

--- a/doc/source/callbacks.rst
+++ b/doc/source/callbacks.rst
@@ -312,33 +312,29 @@ Example:
 .. code-block:: python
 
     from bluesky.plans import outer_product_scan
-    from bluesky.examples import det4, motor1, motor2
+    from bluesky.examples import det5, jittery_motor1, jittery_motor2
     from bluesky.callbacks import LiveMesh
 
-    # We'll introduce some simulated "jitter" in the simulated motors.
-    # Now, they won't go exactly where they are told to go.
-    motor1._fake_jitter = 0.2
-    motor2._fake_jitter = 0.2
+    # The 'jittery' example motors won't go exactly where they are told to go.
 
-    RE(outer_product_scan([det4], motor1, -3, 3, 6, motor2, -5, 5, 10, False),
-       LiveMesh('motor1', 'motor2', 'det4', xlim=(-3, 3), ylim=(-5, 5)))
+    RE(outer_product_scan([det5],
+                          jittery_motor1, -3, 3, 6,
+                          jittery_motor2, -5, 5, 10, False),
+       LiveMesh('jittery_motor1', 'jittery_motor2', 'det5',
+                xlim=(-3, 3), ylim=(-5, 5)))
 
 .. plot::
 
     from bluesky import RunEngine
     from bluesky.plans import outer_product_scan
-    from bluesky.examples import det4, motor1, motor2
+    from bluesky.examples import det5, jittery_motor1, jittery_motor2
     from bluesky.callbacks import LiveMesh
-    motor1._fake_sleep = 0
-    motor2._fake_sleep = 0
-    motor1._fake_jitter = 0.2
-    motor2._fake_jitter = 0.2
     RE = RunEngine({})
-    RE(outer_product_scan([det4], motor1, -3, 3, 6, motor2, -5, 5, 10, False),
-       LiveMesh('motor1', 'motor2', 'det4', xlim=(-3, 3), ylim=(-5, 5)))
-    # Take the jitter back out for later reuse of these motors.
-    motor1._fake_jitter = 0
-    motor2._fake_jitter = 0
+    RE(outer_product_scan([det5],
+                          jittery_motor1, -3, 3, 6,
+                          jittery_motor2, -5, 5, 10, False),
+       LiveMesh('jittery_motor1', 'jittery_motor2', 'det5',
+                xlim=(-3, 3), ylim=(-5, 5)))
 
 .. autoclass:: bluesky.callbacks.LiveMesh
 

--- a/doc/source/documents.rst
+++ b/doc/source/documents.rst
@@ -48,6 +48,8 @@ The documents in each run are:
     - time --- a timestamp for this group of readings
     - data --- a dictionary of readings like
       ``{'temperature': 5.0, 'position': 3.0}``
+    - timestamps --- a dictionary of individual timestamps for each reading,
+      from the hardware
 
 - Event Descriptor documents, with metadata about the measurements in the
   events (units, precision, etc.) and about the configuration of the hardware
@@ -115,7 +117,7 @@ The command:
     from bluesky.examples import det, motor  # simulated detector, motor
 
     RE(scan([det], motor, -3, 3, 16), purpose='calibration',
-       sample='krypotonite')
+       sample='kryptonite')
 
 generates a 'start' document like this:
 

--- a/doc/source/hardware.rst
+++ b/doc/source/hardware.rst
@@ -1,0 +1,24 @@
+How Bluesky Interface to Hardware
+=================================
+
+Bluesky interacts with hardware through a high-level abstraction, leaving the
+low-level details of communication as a separate concern. In bluesky's view,
+*all* devices are in a sense "detectors," in that they can be read. A subset
+of these devices are "positioners" that can also be set (i.e., written to or
+moved).
+
+In short, each device is represented by a Python object that has attributes and
+methods with certain established names. We have taken pains to make this
+interface as slim as possible, while still being general enough to address
+every kind of hardware we have encountered.
+
+A working reference implementation of a ``Reader`` (e.g., a detector) and a
+``Mover`` (e.g., a motor or temperature controller) are in the
+``bluesky.examples`` module. These implementations act as "simulated hardware,"
+and we use them extensively in examples, demos, and the test suite.
+
+The `ophyd
+<https://nsls-ii.github.io/ophyd>`_ package implements this interface for
+*real* hardware, communicating via `EPICS <http://www.aps.anl.gov/epics/>`_.
+Other control systems (Tango, LabView, etc.) could be integrated with bluesky
+in the future by implementing this same interface.

--- a/doc/source/hardware.rst
+++ b/doc/source/hardware.rst
@@ -1,6 +1,9 @@
 How Bluesky Interface to Hardware
 =================================
 
+Overview
+--------
+
 Bluesky interacts with hardware through a high-level abstraction, leaving the
 low-level details of communication as a separate concern. In bluesky's view,
 *all* devices are in a sense "detectors," in that they can be read. A subset
@@ -12,13 +15,31 @@ methods with certain established names. We have taken pains to make this
 interface as slim as possible, while still being general enough to address
 every kind of hardware we have encountered.
 
-A working reference implementation of a ``Reader`` (e.g., a detector) and a
-``Mover`` (e.g., a motor or temperature controller) are in the
-``bluesky.examples`` module. These implementations act as "simulated hardware,"
-and we use them extensively in examples, demos, and the test suite.
+Implementations
+---------------
+
+Real Hardware
+^^^^^^^^^^^^^
 
 The `ophyd
 <https://nsls-ii.github.io/ophyd>`_ package implements this interface for
 *real* hardware, communicating via `EPICS <http://www.aps.anl.gov/epics/>`_.
 Other control systems (Tango, LabView, etc.) could be integrated with bluesky
 in the future by implementing this same interface.
+
+Simulated Hardware
+^^^^^^^^^^^^^^^^^^
+
+A working reference implementation of a ``Reader`` (e.g., a detector) and a
+``Mover`` (e.g., a motor or temperature controller) are in the
+``bluesky.examples`` module. These implementations act as "simulated hardware,"
+and we use them extensively in examples, demos, and the test suite. Their API
+documentation is below.
+
+.. autoclass:: bluesky.examples.Reader
+.. autoclass:: bluesky.examples.Mover
+
+Specification
+-------------
+
+TO DO

--- a/doc/source/hardware.rst
+++ b/doc/source/hardware.rst
@@ -75,7 +75,7 @@ Readable Device
 
 The interface of a readable device:
 
-.. class:: ReadableDevice(name=None)
+.. class:: ReadableDevice
 
     .. attribute:: name
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -43,6 +43,7 @@ Index
    callbacks
    state-machine
    debugging
+   hardware
    msg
    run_engine
    api_changes

--- a/doc/source/metadata.rst
+++ b/doc/source/metadata.rst
@@ -93,12 +93,13 @@ For each run, the RunEngine automatically records:
 * 'plan_name' --- the function or class name of ``plan`` (e.g., 'count')
 * 'plan_type'--- e.g., the Python type of ``plan`` (e.g., 'generator')
 
-The last two can be overridden by any of the methods above. The first two are
-not user-overridable.
+The last two can be overridden by any of the methods above. The first two
+cannot be overridden by the user.
 
 .. note::
 
-    The RunEngine gets 'plan_name' and 'plan_type' from ``plan`` as follows:
+    *A technical point:* The RunEngine gets 'plan_name' and 'plan_type' from
+    ``plan`` as follows:
 
     .. code-block:: python
 
@@ -106,7 +107,7 @@ not user-overridable.
         plan_type = getattr(plan, '__name__', '')
 
     These can be more or less informative depending on what ``plan`` is. They
-    are just heurisitcs to provide *some* information by default if the plan
+    are just heuristics to provide *some* information by default if the plan
     itself and the user do not provide it.
 
 Persistently
@@ -217,8 +218,8 @@ The fields:
 * **group**
 * **project**
   
-are optional but, to facilite searchability, if they are not blank they must be
-strings. A non-string, like ``owner=5`` will produce an error that will
+are optional but, to facilitate searchability, if they are not blank they must
+be strings. A non-string, like ``owner=5`` will produce an error that will
 interrupt scan execution immediately after it starts.
 
 Similarly, the keyword **sample** has special significance. It must be either a
@@ -238,12 +239,10 @@ are reserved by the document model and cannot be set by the user.
 Required Fields
 ===============
 
-In current versions of bluesky, **no fields are universally required**. It is
-possible specify your own required fields in local configuration. See
-:ref:`md_validator`.
-
-In versions v0.4.3 and below, the keys ``owner``, ``group``, and
-``beamline_id`` were required.
+In current versions of bluesky, **no fields are universally required by bluesky
+itself**. It is possible specify your own required fields in local
+configuration. See :ref:`md_validator`. (At NSLS-II, there are facility-wide
+requirements coming soon.)
 
 .. _md_validator:
 


### PR DESCRIPTION
Two motivations for this change:

1. It is now easy to make simulated hardware that returns realistic data for testing analysis workflows when the beam is down. See docstrings for suggestive examples.

2. The `examples.py` has built up a lot of cruft as did not serve as a nice entry point for developers trying to understand the bluesky interface.

Still to do (in a later PR): unify the three different implementations of simulated flyers.