### PR TITLE
FIX: _monitor was packing configuration wrong.

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1260,7 +1260,7 @@ class RunEngine:
         data_keys = obj.describe()
         config = {obj.name: {'data': {}, 'timestamps': {}}}
         config[obj.name]['data_keys'] = obj.describe_configuration()
-        for key, val in list(obj.read_configuration().items()):
+        for key, val in obj.read_configuration().items():
             config[obj.name]['data'][key] = sanitize_np(val['value'])
             config[obj.name]['timestamps'][key] = val['timestamp']
         object_keys = {obj.name: list(data_keys)}

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1258,9 +1258,11 @@ class RunEngine:
                                              obj))
         descriptor_uid = new_uid()
         data_keys = obj.describe()
-        config = obj.read_configuration()
-        for key, val in list(config.items()):
-            val['value'] = sanitize_np(val['value'])
+        config = {obj.name: {'data': {}, 'timestamps': {}}}
+        config[obj.name]['data_keys'] = obj.describe_configuration()
+        for key, val in list(obj.read_configuration().items()):
+            config[obj.name]['data'][key] = sanitize_np(val['value'])
+            config[obj.name]['timestamps'][key] = val['timestamp']
         object_keys = {obj.name: list(data_keys)}
         desc_doc = dict(run_start=self._run_start_uid, time=ttime.time(),
                         data_keys=data_keys, uid=descriptor_uid,

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -211,6 +211,9 @@ def test_redundant_monitors_are_illegal(fresh_RE):
         def read_configuration(self):
             return {}
 
+        def describe_configuration(self):
+            return {}
+
         def describe(self):
             return {}
 


### PR DESCRIPTION
Stop-stopping bug in the RunEngine monitoring code organized the configuration into the descriptor with the wrong layout. The currently-deployed code acquired data without complaint but the databroker errors (rightly) when it can't find the keys it expects.

In addition to this PR, which should probably be merged and deployed ASAP, we should:

* add more tests that exercise configuration (I will add at least one to this PR later today, but I have to teach first.)
* make the event_model stricter (mentioned way back in https://github.com/NSLS-II/bluesky/issues/134) -- this should have produced an error at acquisition time!

Can you look into this next, @licode? Reference for how the Event Descriptor is organized: http://nsls-ii.github.io/bluesky/event_descriptors.html