### PR TITLE
ENH: Add LiveFit, a callback that integrates with lmfit.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,8 @@ before_install:
 
 install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
-  - conda create -n testenv nose python=$TRAVIS_PYTHON_VERSION scipy jsonschema traitlets pytest coverage pip databroker ophyd historydict boltons doct pyepics super_state_machine xray-vision lmfit jinja2 icu pyzmq mongoquery dill -c lightsource2 -c conda-forge -c soft-matter
+  - conda create -n testenv python=$TRAVIS_PYTHON_VERSION scipy matplotlib numpy h5py -c conda-forge -c defaults --override-channels
+  - conda install -n testenv nose jsonschema traitlets pytest coverage pip databroker ophyd historydict boltons doct pyepics super_state_machine xray-vision lmfit jinja2 icu pyzmq mongoquery dill -c lightsource2 -c conda-forge -c soft-matter
   - source activate testenv
   - 'pip install https://github.com/NSLS-II/event-model/zipball/master#egg=event_model'
   - conda remove metadatastore databroker filestore --yes

--- a/bluesky/callbacks/__init__.py
+++ b/bluesky/callbacks/__init__.py
@@ -1,3 +1,3 @@
 from .core import (CallbackBase, CallbackCounter, print_metadata, collector,
                    LiveMesh, LivePlot, LiveRaster, LiveTable, LiveFit,
-                   CollectThenCompute, _get_obj_fields)
+                   LiveFitPlot, CollectThenCompute, _get_obj_fields)

--- a/bluesky/callbacks/__init__.py
+++ b/bluesky/callbacks/__init__.py
@@ -1,3 +1,3 @@
 from .core import (CallbackBase, CallbackCounter, print_metadata, collector,
-                   LiveMesh, LivePlot, LiveRaster, LiveTable,
+                   LiveMesh, LivePlot, LiveRaster, LiveTable, LiveFit,
                    CollectThenCompute, _get_obj_fields)

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -731,7 +731,8 @@ class LiveFit(CallbackBase):
         if len(self.__ydata) < N:
             raise RuntimeError("cannot update fit until there are least {} "
                                "data points".format(N))
-        self.result = self.model.fit(self.__ydata,
-                                     **self.__independent_vars_data,
-                                     **self.init_guess)
+        kwargs = {}
+        kwargs.update(self.__independent_vars_data)
+        kwargs.update(self.init_guess)
+        self.result = self.model.fit(self.__ydata, **kwargs)
         self.__stale = False

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -636,6 +636,10 @@ class LiveTable(CallbackBase):
 
 class LiveFit(CallbackBase):
     """
+    Fit a model to data using nonlinear least-squares minimization.
+
+    Parameters
+    ----------
     model : lmfit.Model
     y : string
         name of the field in the Event document that is the dependent variable

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -359,5 +359,3 @@ def test_live_fit_plot():
     expected = {'A': 1, 'sigma': 1, 'x0': 0}
     for k, v in expected.items():
         assert np.allclose(livefit.result.values[k], v, atol=1e-6)
-
-    plt.savefig('/Users/dallan/Desktop/livefitplot.png')

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -1,17 +1,15 @@
 from bluesky.run_engine import Msg
-import asyncio
 from bluesky.examples import (motor, det, stepscan)
-from bluesky.plans import AdaptiveAbsScanPlan, AbsScanPlan
-from bluesky.callbacks import (CallbackCounter, LiveTable)
+from bluesky.plans import AdaptiveAbsScanPlan, AbsScanPlan, scan
+from bluesky.callbacks import (CallbackCounter, LiveTable, LiveFit)
 from bluesky.callbacks.zmqpub import Publisher
 from bluesky.callbacks.zmqsub import RemoteDispatcher
-from bluesky.spec_api import mesh
 from bluesky.tests.utils import setup_test_run_engine
 from bluesky.tests.utils import _print_redirect
 import multiprocessing
 import time
 import pytest
-# import numpy as numpy
+import numpy as np
 RE = setup_test_run_engine()
 
 
@@ -39,6 +37,7 @@ def _raising_callbacks_helper(stream_name, callback):
 def test_raising_ignored_or_not():
     RE.ignore_callback_exceptions = True
     assert RE.ignore_callback_exceptions
+
     def cb(name, doc):
         raise Exception
     # by default (with ignore... = True) it warns
@@ -72,11 +71,14 @@ def test_subs_input():
     # Test input normalization on OO plans
     obj_ascan = AbsScanPlan([det], motor, 1, 5, 4)
     obj_ascan.subs = cb1
-    assert obj_ascan.subs == {'all': [cb1], 'start': [], 'stop': [], 'descriptor': [], 'event': []}
+    assert obj_ascan.subs == {'all': [cb1], 'start': [], 'stop': [],
+                              'descriptor': [], 'event': []}
     obj_ascan.subs.update({'start': [cb2]})
-    assert obj_ascan.subs == {'all': [cb1], 'start': [cb2], 'stop': [], 'descriptor': [], 'event': []}
+    assert obj_ascan.subs == {'all': [cb1], 'start': [cb2], 'stop': [],
+                              'descriptor': [], 'event': []}
     obj_ascan.subs = [cb2, cb3]
-    assert obj_ascan.subs == {'all': [cb2, cb3], 'start': [], 'stop': [], 'descriptor': [], 'event': []}
+    assert obj_ascan.subs == {'all': [cb2, cb3], 'start': [], 'stop': [],
+                              'descriptor': [], 'event': []}
 
 
 def test_subscribe_msg():
@@ -112,7 +114,7 @@ def test_table_warns():
     table('start', {})
     with pytest.warns(UserWarning):
         table('descriptor', {'uid': 'asdf', 'name': 'primary',
-                            'data_keys': {'field': {'dtype': 'array'}}})
+                             'data_keys': {'field': {'dtype': 'array'}}})
 
 
 def test_table():
@@ -267,7 +269,7 @@ def test_zmq(fresh_RE):
     # Run a Publisher and a RunEngine in this main process.
 
     RE = fresh_RE
-    p = Publisher(RE, '127.0.0.1', 5567)
+    p = Publisher(RE, '127.0.0.1', 5567)  # noqa
 
     # COMPONENT 3
     # Run a RemoteDispatcher on another separate process. Pass the documents
@@ -310,3 +312,25 @@ def test_zmq(fresh_RE):
     forwarder_proc.terminate()
     dispatcher_proc.terminate()
     assert remote_accumulator == local_accumulator
+
+
+def test_live_fit():
+    try:
+        import lmfit
+    except ImportError:
+        raise pytest.skip('requires lmfit')
+
+    def gaussian(x, A, sigma, x0):
+        return A*np.exp(-(x - x0)**2/(2 * sigma**2))
+
+    model = lmfit.Model(gaussian)
+    init_guess = {'A': 2,
+                  'sigma': lmfit.Parameter('sigma', 3, min=0),
+                  'x0': -0.2}
+    cb = LiveFit(model, 'det', {'x': 'motor'}, init_guess)
+    RE(scan([det], motor, -1, 1, 100), cb)
+    # results are in cb.result.values
+
+    expected = {'A': 1, 'sigma': 1, 'x0': 0}
+    for k, v in expected.items():
+        assert np.allclose(cb.result.values[k], v, atol=1e-6)

--- a/doc/source/callbacks.rst
+++ b/doc/source/callbacks.rst
@@ -371,7 +371,7 @@ in the case of 'sigma' above, to specify constraints.
 
 To integrate with the bluesky we need to provide:
 
-* the field with the independent variable (in this example, ``'det'``)
+* the field with the dependent variable (in this example, ``'det'``)
 * a mapping between the name(s) of independent variable(s) in
   the function (``'x'``) to the corresponding field(s) in the data
   (``'motor'``)


### PR DESCRIPTION
In summary:

``` python
cb = LiveFit(lmfit_model, 'det', {'x': 'motor'}, init_guess)
# ...run a scan...
cb.result  # an lmfit.ModelResult
```

See documentation in this PR for details.

`LiveFit` itself does not introduce an lmfit dependency or any other new dependency -- it expects the user to pass in an lmfit model (or anything that provides that interface) -- so I put it in `bluesky/callbacks/core.py`.

Includes a test and minor adjacent code and docs cleanup.
