### PR TITLE
API: num_steps -> num_points; add num_intervals as well.

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1861,8 +1861,13 @@ def count(detectors, num=1, delay=None, *, md=None):
     If ``delay`` is an iterable, it must have at least ``num - 1`` entries or
     the plan will raise a ``ValueError`` during iteration.
     """
+    if num is None:
+        num_intervals = None
+    else:
+        num_intervals = num - 1
     _md = {'detectors': [det.name for det in detectors],
-           'num_steps': num,
+           'num_points': num,
+           'num_intervals': num_intervals,
            'plan_args': {'detectors': list(map(repr, detectors)), 'num': num},
            'plan_name': 'count'}
     _md.update(md or {})
@@ -1963,7 +1968,8 @@ def list_scan(detectors, motor, steps, *, per_step=None, md=None):
     """
     _md = {'detectors': [det.name for det in detectors],
            'motors': [motor.name],
-           'num_steps': len(steps),
+           'num_points': len(steps),
+           'num_intervals': len(steps) - 1,
            'plan_args': {'detectors': list(map(repr, detectors)),
                            'motor': repr(motor), 'steps': steps,
                            'per_step': repr(per_step)},
@@ -2047,7 +2053,8 @@ def scan(detectors, motor, start, stop, num, *, per_step=None, md=None):
     """
     _md = {'detectors': [det.name for det in detectors],
           'motors': [motor.name],
-          'num_steps': num,
+          'num_points': num,
+          'num_intervals': num - 1,
           'plan_args': {'detectors': list(map(repr, detectors)), 'num': num,
                         'motor': repr(motor),
                         'start': start, 'stop': stop,
@@ -2141,7 +2148,8 @@ def log_scan(detectors, motor, start, stop, num, *, per_step=None, md=None):
     """
     _md = {'detectors': [det.name for det in detectors],
            'motors': [motor.name],
-           'num_steps': num,
+           'num_points': num,
+           'num_intervals': num - 1,
            'plan_args': {'detectors': list(map(repr, detectors)), 'num': num,
                          'start': start, 'stop': stop, 'motor': repr(motor),
                          'per_step': repr(per_step)},
@@ -2406,7 +2414,8 @@ def scan_nd(detectors, cycler, *, per_step=None, md=None):
     """
     _md = {'detectors': [det.name for det in detectors],
            'motors': [motor.name for motor in cycler.keys],
-           'num_steps': len(cycler),
+           'num_points': len(cycler),
+           'num_intervals': len(cycler) - 1,
            'plan_args': {'detectors': list(map(repr, detectors)),
                          'cycler': repr(cycler),
                          'per_step': repr(per_step)},
@@ -2521,7 +2530,7 @@ def outer_product_scan(detectors, *args, per_step=None, md=None):
                             in chunk_args),
            'snaking': tuple(snake for motor, start, stop, num, snake
                             in chunk_args),
-           # 'num_steps': inserted by scan_nd
+           # 'num_points': inserted by scan_nd
            'plan_args': {'detectors': list(map(repr, detectors)),
                          'args': md_args,
                          'per_step': repr(per_step)},

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -7,9 +7,13 @@ v0.9.0
 API Changes
 ^^^^^^^^^^^
 
-Moved ``configure_count_time_wrapper`` and
-``configure_count_time_detector`` to ``bluesky.spec_api`` from
-``bluesky.plans``.
+* Moved ``configure_count_time_wrapper`` and
+  ``configure_count_time_detector`` to ``bluesky.spec_api`` from
+  ``bluesky.plans``.
+* The metadata reported by step scans that used to be labeled ``num_steps``
+  is now renamed ``num_points``, generally considered a less ambiguous name.
+  Separately, ``num_interals`` (which one might mistakenly assume is what was
+  meant by ``num_steps``) is also stored.
 
 
 v0.8.0


### PR DESCRIPTION
## Description

Of the options discussed in #652, I vote for removing the ambiguously-named 'num_steps' from metadata altogether. I volunteer for cleanup of any breakage in BL configs.

## Motivation and Context

Closes https://github.com/NSLS-II/bluesky/issues/652

## How Has This Been Tested?
```
$ git grep -A 1 num_points
bluesky/callbacks/core.py:    num_points : int, optional
bluesky/callbacks/core.py-        number of points to sample when evaluating the model; default 100
--
bluesky/callbacks/core.py:    def __init__(self, livefit, *, num_points=100, legend_keys=None, xlim=None,
bluesky/callbacks/core.py-                 ylim=None, ax=None, **kwargs):
--
bluesky/callbacks/core.py:        self.num_points = num_points
bluesky/callbacks/core.py-        self._livefit = livefit
--
bluesky/callbacks/core.py:            x_points = np.linspace(xmin, xmax, self.num_points)
bluesky/callbacks/core.py-            kwargs = {self.__x_key: x_points}
--
bluesky/plans.py:           'num_points': num,
bluesky/plans.py-           'num_intervals': num - 1,
--
bluesky/plans.py:           'num_points': len(steps),
bluesky/plans.py-           'num_intervals': len(steps) - 1,
--
bluesky/plans.py:          'num_points': num,
bluesky/plans.py-          'num_intervals': num - 1,
--
bluesky/plans.py:           'num_points': num,
bluesky/plans.py-           'num_intervals': num - 1,
--
bluesky/plans.py:           'num_points': len(cycler),
bluesky/plans.py-           'num_intervals': len(cycler) - 1,
--
bluesky/plans.py:           # 'num_points': inserted by scan_nd
bluesky/plans.py-           'plan_args': {'detectors': list(map(repr, detectors)),
$ git grep num_steps
$
```

Note: I realized my first attempt had (+) instead of (-). Fixed and force-pushed.