### PR TITLE
FIX: complete should *not* wait by default

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -649,7 +649,7 @@ def kickoff(obj, *, group=None, wait=False, **kwargs):
     return ret
 
 
-def complete(obj, *, group=None, wait=True, **kwargs):
+def complete(obj, *, group=None, wait=False, **kwargs):
     """
     Tell a flyer, 'stop collecting, whenver you are ready'.
 

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -1,6 +1,18 @@
 Release Notes
 =============
 
+v0.7.0 (dev)
+------------
+
+API Changes
+^^^^^^^^^^^
+
+* The plan ``complete``, related to fly scans, previously had ``wait=True`` by
+  default, although its documentation indicated that ``False`` was the default.
+  The code has been changed to match the documentation. Any calls to
+  ``complete`` that are expected to be blocking should be updated with the
+  keyword ``wait=True``.
+
 v0.6.4
 ------
 


### PR DESCRIPTION
- The docstring states that it does not wait by default. This changes makes the
  docstring correct.
- All other plans that have a `wait` keyword set to False by default, except
  `mv` which is a convenience.