### PR TITLE
API: Change default to ignore_callback_exceptions=False.

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -114,7 +114,7 @@ class RunEngine:
         md
             direct access to the dict-like persistent storage described above
         ignore_callback_exceptions
-            Boolean, True by default
+            Boolean, False by default
 
         msg_hook
             callable that receives all messages before they are processed
@@ -236,7 +236,7 @@ class RunEngine:
         # The Dispatcher's public methods are exposed through the
         # RunEngine for user convenience.
         self.dispatcher = Dispatcher()
-        self.ignore_callback_exceptions = True
+        self.ignore_callback_exceptions = False
         self.subscribe = self.dispatcher.subscribe
         self.unsubscribe = self.dispatcher.unsubscribe
 

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -19,16 +19,6 @@ def exception_raiser(name, doc):
     raise Exception("it's an exception that better not kill the scan!!")
 
 
-def test_main_thread_callback_exceptions():
-
-    RE(stepscan(det, motor), subs={'start': exception_raiser,
-                                   'stop': exception_raiser,
-                                   'event': exception_raiser,
-                                   'descriptor': exception_raiser,
-                                   'all': exception_raiser},
-       beamline_id='testing', owner='tester')
-
-
 def test_all():
     c = CallbackCounter()
     RE(stepscan(det, motor), subs={'all': c})

--- a/doc/source/callbacks.rst
+++ b/doc/source/callbacks.rst
@@ -517,21 +517,22 @@ false alarm.
 
 .. _debugging_callbacks:
 
-Debugging Callbacks
--------------------
+Ignoring Callback Exceptions
+----------------------------
 
-If a callback raises an exception, the RunEngine catches that exception and
-merely prints a warning. This behavior is intended to prevent some problem in
-the callbacks from aborting the plan. Often, users to prefer to let data
-collection complete and "pick up the pieces" later.
+If an exception is raised while processing a callback, the error can interrupt
+data collection. Usually, this is good: if, for example, the callback that is
+saving your data encounters an error, you want to know immediately.
 
-But this is not always desirable, especially when trying to debug problems with
-callbacks. To stop the RunEngine from catching exceptions from the callbacks,
-set
+But if a "flaky" callback is causing errors, it is possible to convert errors
+to warnings like so.
 
 .. code-block:: python
 
     RE.ignore_callback_exceptions = False
+
+This is ``False`` by default. In bluesky version 0.6.4 (September 2016) and
+earlier, this was ``True`` by default.
 
 .. _filtering:
 

--- a/doc/source/debugging.rst
+++ b/doc/source/debugging.rst
@@ -101,8 +101,3 @@ change the log level to skip DEBUG-level messages:
     For back-compatibility with old versions of bluesky, there is also an
     ``RE.verbose`` attribute. ``RE.verbose`` is a synonym for
     ``not RE.log.disabled``.
-
-Debugging Callbacks
--------------------
-
-    See :ref:`debugging_callbacks`.


### PR DESCRIPTION
We should have done this back when we removed the lossy/lossless exceptions distinction. In the current code, if MDS fails to insert your documents, all you get is a warning.

attn @gjwillms 