### PR TITLE
FIX: monitor seq_num should start 1 for consistency

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1285,7 +1285,7 @@ class RunEngine:
         self.log.debug("Emitted Event Descriptor with name %r containing "
                        "data keys %r (uid=%r)", name, data_keys.keys(),
                        descriptor_uid)
-        seq_num_counter = count()
+        seq_num_counter = count(1)
 
         def emit_event(*args, **kwargs):
             # Ignore the inputs. Use this call as a signal to call read on the


### PR DESCRIPTION
For better or worse, the convention we have adopted (I think in deference to SPEC?) is that seq_num starts at 1. Callbacks like LiveRaster rely on this.