### PR TITLE
MNT: Specify a root in FileStore resource generated by example.

### DIFF
--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -473,7 +473,8 @@ class ReaderWithFileStore(Reader):
         self._file_stem = short_uid()
         self._path_stem = os.path.join(self.save_path, self._file_stem)
         self._resource_id = self.fs.insert_resource(self.filestore_spec,
-                                                    self._path_stem, {})
+                                                    self._path_stem, {},
+                                                    root=self.save_path)
 
     def trigger(self):
         # save file stash file name
@@ -686,7 +687,8 @@ class GeneralReaderWithFileStore(Reader):
         self._file_stem = short_uid()
         self._path_stem = os.path.join(self.save_path, self._file_stem)
         self._resource_id = self.fs.insert_resource(self.filestore_spec,
-                                                    self._path_stem, {})
+                                                    self._path_stem, {},
+                                                    root=self.save_path)
 
     def trigger(self):
         # save file stash file name

--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -473,7 +473,7 @@ class ReaderWithFileStore(Reader):
         self._file_stem = short_uid()
         self._path_stem = os.path.join(self.save_path, self._file_stem)
         self._resource_id = self.fs.insert_resource(self.filestore_spec,
-                                                    self._path_stem, {},
+                                                    self._file_stem, {},
                                                     root=self.save_path)
 
     def trigger(self):
@@ -726,8 +726,8 @@ class GeneralReaderWithFileStore(Reader):
 class ReaderWithFSHandler:
     specs = {'RWFS_NPY'}
 
-    def __init__(self, filename):
-        self._name = filename
+    def __init__(self, filename, root=''):
+        self._name = os.path.join(root, filename)
 
     def __call__(self, index):
         return np.load('{}_{}.npy'.format(self._name, index))

--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -732,6 +732,11 @@ class ReaderWithFSHandler:
     def __call__(self, index):
         return np.load('{}_{}.npy'.format(self._name, index))
 
+    def get_file_list(self, datum_kwarg_gen):
+        "This method is optional. It is not needed for access, but for export."
+        return ['{name}_{index}.npy'.format(name=self._name, **kwargs)
+                for kwargs in datum_kwarg_gen]
+
 
 motor = Mover('motor', OrderedDict([('motor', lambda x: x),
                                     ('motor_setpoint', lambda x: x)]),

--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -687,7 +687,7 @@ class GeneralReaderWithFileStore(Reader):
         self._file_stem = short_uid()
         self._path_stem = os.path.join(self.save_path, self._file_stem)
         self._resource_id = self.fs.insert_resource(self.filestore_spec,
-                                                    self._path_stem, {},
+                                                    self._file_stem, {},
                                                     root=self.save_path)
 
     def trigger(self):


### PR DESCRIPTION
Need this to test `db.export` and it's good to advertise this best-practice anyway.