### PR TITLE
DOC: Move debugging details from top-level docs.

### DIFF
--- a/doc/source/debugging.rst
+++ b/doc/source/debugging.rst
@@ -12,13 +12,32 @@ To follow the RunEngine's progress through the plan, use the message hook:
 
     RE.msg_hook = print
 
-Before each message ``msg`` in the plan is processed by the RunEngine,
-``print(msg)`` will be called. The result is *extremely* verbose and may even
-significantly slow down plan execution, so it should only be used for
-debugging.
+Now the RunEngine will call ``print(msg)`` before processing each ``msg`` in
+the plan. Execute the plan that is causing the issue and watch the output.
+Suppose we are running a ``count`` that freezes up while triggering a detector.
+That would look like this:
 
-Using ``print`` is easiest, but in general any function can be used. For
-example, to write to a file:
+.. code-block:: python
+
+   In [7]: RE(count([det]))
+   stage: (<bluesky.examples.SynGauss object at 0x10f1bfb38>), (), {}
+   open_run: (None), (), {'plan_args': {'num': 1, 'detectors': ['<bluesky.examples.SynGauss object at 0x10f1bfb38>']}, 'detectors': ['det'], 'plan_name': 'count'}
+   checkpoint: (None), (), {}
+   trigger: (<bluesky.examples.SynGauss object at 0x10f1bfb38>), (), {'group': 'trigger-ff93f4'}
+   wait: (None), (), {'group': 'trigger-ff93f4'}
+
+The last message is is a 'wait' message, and it waiting for the 'trigger' just
+above it to complete. If the plan freezes at this point, a likely culprit is
+the triggering mechanism of the detector. In this example, we can see the
+detector in question is a simulated detector, ``bluesky.examples.SynGauss``.
+From here we would investigate whether the hardware was behaving properly and
+whether its triggering behavior was programmed properly on the Python side.
+
+When finished troubleshooting, set ``RE.msg_hook = None``.
+
+We used ``print`` for simple debugging. Any user-defined function that accepts
+a ``bluesky.Msg`` namedtuple as its argument could also be used. For example,
+to write to a file:
 
 .. code-block:: python
 
@@ -27,12 +46,6 @@ example, to write to a file:
             f.write(str(msg))
 
     RE.msg_hook = append_to_file
-
-To restore default behavior, set the hook back to ``None``:
-
-.. code-block:: python
-
-    RE.msg_hook = None
 
 State Hook
 ----------


### PR DESCRIPTION
Content rescued from rewrite of top-level docs' examples (a.k.a. cookbook) section. This was not really much of an "example," more like a wall of text. It belongs here in bluesky.