### PR TITLE
Update plan_patterns.py

### DIFF
--- a/bluesky/plan_patterns.py
+++ b/bluesky/plan_patterns.py
@@ -9,7 +9,7 @@ from .utils import snake_cyclers
 
 
 def spiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth, *,
-           tilt=0.0):
+           asym=1, tilt=0.0):
     '''Spiral scan, centered around (x_start, y_start)
 
     Parameters
@@ -28,6 +28,8 @@ def spiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth, *,
         y width of spiral
     dr : float
         Delta radius
+    asym : float
+        asymetry of the scan, giving a y axis 'radius' (dr) = asym*dr while keeping the x axis 'radius' (dr) = dr 
     nth : float
         Number of theta steps
     tilt : float, optional
@@ -38,9 +40,9 @@ def spiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth, *,
     cyc : cycler
     '''
     half_x = x_range / 2
-    half_y = y_range / 2
+    half_y = y_range / (2*asym)
 
-    r_max = np.sqrt(half_x ** 2 + half_y ** 2)
+    r_max = np.sqrt(half_x ** 2 + half_y** 2)
     num_ring = 1 + int(r_max / dr)
     tilt_tan = np.tan(tilt + np.pi / 2.)
 
@@ -53,8 +55,8 @@ def spiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth, *,
         for i_angle in range(int(i_ring * nth)):
             angle = i_angle * angle_step
             x = radius * np.cos(angle)
-            y = radius * np.sin(angle)
-            if ((abs(x - y / tilt_tan) <= half_x) and (abs(y) <= half_y)):
+            y = radius * np.sin(angle)*asym
+            if ((abs(x - (y/asym) / tilt_tan) <= half_x) and (abs(y/asym) <= half_y)):
                 x_points.append(x_start + x)
                 y_points.append(y_start + y)
 
@@ -64,7 +66,7 @@ def spiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth, *,
 
 
 def spiral_fermat(x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
-                  factor, *, tilt=0.0):
+                  factor, *, asym=1,tilt=0.0):
     '''Absolute fermat spiral scan, centered around (x_start, y_start)
 
     Parameters
@@ -95,7 +97,7 @@ def spiral_fermat(x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
     phi = 137.508 * np.pi / 180.
 
     half_x = x_range / 2
-    half_y = y_range / 2
+    half_y = y_range / (2*asym)
     tilt_tan = np.tan(tilt + np.pi / 2.)
 
     x_points, y_points = [], []
@@ -106,9 +108,9 @@ def spiral_fermat(x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
         radius = np.sqrt(i_ring) * dr / factor
         angle = phi * i_ring
         x = radius * np.cos(angle)
-        y = radius * np.sin(angle)
+        y = radius * np.sin(angle)*asym
 
-        if ((abs(x - y / tilt_tan) <= half_x) and (abs(y) <= half_y)):
+        if ((abs(x - (y/asym) / tilt_tan) <= half_x) and (abs(y) <= half_y)):
             x_points.append(x_start + x)
             y_points.append(y_start + y)
 


### PR DESCRIPTION
<!--- Add an asymetry paramter to spiral and fermat_spiral to allow for elliptical spirals -->


## Description
<!--- I have added an asymetry parameter to spiral_pattern and fermat_spiral_pattern which is multiplied by the y value to result in an elliptical spiral. This allows for these scans to work effectively when the x and y axis do not have the same units.-->

## Motivation and Context
<!--- THis change is used to allow for axis of different units to be used in the spiral and fermat_spiral plans -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- This has been tested extensively on the ESM beamline-->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
