### PR TITLE
REF: Drop boltons dependency by using toolz (already a dep).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
   - |
     if [ $CONDA_ENV ]; then
-       conda create -n testenv python=$TRAVIS_PYTHON_VERSION scipy matplotlib numpy h5py traitlets jsonschema databroker pip doct xray-vision lmfit pyzmq ophyd filestore event-model dill boltons ophyd pims mongoquery pytest $EXTRA_C_CHAN -c lightsource2-tag -c conda-forge -c soft-matter -c defaults --override-channels
+       conda create -n testenv python=$TRAVIS_PYTHON_VERSION scipy matplotlib numpy h5py traitlets jsonschema databroker pip doct xray-vision lmfit pyzmq ophyd filestore event-model dill ophyd pims mongoquery pytest $EXTRA_C_CHAN -c lightsource2-tag -c conda-forge -c soft-matter -c defaults --override-channels
        source activate testenv
        pip install https://github.com/NSLS-II/portable-mds/zipball/master#egg=portable_mds
        pip install https://github.com/NSLS-II/event-model/zipball/master#egg=event_model

--- a/bluesky/plan_patterns.py
+++ b/bluesky/plan_patterns.py
@@ -3,7 +3,11 @@ import operator
 
 import numpy as np
 from cycler import cycler
-from boltons.iterutils import chunked
+try:
+    # cytools is a drop-in replacement for toolz, implemented in Cython
+    from cytools import partition
+except ImportError:
+    from toolz import partition
 
 from .utils import snake_cyclers
 
@@ -136,7 +140,7 @@ def inner_product(num, args):
         raise ValueError("wrong number of positional arguments")
 
     cyclers = []
-    for motor, start, stop, in chunked(args, 3):
+    for motor, start, stop, in partition(3, args):
         steps = np.linspace(start, stop, num=num, endpoint=True)
         c = cycler(motor, steps)
         cyclers.append(c)
@@ -174,7 +178,7 @@ def chunk_outer_product_args(args):
     if len(args) % 5 != 0:
         raise ValueError("wrong number of positional arguments")
 
-    yield from chunked(args, 5)
+    yield from partition(5, args)
 
 
 def outer_product(args):

--- a/bluesky/spec_api.py
+++ b/bluesky/spec_api.py
@@ -15,10 +15,14 @@ http://www.certif.com/downloads/css_docs/spec_man.pdf
 from collections import OrderedDict, namedtuple
 
 import matplotlib.pyplot as plt
+try:
+    # cytools is a drop-in replacement for toolz, implemented in Cython
+    from cytools import partition
+except ImportError:
+    from toolz import partition
 from bluesky import plans
 from bluesky.callbacks import LiveTable, LivePlot, LiveRaster
 from bluesky.callbacks.scientific import PeakStats
-from boltons.iterutils import chunked
 from bluesky.global_state import gs
 from bluesky.utils import (first_key_heuristic, normalize_subs_input,
                            update_sub_lists)
@@ -409,13 +413,13 @@ def mesh(*args, time=None, md=None):
     motors = []
     shape = []
     extents = []
-    for motor, start, stop, num, in chunked(args, 4):
+    for motor, start, stop, num, in partition(4, args):
         motors.append(motor)
         shape.append(num)
         extents.append([start, stop])
 
     # outer_product_scan expects a 'snake' param for all but fist motor
-    chunked_args = iter(chunked(args, 4))
+    chunked_args = iter(partition(4, args))
     new_args = list(next(chunked_args))
     for chunk in chunked_args:
         new_args.extend(list(chunk) + [False])
@@ -450,7 +454,7 @@ def a2scan(*args, time=None, md=None):
     if len(args) % 3 != 1:
         raise ValueError("wrong number of positional arguments")
     motors = []
-    for motor, start, stop, in chunked(args[:-1], 3):
+    for motor, start, stop, in partition(3, args[:-1]):
         motors.append(motor)
 
     intervals = list(args)[-1]
@@ -494,7 +498,7 @@ def d2scan(*args, time=None, md=None):
     if len(args) % 3 != 1:
         raise ValueError("wrong number of positional arguments")
     motors = []
-    for motor, start, stop, in chunked(args[:-1], 3):
+    for motor, start, stop, in partition(3, args[:-1]):
         motors.append(motor)
 
     intervals = list(args)[-1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
 cycler
-doct
 event-model
 historydict
 jsonschema
-matplotlib
 numpy
 super_state_machine
 toolz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-boltons
 cycler
 doct
 event-model

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,9 +1,11 @@
 attrs
 coverage
 dill
+doct
 ipython
 jinja2
 lmfit
+matplotlib
 mongoquery
 networkx
 nose

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 attrs
-boltons
 coverage
 dill
 ipython


### PR DESCRIPTION
## Description

Use `toolz.partition` instead of `boltons.chunked`.

Also, remove doct as a core dep (it's only use in `bluesky.callbacks.broker`) and matplotlib.

## Motivation and Context

We don't need both toolz and boltons, and it seems more likely we'll want more things from toolz in the future. I also have the impression it's more widely used than boltons.

## How Has This Been Tested?

There is good test coverage of the relevant sections of bluesky.
