### PR TITLE
ENH: add nicely formatted msg_hook hepler

### DIFF
--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -15,6 +15,7 @@ import sys
 import numpy as np
 from cycler import cycler
 import logging
+import datetime
 logger = logging.getLogger(__name__)
 
 
@@ -872,3 +873,13 @@ def ensure_uid(doc_or_uid):
         return doc_or_uid['uid']
     except TypeError:
         return doc_or_uid
+
+
+def ts_msg_hook(msg):
+    t = '{:%H:%m:%S}'.format(datetime.datetime.now())
+    msg_fmt = '{: <17s} -> {!s: <15s} args: {}, kwargs: {}'.format(
+        msg.command,
+        msg.obj.name if hasattr(msg.obj, 'name') else msg.obj,
+        msg.args,
+        msg.kwargs)
+    print('{} {}'.format(t, msg_fmt))


### PR DESCRIPTION
Gives time stamps, uses the object name and keeps things alligned

```
In [121]: RE.msg_hook = ts_msg_hook

In [122]: RE(bp.count([det], num=5, delay=1))
11:02:55 stage             -> det             args: (), kwargs: {}
11:02:55 open_run          -> None            args: (), kwargs: {'num_steps': 5, 'plan_name': 'count', 'plan_args': {'detectors': ['SynGauss(name=det)'], 'num': 5}, 'detectors': ['det']}
11:02:55 checkpoint        -> None            args: (), kwargs: {}
11:02:55 trigger           -> det             args: (), kwargs: {'group': 'trigger-f4a928'}
11:02:55 wait              -> None            args: (), kwargs: {'group': 'trigger-f4a928'}
11:02:55 create            -> None            args: (), kwargs: {'name': 'primary'}
11:02:55 read              -> det             args: (), kwargs: {}
11:02:55 save              -> None            args: (), kwargs: {}
11:02:55 sleep             -> None            args: (1,), kwargs: {}
11:02:56 checkpoint        -> None            args: (), kwargs: {}
11:02:56 trigger           -> det             args: (), kwargs: {'group': 'trigger-11a9a7'}
11:02:56 wait              -> None            args: (), kwargs: {'group': 'trigger-11a9a7'}
11:02:56 create            -> None            args: (), kwargs: {'name': 'primary'}
11:02:56 read              -> det             args: (), kwargs: {}
11:02:56 save              -> None            args: (), kwargs: {}
11:02:56 sleep             -> None            args: (1,), kwargs: {}
11:02:57 checkpoint        -> None            args: (), kwargs: {}
11:02:57 trigger           -> det             args: (), kwargs: {'group': 'trigger-27a439'}
11:02:57 wait              -> None            args: (), kwargs: {'group': 'trigger-27a439'}
11:02:57 create            -> None            args: (), kwargs: {'name': 'primary'}
11:02:57 read              -> det             args: (), kwargs: {}
11:02:57 save              -> None            args: (), kwargs: {}
11:02:57 sleep             -> None            args: (1,), kwargs: {}
11:02:58 checkpoint        -> None            args: (), kwargs: {}
11:02:58 trigger           -> det             args: (), kwargs: {'group': 'trigger-96cec9'}
11:02:58 wait              -> None            args: (), kwargs: {'group': 'trigger-96cec9'}
11:02:58 create            -> None            args: (), kwargs: {'name': 'primary'}
11:02:58 read              -> det             args: (), kwargs: {}
11:02:58 save              -> None            args: (), kwargs: {}
11:02:58 sleep             -> None            args: (1,), kwargs: {}
11:02:59 checkpoint        -> None            args: (), kwargs: {}
11:02:59 trigger           -> det             args: (), kwargs: {'group': 'trigger-60b6d3'}
11:02:59 wait              -> None            args: (), kwargs: {'group': 'trigger-60b6d3'}
11:02:59 create            -> None            args: (), kwargs: {'name': 'primary'}
11:02:59 read              -> det             args: (), kwargs: {}
11:02:59 save              -> None            args: (), kwargs: {}
11:02:59 sleep             -> None            args: (1,), kwargs: {}
11:02:00 close_run         -> None            args: (), kwargs: {}
11:02:00 unstage           -> det             args: (), kwargs: {}
Out[122]: 
['2e772213-d6cf-44c2-8358-022b84bf7897']
```