### PR TITLE
Add square spiral plan

### DIFF
--- a/bluesky/plan_patterns.py
+++ b/bluesky/plan_patterns.py
@@ -85,7 +85,7 @@ def spiral_square_pattern(x_motor, y_motor, x_centre, y_centre, x_range, y_range
     y_num : float (must be even if x_num is even and must be odd if x_num is odd, if not it is increased by 1 to ensure this)
         number of y axis points
    
-   Returns
+    Returns
     -------
     cyc : cycler
     '''
@@ -114,13 +114,10 @@ def spiral_square_pattern(x_motor, y_motor, x_centre, y_centre, x_range, y_range
     y_min=y_centre - delta_y * (y_num-1)/2
     
     for n,i_ring in enumerate(range(num_st, num_ring+1,2)):
-        #print ('x_centre: '+str(x_centre)+', delta_x: '+str(delta_x))
-        #print ('y_centre: '+str(y_centre)+', delta_y: '+str(delta_y))
         x_ring_max=x_centre + delta_x * (n+offset)
         y_ring_max=y_centre + delta_y * (n+offset)
         x_ring_min=x_centre - delta_x * (n+offset)
-        y_ring_min=y_centre - delta_y * (n+offset)
-        #print('i_ring = '+str(i_ring)+', x_ring_min= '+str(x_ring_min)+', y_ring_min= '+str(y_ring_min)  ) 
+        y_ring_min=y_centre - delta_y * (n+offset) 
 
         for n in range(1, i_ring):
             x = x_ring_min+delta_x*(n-1)

--- a/bluesky/plan_patterns.py
+++ b/bluesky/plan_patterns.py
@@ -65,6 +65,7 @@ def spiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth, *,
         
 def spiral_square_pattern(x_motor, y_motor, x_centre, y_centre, x_range, y_range, x_num,y_num):
     '''Square spiral scan, centered around (x_start, y_start)
+    
     Parameters
     ----------
     x_motor : object, optional
@@ -82,52 +83,36 @@ def spiral_square_pattern(x_motor, y_motor, x_centre, y_centre, x_range, y_range
     x_num : float
         number of x axis points
     y_num : float (must be even if x_num is even and must be odd if x_num is odd, if not it is increased by 1 to ensure this)
-        number of y axis points 
-    Returns
+        number of y axis points
+   
+   Returns
     -------
     cyc : cycler
     '''
-
-
     x_points, y_points = [], []
 
     if x_num%2==0:
         num_st= 2
         if y_num%2==1:
            y_num+=1
-
         offset=0.5
-        
     else:
         num_st=1
         if y_num%2==0:
             y_num+=1
-
         offset=0
         
         x_points.append(x_centre)
         y_points.append(y_centre)
-        
-    #print( 'x_range = '+str(x_range)+', x_num = '+str(x_num)  )
-    #print( 'y_range = '+str(y_range)+', y_num = '+str(y_num)  )
-     
+
     delta_x = x_range/(x_num-1)
     delta_y = y_range/(y_num-1)
-
-
-    
     num_ring = max(x_num,y_num)
-
     x_max=x_centre + delta_x * (x_num-1)/2
     x_min=x_centre - delta_x * (x_num-1)/2
-
     y_max=y_centre + delta_y * (y_num-1)/2
     y_min=y_centre - delta_y * (y_num-1)/2
     
-
-
-    
-    #print ( 'num_ring = '+str(num_ring)  )
     for n,i_ring in enumerate(range(num_st, num_ring+1,2)):
         #print ('x_centre: '+str(x_centre)+', delta_x: '+str(delta_x))
         #print ('y_centre: '+str(y_centre)+', delta_y: '+str(delta_y))
@@ -152,8 +137,7 @@ def spiral_square_pattern(x_motor, y_motor, x_centre, y_centre, x_range, y_range
             if ( (x <= x_max) and (x>= x_min) and (y<=y_max) and (y>=y_min)     ):
                 x_points.append(x)
                 y_points.append(y)
-
-            
+       
         for n in range(1, i_ring):
             x = x_ring_max-delta_x*(n-1)
             y = y_ring_max
@@ -169,8 +153,6 @@ def spiral_square_pattern(x_motor, y_motor, x_centre, y_centre, x_range, y_range
             if ( (x <= x_max) and (x>= x_min) and (y<=y_max) and (y>=y_min)     ):
                 x_points.append(x)
                 y_points.append(y)
-
-
 
     cyc = cycler(x_motor, x_points)
     cyc += cycler(y_motor, y_points)

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2890,6 +2890,7 @@ def relative_spiral(detectors, x_motor, y_motor, x_range, y_range, dr, nth,
 def spiral_square(detectors, x_motor, y_motor, x_centre, y_centre, x_range,
                   y_range, x_num, y_num, *, per_step=None, md=None):
     '''Absolute square spiral scan, centered around (x_centre, y_centre)
+    
     Parameters
     ----------
     detectors : list


### PR DESCRIPTION
<!--- This request adds square spiral plan to plan.py and square spiral pattern to plan_pattern.py-->

## Description
<!--- This allows for a square spiral scan, similar to a spiral scan but using squares instead of circles. This allows for the resulting data to be placed on a rectangular mesh without interpolation.-->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
