### PR TITLE
REF: Make callbacks call super(); split plot drawing into update().

### DIFF
--- a/bluesky/callbacks/olog.py
+++ b/bluesky/callbacks/olog.py
@@ -196,3 +196,4 @@ class OlogCallback(CallbackBase):
                                     pformat(doc)))
         olog_status = self.client.log(document_content, logbooks=self.logbook)
         logger.debug('client.log returned %s' % olog_status)
+        super().start(doc)


### PR DESCRIPTION
For the plotting callbacks, here `event` just performs the document munging and calls `update(...)` to update the caches and line objects do the redraw. The arguments to `update` are just numbers, and this provides a good hook for subclasses that want to alter those numbers without mutating the document.

Also, all callbacks that inherit from `CallbackBase` now call super() to play well with multiple inheritance. We don't actually *use* MI anywhere in the package, but now we play nicer with user MI code.