### PR TITLE
Make example hardware more realistic

### DIFF
--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -179,7 +179,7 @@ class Reader:
                         'dtype': 'number',
                         'shape': [],
                         'precision': 2}
-                for field in self._fields if field in self.read_attrs}
+                for field in self.read_attrs}
 
     def read_configuration(self):
         """
@@ -194,7 +194,7 @@ class Reader:
                         'dtype': 'number',
                         'shape': [],
                         'precision': 2}
-                for field in self._fields if field in self.conf_attrs}
+                for field in self.conf_attrs}
 
     def configure(self, *args, **kwargs):
         old_conf = self.read_configuration()

--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -247,14 +247,16 @@ class Mover(Reader):
     >>> motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
 
     A motor that simply goes where it is set.
-    >>> motor = Mover('motor', {'readback': lambda x: x},
-    ...                         'setpoint': lambda x: x},
+    >>> motor = Mover('motor',
+    ...               OrderedDict([('motor', lambda x: x),
+    ...                            ('motor_setpoint', lambda x: x)]),
     ...               {'x': 0})
 
     A motor that adds jitter.
     >>> import numpy as np
-    >>> motor = Mover('motor', {'readback': lambda x: x + np.random.randn()},
-    ...                         'setpoint': lambda x: x},
+    >>> motor = Mover('motor',
+    ...               OrderedDict([('motor', lambda x: x + np.random.randn()),
+    ...                            ('motor_setpoint', lambda x: x)]),
     ...               {'x': 0})
     """
     def __init__(self, name, fields, initial_set, *, read_attrs=None,
@@ -541,16 +543,28 @@ class MockFlyer:
         pass
 
 
-motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
-motor1 = Mover('motor1', {'motor1': lambda x: x}, {'x': 0})
-motor2 = Mover('motor2', {'motor2': lambda x: x}, {'x': 0})
-motor3 = Mover('motor3', {'motor3': lambda x: x}, {'x': 0})
+motor = Mover('motor', OrderedDict([('motor', lambda x: x),
+                                    ('motor_setpoint', lambda x: x)]),
+              {'x': 0})
+motor1 = Mover('motor1', OrderedDict([('motor1', lambda x: x),
+                                      ('motor1_setpoint', lambda x: x)]),
+               {'x': 0})
+motor2 = Mover('motor2', OrderedDict([('motor2', lambda x: x),
+                                      ('motor2_setpoint', lambda x: x)]),
+               {'x': 0})
+motor3 = Mover('motor3', OrderedDict([('motor3', lambda x: x),
+                                      ('motor3_setpoint', lambda x: x)]),
+               {'x': 0})
 jittery_motor1 = Mover('jittery_motor1',
-                  {'jittery_motor1': lambda x: x + np.random.randn()},
-                  {'x': 0})
+                       OrderedDict([('jittery_motor1',
+                                     lambda x: x + np.random.randn()),
+                                    ('jittery_motor1_setpoint', lambda x: x)]),
+                       {'x': 0})
 jittery_motor2 = Mover('jittery_motor2',
-                  {'jittery_motor2': lambda x: x + np.random.randn()},
-                  {'x': 0})
+                       OrderedDict([('jittery_motor2',
+                                     lambda x: x + np.random.randn()),
+                                    ('jittery_motor2_setpoint', lambda x: x)]),
+                       {'x': 0})
 noisy_det = SynGauss('noisy_det', motor, 'motor', center=0, Imax=1,
                      noise='uniform', sigma=1)
 det = SynGauss('det', motor, 'motor', center=0, Imax=1, sigma=1)

--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -106,7 +106,7 @@ class Reader:
 
     A detector that is coupled to a motor, such that measured insensity
     varies with motor position.
-    >>> motor = Mover('motor')
+    >>> motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
     >>> det = Readable('det',
     ...                {'intensity': lambda: 2 * motor.read()['value']})
     """

--- a/bluesky/tests/test_scans.py
+++ b/bluesky/tests/test_scans.py
@@ -71,6 +71,9 @@ def test_outer_product_ascan():
         {'motor2': 20.0, 'det': 1.0, 'motor1': 2.0},
         {'motor2': 10.0, 'det': 1.0, 'motor1': 3.0},
         {'motor2': 20.0, 'det': 1.0, 'motor1': 3.0}]
+    for d in expected_data:
+        d.update({'motor1_setpoint': d['motor1']})
+        d.update({'motor2_setpoint': d['motor2']})
     multi_traj_checker(scan, expected_data)
 
 
@@ -86,6 +89,9 @@ def test_outer_product_ascan_snaked():
         {'motor2': 10.0, 'det': 1.0, 'motor1': 2.0},
         {'motor2': 10.0, 'det': 1.0, 'motor1': 3.0},
         {'motor2': 20.0, 'det': 1.0, 'motor1': 3.0}]
+    for d in expected_data:
+        d.update({'motor1_setpoint': d['motor1']})
+        d.update({'motor2_setpoint': d['motor2']})
     multi_traj_checker(scan, expected_data)
 
 
@@ -98,6 +104,9 @@ def test_inner_product_ascan():
         {'motor2': 10.0, 'det': 1.0, 'motor1': 1.0},
         {'motor2': 20.0, 'det': 1.0, 'motor1': 2.0},
         {'motor2': 30.0, 'det': 1.0, 'motor1': 3.0}]
+    for d in expected_data:
+        d.update({'motor1_setpoint': d['motor1']})
+        d.update({'motor2_setpoint': d['motor2']})
     multi_traj_checker(scan, expected_data)
 
 
@@ -116,6 +125,9 @@ def test_outer_product_dscan():
         {'motor2': 28.0, 'det': 1.0, 'motor1': 7.0},
         {'motor2': 18.0, 'det': 1.0, 'motor1': 8.0},
         {'motor2': 28.0, 'det': 1.0, 'motor1': 8.0}]
+    for d in expected_data:
+        d.update({'motor1_setpoint': d['motor1']})
+        d.update({'motor2_setpoint': d['motor2']})
     multi_traj_checker(scan, expected_data)
 
 
@@ -134,6 +146,9 @@ def test_outer_product_dscan_snaked():
         {'motor2': 18.0, 'det': 1.0, 'motor1': 7.0},
         {'motor2': 18.0, 'det': 1.0, 'motor1': 8.0},
         {'motor2': 28.0, 'det': 1.0, 'motor1': 8.0}]
+    for d in expected_data:
+        d.update({'motor1_setpoint': d['motor1']})
+        d.update({'motor2_setpoint': d['motor2']})
     multi_traj_checker(scan, expected_data)
 
 
@@ -148,6 +163,9 @@ def test_inner_product_dscan():
         {'motor2': 18.0, 'det': 1.0, 'motor1': 6.0},
         {'motor2': 28.0, 'det': 1.0, 'motor1': 7.0},
         {'motor2': 38.0, 'det': 1.0, 'motor1': 8.0}]
+    for d in expected_data:
+        d.update({'motor1_setpoint': d['motor1']})
+        d.update({'motor2_setpoint': d['motor2']})
     multi_traj_checker(scan, expected_data)
 
 

--- a/bluesky/tests/test_simple_api.py
+++ b/bluesky/tests/test_simple_api.py
@@ -48,7 +48,7 @@ def test_spec_plans(fresh_RE, pln, name, args, kwargs):
     gs.TH_MOTOR = motor1
     gs.TTH_MOTOR = motor2
     run_start = None
-    gs.MASTER_DET_FIELD = list(det._read_fields)[0]
+    gs.MASTER_DET_FIELD = list(det._fields)[0]
     gs.MD_TIME_KEY = 'exposure_time'
 
     def capture_run_start(name, doc):


### PR DESCRIPTION
* Add a setpoint to the motor instances. This makes it easier to see the difference between `.name` and `.describe().keys()`. It's confusing when there is only one key.
* Refactor how read vs. conf works to make it more like ophyd.