### PR TITLE
ENH/TST: Make example devices serializable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_install:
 
 install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
-  - conda create -n testenv nose python=$TRAVIS_PYTHON_VERSION scipy jsonschema traitlets pytest coverage pip databroker ophyd historydict boltons doct pyepics super_state_machine xray-vision lmfit jinja2 icu pyzmq mongoquery -c lightsource2 -c conda-forge -c soft-matter
+  - conda create -n testenv nose python=$TRAVIS_PYTHON_VERSION scipy jsonschema traitlets pytest coverage pip databroker ophyd historydict boltons doct pyepics super_state_machine xray-vision lmfit jinja2 icu pyzmq mongoquery dill -c lightsource2 -c conda-forge -c soft-matter
   - source activate testenv
   - 'pip install https://github.com/NSLS-II/event-model/zipball/master#egg=event_model'
   - conda remove metadatastore databroker filestore --yes

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -3,8 +3,9 @@ from bluesky.examples import (motor, simple_scan, det, sleepy, wait_one,
                               wait_multiple, motor1, motor2, conditional_pause,
                               checkpoint_forever, simple_scan_saving,
                               stepscan, MockFlyer, fly_gen,
-                              conditional_break, SynGauss
+                              conditional_break, SynGauss, flyer1
                               )
+from bluesky.plans import scan, fly_during_wrapper
 from bluesky.callbacks import LivePlot
 from bluesky import (RunEngine, Msg, IllegalMessageSequence,
                      RunEngineInterrupted, FailedStatus)
@@ -630,3 +631,16 @@ def test_rewindable_by_default(fresh_RE):
 
     RE(plan())  # cannot pause
     assert RE.state == 'idle'
+
+
+def test_pickling_examples(fresh_RE):
+    try:
+        import dill
+    except ImportError:
+        raise pytest.skip('requires dill')
+    _det = dill.loads(dill.dumps(det))
+    _motor = dill.loads(dill.dumps(motor))
+    _flyer1 = dill.loads(dill.dumps(flyer1))
+
+    # Make sure these objects aren't missing anything required.
+    fresh_RE(fly_during_wrapper(scan([_det], _motor, 1, 5, 5), [_flyer1]))


### PR DESCRIPTION
The old example devices happened to be serializable. I didn't realize xpdacq was effectively testing on that. This restores serializability and adds a test using dill, now an optional test dependency.

- Built-in pickle won't work in general (can't pickle local functions or
  lambda functions) but other implementations will. Here we test using dill.

attn @chiahaoliu 