### PR TITLE
MNT: stop all movable objects as successful

### DIFF
--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -253,7 +253,7 @@ class Mover(Reader):
         "A heuristic that picks a single scalar out of the `read` dict."
         return self.read()[list(self._read_fields)[0]]['value']
 
-    def stop(self):
+    def stop(self, *, success=False):
         pass
 
 
@@ -385,7 +385,7 @@ class TrivialFlyer:
         for i in range(100):
             yield {'data': {}, 'timestamps': {}, 'time': i, 'seq_num': i}
 
-    def stop(self):
+    def stop(self, *, success=False):
         pass
 
 
@@ -470,7 +470,7 @@ class MockFlyer:
         self._completion_status._finished()
         self._completion_status = None
 
-    def stop(self):
+    def stop(self, *, success=False):
         pass
 
 

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -416,7 +416,7 @@ class RunEngine:
             obj.clear_sub(cb)
         # During pause, all motors should be stopped. Call stop() on every
         # object we ever set().
-        self._stop_movable_objects()
+        self._stop_movable_objects(success=True)
         # Notify Devices of the pause in case they want to clean up.
         for obj in self._objs_seen:
             if hasattr(obj, 'pause'):
@@ -674,7 +674,7 @@ class RunEngine:
                 obj.clear_sub(cb)
             # During suspend, all motors should be stopped. Call stop() on
             # every object we ever set().
-            self._stop_movable_objects()
+            self._stop_movable_objects(success=True)
             # Notify Devices of the pause in case they want to clean up.
             for obj in self._objs_seen:
                 if hasattr(obj, 'pause'):
@@ -748,7 +748,7 @@ class RunEngine:
         if self.state == 'paused':
             self._resume_event_loop()
 
-    def _stop_movable_objects(self):
+    def _stop_movable_objects(self, *, success=True):
         "Call obj.stop() for all objects we have moved. Log any exceptions."
         for obj in self._movable_objs_touched:
             try:
@@ -757,7 +757,7 @@ class RunEngine:
                 self.log.debug("No 'stop' method available on %r", obj)
             else:
                 try:
-                    stop()
+                    stop(success=success)
                 except Exception as exc:
                     self.log.error("Failed to stop %r. Error: %r", obj, exc)
 
@@ -922,7 +922,7 @@ class RunEngine:
             raise err
         finally:
             # call stop() on every movable object we ever set()
-            self._stop_movable_objects()
+            self._stop_movable_objects(success=True)
             # Try to collect any flyers that were kicked off but not finished.
             # Some might not support partial collection. We swallow errors.
             for obj in list(self._uncollected):

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -596,7 +596,7 @@ def test_failed_status_object(fresh_RE):
             fresh_RE.loop.call_later(1, lambda: st._finished(success=False))
             return st
 
-        def stop(self):
+        def stop(self, *, success=False):
             pass
 
     ff = failer()

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -95,11 +95,11 @@ def test_stop_motors_and_log_any_errors(fresh_RE):
     stopped = {}
 
     class MoverWithFlag(Mover):
-        def stop(self):
+        def stop(self, *, success=False):
             stopped[self.name] = True
 
     class BrokenMoverWithFlag(Mover):
-        def stop(self):
+        def stop(self, *, success=False):
             stopped[self.name] = True
             raise Exception
 


### PR DESCRIPTION
These relies on changes to ophyd to allow a `success` kwarg in stop.