### PR TITLE
ENH: Add RE.clear_suspenders()

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -620,6 +620,7 @@ class RunEngine:
         See Also
         --------
         `RunEngine.remove_suspender`
+        `RunEngine.clear_suspenders`
         """
         self._suspenders.add(suspender)
         suspender.install(self)
@@ -635,10 +636,23 @@ class RunEngine:
         See Also
         --------
         `RunEngine.install_suspender`
+        `RunEngine.clear_suspenders`
         """
         if suspender in self._suspenders:
             suspender.remove()
         self._suspenders.discard(suspender)
+
+    def clear_suspenders(self):
+        """
+        Uninstall all suspenders.
+
+        See Also
+        --------
+        `RunEngine.install_suspender`
+        `RunEngine.remove_suspender`
+        """
+        for sus in self.suspenders:
+            self.remove_suspender(sus)
 
     def request_suspend(self, fut, *, pre_plan=None, post_plan=None,
                         justification=None):

--- a/bluesky/tests/test_suspenders.py
+++ b/bluesky/tests/test_suspenders.py
@@ -113,6 +113,11 @@ def test_pre_suspend_plan(fresh_RE, pre_plan, post_plan, expected_list):
     RE(scan)
     assert susp.RE is None
 
+    RE.install_suspender(susp)
+    RE.clear_suspenders()
+    assert susp.RE is None
+    assert not RE.suspenders
+
 
 def test_pause_from_suspend(fresh_RE):
     'Tests what happens when a pause is requested from a suspended state'


### PR DESCRIPTION
Just a convenience. It's annoying to have to write a loop over `RE.remove_suspender` every time you want to turn suspenders off.