### PR TITLE
API: Change default monitor name.

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1273,7 +1273,7 @@ def monitor_during_wrapper(plan, signals):
     --------
     :func:`bluesky.plans.fly_during_wrapper`
     """
-    monitor_msgs = [Msg('monitor', sig, name=sig.name + '-monitor')
+    monitor_msgs = [Msg('monitor', sig, name=sig.name + '_monitor')
                     for sig in signals]
     unmonitor_msgs = [Msg('unmonitor', sig) for sig in signals]
 

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -181,7 +181,7 @@ def test_monitor_during_wrapper():
     processed_plan = list(monitor_during_wrapper(plan(), [det]))
     expected = 2 * [Msg('open_run'),
                     # inserted
-                    Msg('monitor', det, name=(det.name + '-monitor')),
+                    Msg('monitor', det, name=(det.name + '_monitor')),
                     Msg('null'),
                     Msg('unmonitor', det),  # inserted
                     Msg('close_run')]

--- a/bluesky/tests/test_ramp_plan.py
+++ b/bluesky/tests/test_ramp_plan.py
@@ -39,12 +39,12 @@ def test_ramp(RE, db):
     assert len(hdr.descriptors) == 2
 
     assert set([d['name'] for d in hdr.descriptors]) == \
-        set(['primary', 'mot-monitor'])
+        set(['primary', 'mot_monitor'])
 
     primary_events = list(db.get_events(hdr, stream_name='primary'))
     assert len(primary_events) > 11
 
-    monitor_events = list(db.get_events(hdr, stream_name='mot-monitor'))
+    monitor_events = list(db.get_events(hdr, stream_name='mot_monitor'))
     assert len(monitor_events) == 10
 
 


### PR DESCRIPTION
Change the default stream name for monitors from `<signal_name>-monitor` to just `<signal_name>`. The original default was both unnecessarily verbose and not a valid Python identifier (due to the `-`), which is fine but less convenient to access within a document / document stream because it is not a valid attribute name.

Since monitoring was completely broken in the last tagged release, this is a cost-free API break. We just need to notify CSX and SRX where fixed versions of monitoring are source-installed. They can keep the old names (it's configurable through the 'monitor' plans) or transition to the new ones at their preference.

attn @cmazzoli @ambarb @gjwillms @imrealkaren 