### PR TITLE
ENH: add hard-kill option to SignalHandler

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -972,8 +972,8 @@ class RunEngine:
                     # See https://github.com/NSLS-II/bluesky/pull/242
                     print("An unknown external library has improperly raised "
                           "KeyboardInterrupt. Intercepting and triggering "
-                          "a hard pause instead.")
-                    self.loop.call_soon(self.request_pause, False)
+                          "a HALT.")
+                    self.loop.call_soon(self.halt)
                     print(PAUSE_MSG)
                 except asyncio.CancelledError as e:
                     # if we are handling this twice, raise and leave the plans

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -406,8 +406,7 @@ def test_rogue_sigint(fresh_RE):
         raise KeyboardInterrupt()
 
     RE(bad_scan())
-    assert RE.state == 'paused'
-    RE.abort()
+    assert RE.state == 'idle'
 
 
 def test_seqnum_nonrepeated(fresh_RE):

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -523,6 +523,26 @@ def test_sigint_many_hits(fresh_RE):
     RE(hanging_plan())
     # Check that hammering SIGINT escaped from that 10-second sleep.
     assert ttime.time() - start_time < 2
+    # The KeyboardInterrupt will have been converted to a hard pause.
+    assert RE.state == 'paused'
+    RE.abort()
+
+    def infinite_plan():
+        while True:
+            yield Msg('null')
+
+    def hanging_callback(name, doc):
+        ttime.sleep(10)
+
+    start_time = ttime.time()
+    timer = threading.Timer(0.2, sim_kill, (11,))
+    timer.start()
+    RE(infinite_plan())
+    # Check that hammering SIGINT escaped from that 10-second sleep.
+    assert ttime.time() - start_time < 2
+    # The KeyboardInterrupt will have been converted to a hard pause.
+    assert RE.state == 'paused'
+    RE.abort()
 
 
 def _make_plan_marker():

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -2,6 +2,7 @@ import asyncio
 import threading
 import os
 import signal
+import sys
 from collections import defaultdict
 import time as ttime
 import pytest
@@ -502,6 +503,8 @@ def test_sigint_three_hits(fresh_RE, motor_det):
     assert done_cleanup_time - end_time > 0.3
 
 
+@pytest.mark.skipif(sys.version_info < (3, 5),
+                    reason="requires python3.5")
 def test_sigint_many_hits_pln(fresh_RE):
     RE = fresh_RE
     pid = os.getpid()
@@ -527,6 +530,8 @@ def test_sigint_many_hits_pln(fresh_RE):
     assert RE.state == 'idle'
 
 
+@pytest.mark.skipif(sys.version_info < (3, 5),
+                    reason="requires python3.5")
 def test_sigint_many_hits_cb(fresh_RE):
     RE = fresh_RE
     pid = os.getpid()

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -524,8 +524,7 @@ def test_sigint_many_hits_pln(fresh_RE):
     # Check that hammering SIGINT escaped from that 10-second sleep.
     assert ttime.time() - start_time < 2
     # The KeyboardInterrupt will have been converted to a hard pause.
-    assert RE.state == 'paused'
-    RE.abort()
+    assert RE.state == 'idle'
 
 
 def test_sigint_many_hits_cb(fresh_RE):
@@ -553,8 +552,7 @@ def test_sigint_many_hits_cb(fresh_RE):
     # Check that hammering SIGINT escaped from that 10-second sleep.
     assert ttime.time() - start_time < 2
     # The KeyboardInterrupt will have been converted to a hard pause.
-    assert RE.state == 'paused'
-    RE.abort()
+    assert RE.state == 'idle'
     # Check that hammering SIGINT escaped from that 10-second sleep.
     assert ttime.time() - start_time < 2
 

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -549,7 +549,7 @@ def test_sigint_many_hits_cb(fresh_RE):
     start_time = ttime.time()
     timer = threading.Timer(0.2, sim_kill, (11,))
     timer.start()
-    RE(infinite_plan(), hanging_callback)
+    RE(infinite_plan(), {'start': hanging_callback})
     # Check that hammering SIGINT escaped from that 10-second sleep.
     assert ttime.time() - start_time < 2
     # The KeyboardInterrupt will have been converted to a hard pause.

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -508,7 +508,7 @@ def test_sigint_many_hits_pln(fresh_RE):
 
     def sim_kill(n=1):
         for j in range(n):
-            print('KILL')
+            print('KILL', j)
             ttime.sleep(0.05)
             os.kill(pid, signal.SIGINT)
 

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -141,6 +141,10 @@ class SignalHandler:
             if self.log is not None:
                 self.log.debug('SignalHandler caught SIGINT; count is %r',
                                self.count)
+            if self.count > 10:
+                orig_func = self.original_handler
+                self.release()
+                orig_func(signum, frame)
 
         signal.signal(self.sig, handler)
         return self


### PR DESCRIPTION
If the handler has accumulated 10 sigints without it being cleared by
the RunEngine, something is going very wrong.  Let python raise a
KeyboardInterupt.

This needs a bit of consideration to make sure that we are properly resetting the count from the RE.