### PR TITLE
Allow optional max_depth to error when RE is called in a function

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -124,6 +124,8 @@ class RunEngine:
             Maximum stack depth; set this to prevent users from calling the
             RunEngine inside a function (which can result in unexpected
             behavior and breaks introspection tools). Default is None.
+            For built-in Python interpreter, set to 2. For IPython, set to 11
+            (tested on IPython 5.1.0; other versions may vary).
 
         md
             Direct access to the dict-like persistent storage described above
@@ -521,7 +523,8 @@ class RunEngine:
             frame = inspect.currentframe()
             depth = len(inspect.getouterframes(frame))
             if depth > self.max_depth:
-                raise RuntimeError(MAX_DEPTH_EXCEEDED_ERROR_TEXT)
+                text = MAX_DEPTH_EXCEEDED_ERR_MSG.format(self.max_depth, depth)
+                raise RuntimeError(text)
 
         # If we are in the wrong state, raise.
         if not self.state.is_idle:
@@ -2031,10 +2034,13 @@ RE.halt()      Emergency Stop: Do not perform cleanup --- just stop.
 """
 
 
-MAX_DEPTH_EXCEEDED_ERROR_TEXT = """The RunEngine should not be called from
-inside another function. Doing so breaks introspection tools and can result in
-unexpected behavior in the event of an interruption. See documentation for more
-information and what to do instead:
+MAX_DEPTH_EXCEEDED_ERR_MSG = """
+RunEngine.max_depth is set to {}; depth of {} was detected.
+
+The RunEngine should not be called from inside another function. Doing so
+breaks introspection tools and can result in unexpected behavior in the event
+of an interruption. See documentation for more information and what to do
+instead:
 
 http://nsls-ii.github.io/bluesky/plans_intro.html#combining-plans
 """

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -114,28 +114,41 @@ class RunEngine:
 
         Attributes
         ----------
-        state
-            {'idle', 'running', 'paused'}
-        md
-            direct access to the dict-like persistent storage described above
         ignore_callback_exceptions
-            Boolean, False by default
+            Boolean, False by default.
+
+        loop : asyncio event loop
+            e.g., ``asyncio.get_event_loop()`` or ``asyncio.new_event_loop()``
+
+        max_depth
+            Maximum stack depth; set this to prevent users from calling the
+            RunEngine inside a function (which can result in unexpected
+            behavior and breaks introspection tools). Default is None.
+
+        md
+            Direct access to the dict-like persistent storage described above
 
         msg_hook
-            callable that receives all messages before they are processed
+            Callable that receives all messages before they are processed
             (useful for logging or other development purposes); expected
             signature is ``f(msg)`` where ``msg`` is a ``bluesky.Msg``, a
-            kind of namedtuple; default is None
+            kind of namedtuple; default is None.
+
+        record_interruptions
+            False by default. Set to True to generate an extra event stream
+            that records any interruptions (pauses, suspensions).
+
+        state
+            {'idle', 'running', 'paused'}
 
         state_hook
-            callable with signature ``f(new_state, old_state)`` that will be
+            Callable with signature ``f(new_state, old_state)`` that will be
             called whenever the RunEngine's state attribute is updated; default
             is None
 
         suspenders
-            read-only collection of `bluesky.suspenders.SuspenderBase` objects
+            Read-only collection of `bluesky.suspenders.SuspenderBase` objects
             which can suspend and resume execution; see related methods.
-
 
         Methods
         -------

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -941,3 +941,18 @@ def test_state_hook(fresh_RE):
                 ('running', 'paused'),
                 ('idle', 'running')]
     assert states == expected
+
+
+def test_max_depth(fresh_RE):
+    RE = fresh_RE
+
+    RE.max_depth is None
+    RE([])  # should not raise
+
+    # assume test framework needs less than 100 stacks... haha
+    RE.max_depth = 100
+    RE([])  # should not raise
+
+    RE.max_depth = 0
+    with pytest.raises(RuntimeError):
+        RE([])


### PR DESCRIPTION
This PR does not change the default behavior of the RunEngine.

But if `RE.max_depth` is set (say, in the beamline config), `RE.__call__` will check the current stack depth and error out if it think it is being called from inside a function. The error message includes the URL of the specific docs section addressing why this is harmful and what to do instead.

There is no good non-null default for `max_depth` because Python and IPython operate with different base stack depths. And I would guess that different versions of IPython vary in this respect.

In the built-in interpreter:

```
>>> RE = RunEngine({})
>>> RE.max_depth = 2
>>> RE([])  # allowed
[]
>>> (lambda: RE([]))()  # disallowed
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 1, in <lambda>
  File "/Users/dallan/Documents/Repos/bluesky/bluesky/run_engine.py", line 527, in __call__
    raise RuntimeError(text)
RuntimeError:
RunEngine.max_depth is set to 2; depth of 3 was detected.

The RunEngine should not be called from inside another function. Doing so
breaks introspection tools and can result in unexpected behavior in the event
of an interruption. See documentation for more information and what to do
instead:

http://nsls-ii.github.io/bluesky/plans_intro.html#combining-plans
```

In IPython:

```
In [2]: RE = RunEngine({})

In [3]: RE.max_depth = 11

In [4]: RE([])  # allowed
Out[4]: []

In [5]: (lambda: RE([]))()  # disallowed
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-5-d35a0876b5a7> in <module>()
----> 1 (lambda: RE([]))()

<ipython-input-5-d35a0876b5a7> in <lambda>()
----> 1 (lambda: RE([]))()

/Users/dallan/Documents/Repos/bluesky/bluesky/run_engine.py in __call__(self, plan, subs, raise_if_interrupted, **metadata_kw)
    525             if depth > self.max_depth:
    526                 text = MAX_DEPTH_EXCEEDED_ERR_MSG.format(self.max_depth, depth)
--> 527                 raise RuntimeError(text)
    528
    529         # If we are in the wrong state, raise.

RuntimeError:
RunEngine.max_depth is set to 11; depth of 12 was detected.

The RunEngine should not be called from inside another function. Doing so
breaks introspection tools and can result in unexpected behavior in the event
of an interruption. See documentation for more information and what to do
instead:

http://nsls-ii.github.io/bluesky/plans_intro.html#combining-plans
```