### PR TITLE
Improve LiveFit examples (use noisy data) and add new Cookbook section

### DIFF
--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -776,8 +776,8 @@ class LiveFitPlot(LivePlot):
         matplotib Axes; if none specified, new figure and axes are made.
     All additional keyword arguments are passed through to ``Axes.plot``.
     """
-    def __init__(self, livefit, *, legend_keys=None, xlim=None, ylim=None,
-                 num_points=100, ax=None, **kwargs):
+    def __init__(self, livefit, *, num_points=100, legend_keys=None, xlim=None,
+                 ylim=None, ax=None, **kwargs):
         if len(livefit.independent_vars) != 1:
             raise NotImplementedError("LiveFitPlot supports models with one "
                                       "independent variable only.")

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -797,6 +797,8 @@ class LiveFitPlot(LivePlot):
         self.livefit.start(doc)
         self.x, = self.livefit.independent_vars.keys()  # in case it changed
         super().start(doc)
+        # Put fit above other lines (default 2) but below text (default 3).
+        self.current_line.set_zorder(2.5)
 
     def event(self, doc):
         self.livefit.event(doc)

--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -740,7 +740,7 @@ jittery_motor2 = Mover('jittery_motor2',
                                     ('jittery_motor2_setpoint', lambda x: x)]),
                        {'x': 0})
 noisy_det = SynGauss('noisy_det', motor, 'motor', center=0, Imax=1,
-                     noise='uniform', sigma=1)
+                     noise='uniform', sigma=1, noise_multiplier=0.1)
 det = SynGauss('det', motor, 'motor', center=0, Imax=1, sigma=1)
 det1 = SynGauss('det1', motor1, 'motor1', center=0, Imax=5, sigma=0.5)
 det2 = SynGauss('det2', motor2, 'motor2', center=1, Imax=2, sigma=2)

--- a/doc/source/callbacks.rst
+++ b/doc/source/callbacks.rst
@@ -373,7 +373,7 @@ in the case of 'sigma' above, to specify constraints.
 
 To integrate with the bluesky we need to provide:
 
-* the field with the dependent variable (in this example, ``'det'``)
+* the field with the dependent variable (in this example, ``'noisy_det'``)
 * a mapping between the name(s) of independent variable(s) in
   the function (``'x'``) to the corresponding field(s) in the data
   (``'motor'``)
@@ -382,12 +382,12 @@ To integrate with the bluesky we need to provide:
 .. code-block:: python
 
     from bluesky.plans import scan
-    from bluesky.examples import motor, det
+    from bluesky.examples import motor, noisy_det
     from bluesky.callbacks import LiveFit
 
-    lf = LiveFit(model, 'det', {'x': 'motor'}, init_guess)
+    lf = LiveFit(model, 'noisy_det', {'x': 'motor'}, init_guess)
 
-    RE(scan([det], motor, -1, 1, 100), lf)
+    RE(scan([noisy_det], motor, -1, 1, 100), lf)
     # best-fit values for 'A', 'sigma' and 'x0' are in lf.result.values
 
 The fit results are accessible in the ``result`` attribute of the callback.
@@ -397,7 +397,7 @@ could be used in a next step, like so:
 .. code-block:: python
 
     x0 = lf.result.values['x0']
-    RE(scan([det], x0 - 1, x0 + 1, 100))
+    RE(scan([noisy_det], x0 - 1, x0 + 1, 100))
 
 Refer the
 `lmfit documentation <https://lmfit.github.io/lmfit-py/model.html#the-modelresult-class>`_
@@ -406,6 +406,8 @@ for more about ``result``.
 This example uses a model with two independent variables, x and y.
 
 .. code-block:: python
+
+    from bluesky.examples import motor1, motor2, det4
 
     def gaussian(x, y, A, sigma, x0, y0):
         return A*np.exp(-((x - x0)**2 + (y - y0)**2)/(2 * sigma**2))
@@ -446,7 +448,7 @@ Repeating the example from ``LiveFit`` above, adding a plot:
     import numpy as np
     import lmfit
     from bluesky.plans import scan
-    from bluesky.examples import motor, det
+    from bluesky.examples import motor, noisy_det
     from bluesky.callbacks import LiveFit
 
     def gaussian(x, A, sigma, x0):
@@ -457,14 +459,14 @@ Repeating the example from ``LiveFit`` above, adding a plot:
                   'sigma': lmfit.Parameter('sigma', 3, min=0),
                   'x0': -0.2}
 
-    lf = LiveFit(model, 'det', {'x': 'motor'}, init_guess)
+    lf = LiveFit(model, 'noisy_det', {'x': 'motor'}, init_guess)
 
     # now add the plot...
 
     from bluesky.callbacks import LiveFitPlot
     lpf = LiveFitPlot(lf, color='r')
 
-    RE(scan([det], motor, -1, 1, 100), lfp)
+    RE(scan([noisy_det], motor, -1, 1, 100), lfp)
 
     # Notice that we did'nt need to subscribe lf directly, just lfp.
     # But, as before, the results are in lf.result.
@@ -474,7 +476,7 @@ Repeating the example from ``LiveFit`` above, adding a plot:
     import numpy as np
     import lmfit
     from bluesky.plans import scan
-    from bluesky.examples import motor, det
+    from bluesky.examples import motor, noisy_det
     from bluesky.callbacks import LiveFit, LiveFitPlot
     from bluesky import RunEngine
 
@@ -488,14 +490,13 @@ Repeating the example from ``LiveFit`` above, adding a plot:
                   'sigma': lmfit.Parameter('sigma', 3, min=0),
                   'x0': -0.2}
 
-    lf = LiveFit(model, 'det', {'x': 'motor'}, init_guess)
+    lf = LiveFit(model, 'noisy_det', {'x': 'motor'}, init_guess)
     lfp = LiveFitPlot(lf, color='r')
 
-    RE(scan([det], motor, -1, 1, 100), lfp)
+    RE(scan([noisy_det], motor, -1, 1, 100), lfp)
 
 We can use the standard ``LivePlot`` to show the data on the same axes.
 Notice that they can styled independently.
-
 
 .. code-block:: python
 
@@ -503,16 +504,16 @@ Notice that they can styled independently.
 
     fig, ax = plt.subplots()  # explitly create figure, axes to use below
     lfp = LiveFitPlot(lf, ax=ax, color='r')
-    lp = LivePlot('det', 'motor', ax=ax, marker='o', linestyle='none')
+    lp = LivePlot('noisy_det', 'motor', ax=ax, marker='o', linestyle='none')
 
-    RE(scan([det], motor, -1, 1, 100), [lp, lfp])
+    RE(scan([noisy_det], motor, -1, 1, 100), [lp, lfp])
 
 .. plot::
 
     import numpy as np
     import lmfit
     from bluesky.plans import scan
-    from bluesky.examples import motor, det
+    from bluesky.examples import motor, noisy_det
     from bluesky.callbacks import LiveFit, LivePlot, LiveFitPlot
     from bluesky import RunEngine
 
@@ -528,11 +529,11 @@ Notice that they can styled independently.
 
     import matplotlib.pyplot as plt
     fig, ax = plt.subplots()
-    lf = LiveFit(model, 'det', {'x': 'motor'}, init_guess)
+    lf = LiveFit(model, 'noisy_det', {'x': 'motor'}, init_guess)
     lfp = LiveFitPlot(lf, ax=ax, color='r')
-    lp = LivePlot('det', 'motor', ax=ax, marker='o', linestyle='none')
+    lp = LivePlot('noisy_det', 'motor', ax=ax, marker='o', linestyle='none')
 
-    RE(scan([det], motor, -1, 1, 50), [lfp, lp])
+    RE(scan([noisy_det], motor, -1, 1, 50), [lfp, lp])
     plt.draw()
 
 .. autoclass:: bluesky.callbacks.LiveFitPlot

--- a/doc/source/cookbook/index.rst
+++ b/doc/source/cookbook/index.rst
@@ -1,0 +1,19 @@
+Cookbook
+========
+
+These are complete, working examples meant as a starting point for
+customization by the user. They illustrate some of the range of what is
+possible.
+
+For intermediate or advanced Python programmers, this section may be the right
+starting point to quickly get up to speed on bluesky. For newcomers to the
+language, these examples are probably not the right places to start: we
+recommend at least skimming the previous sections, where the various components
+of bluesky are introduced methodically and with more prose commentary.
+
+As you can see, this section is a work in progress. This list of examples will
+grow in the coming weeks.
+
+.. toctree::
+
+    scan_gaussian

--- a/doc/source/cookbook/scan_gaussian.py
+++ b/doc/source/cookbook/scan_gaussian.py
@@ -1,0 +1,52 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import lmfit
+from bluesky.plans import (subs_decorator, abs_set, trigger_and_read,
+                           run_decorator, stage_decorator)
+from bluesky.callbacks import LiveFit, LiveFitPlot, LivePlot
+from bluesky.examples import motor, noisy_det
+from bluesky import RunEngine
+
+RE = RunEngine({})
+
+
+def errorbar(lmfit_result, param_name):
+    # width of 95% conf interfal:
+    ci = lmfit_result.conf_interval()
+    return ci[param_name][-2][1] - ci[param_name][1][1]
+
+
+def gaussian(x, A, sigma, x0):
+    return A * np.exp(-(x - x0)**2 / (2 * sigma**2))
+
+
+model = lmfit.Model(gaussian)
+guess = {'A': 10,
+         'x0': 1,
+         'sigma': lmfit.Parameter('sigma', 3, min=0)}
+
+
+def scan_gaussian(detectors, motor, start, stop, num):
+    global lf
+    main_detector = detectors[0]
+    main_motor_field, *_ = motor.describe()
+    lf = LiveFit(model, main_detector.name, {'x': main_motor_field}, guess)
+    lfp = LiveFitPlot(lf, color='r', ax=fig.gca())
+    lp = LivePlot(main_detector, main_motor_field,
+                  linestyle='none', marker='o', ax=plt.gca())
+
+    @subs_decorator([lfp, lp])
+    @stage_decorator(list(detectors) + [motor])
+    @run_decorator()
+    def plan():
+        while True:
+            for step in np.linspace(start, stop, num):
+                yield from abs_set(motor, step, wait=True)
+                yield from trigger_and_read(list(detectors) + [motor])
+            err = errorbar(lf.result, 'sigma')
+            if err < .03:
+                break
+
+    yield from plan()
+
+RE(scan_gaussian([noisy_det], motor, -1, 1, 200))

--- a/doc/source/cookbook/scan_gaussian.rst
+++ b/doc/source/cookbook/scan_gaussian.rst
@@ -1,0 +1,4 @@
+Re-scan until fit achieves desired confidence
+---------------------------------------------
+
+.. literalinclude:: scan_gaussian.py

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -34,6 +34,7 @@ Index
 -----
 
 .. toctree::
+   :caption: User Documentation
    :maxdepth: 1
 
    plans_intro
@@ -45,6 +46,12 @@ Index
    event_descriptors
    async
    debugging
+   cookbook/index
+
+.. toctree::
+   :caption: Developer Documentation
+   :maxdepth: 1
+
    hardware
    msg
    run_engine


### PR DESCRIPTION
There a couple ways that projects automate generating examples. I looked at a couple and didn't see a clear winner, so I'd like to stick to a basic manual approach until it's more clear which solution best fits bluesky.