### PR TITLE
FIX: do not keep old exceptions around

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ addons:
 
 matrix:
   include:
-    - python: 3.4
-      env: BUILD_DOCS=false
     - python: 3.5
       env: BUILD_DOCS=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
 install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
   - conda create -n testenv python=$TRAVIS_PYTHON_VERSION scipy matplotlib numpy h5py -c conda-forge -c defaults --override-channels
-  - conda install -n testenv nose jsonschema traitlets pytest coverage pip databroker ophyd historydict boltons doct pyepics super_state_machine xray-vision lmfit jinja2 icu pyzmq mongoquery dill attrs -c lightsource2 -c conda-forge -c soft-matter
+  - conda install -n testenv nose jsonschema traitlets pytest coverage pip databroker ophyd historydict boltons doct pyepics super_state_machine xray-vision lmfit jinja2 icu pyzmq mongoquery dill -c lightsource2 -c conda-forge -c soft-matter
   - source activate testenv
   - 'pip install https://github.com/NSLS-II/event-model/zipball/master#egg=event_model'
   - conda remove metadatastore databroker filestore
@@ -60,6 +60,7 @@ install:
   - 'pip install https://github.com/NSLS-II/filestore/zipball/master#egg=filestore'
   - 'pip install https://github.com/NSLS-II/metadatastore/zipball/master#egg=metadatastore'
   - 'pip install https://github.com/NSLS-II/portable-mds/zipball/master#egg=portable_mds'
+  - pip install attrs
   - pip install codecov
   - python setup.py install
   # Need to clean the python build directory (and other cruft) or pytest is

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1049,20 +1049,6 @@ class RunEngine:
                 except RuntimeError as e:
                     print('The plan {!r} tried to yield a value on close.  '
                           'Please fix your plan.'.format(p))
-            # cancel the rest of the tasks
-            for task in asyncio.Task.all_tasks(self.loop):
-                if task is self._task:
-                    continue
-                task.cancel()
-                try:
-                    texc = task.exception()
-                except (asyncio.CancelledError,
-                        asyncio.InvalidStateError):
-                    pass
-                else:
-                    # TODO, merge this with main task exception?
-                    if texc is not None:
-                        print(texc)
 
             self.loop.stop()
             self.state = 'idle'


### PR DESCRIPTION
We are never actually creating extra tasks so this is useless and the
traceback object is keeping the failed task alive so we see it every
time.

We are creating handles, not Tasks, elsewhere in the code.

If we do start to create other tasks, we must keep track of them to
clean them up rather than relying on a global weak-ref dict in the
Task class.

attn @ambarb 