### PR TITLE
API: Do not 'sanitize' numpy arrays into lists.

### DIFF
--- a/bluesky/callbacks/zmq.py
+++ b/bluesky/callbacks/zmq.py
@@ -5,7 +5,7 @@ import os
 import socket
 import time
 from ..run_engine import Dispatcher, DocumentNames
-from ..utils import expiring_function
+from ..utils import apply_to_dict_recursively, sanitize_np
 
 
 class Publisher:
@@ -51,6 +51,7 @@ class Publisher:
         self._subscription_token = RE.subscribe(self)
 
     def __call__(self, name, doc):
+        apply_to_dict_recursively(doc, sanitize_np)
         message = self._fmt_string.format(name=name, doc=doc)
         self._socket.send_string(message)
 

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -19,7 +19,7 @@ from super_state_machine.extras import PropertyMachine
 from super_state_machine.errors import TransitionError
 
 from .utils import (CallbackRegistry, SignalHandler, normalize_subs_input,
-                    AsyncInput, new_uid, sanitize_np, NoReplayAllowed,
+                    AsyncInput, new_uid, NoReplayAllowed,
                     RequestAbort, RequestStop,  RunEngineInterrupted,
                     IllegalMessageSequence, FailedPause, FailedStatus,
                     InvalidCommand, PlanHalt, Msg, ensure_generator,
@@ -1360,7 +1360,7 @@ class RunEngine:
         config_values = {}
         config_ts = {}
         for key, val in obj.read_configuration().items():
-            config_values[key] = sanitize_np(val['value'])
+            config_values[key] = val['value']
             config_ts[key] = val['timestamp']
         self._config_values_cache[obj] = config_values
         self._config_ts_cache[obj] = config_ts
@@ -1401,7 +1401,7 @@ class RunEngine:
         config = {obj.name: {'data': {}, 'timestamps': {}}}
         config[obj.name]['data_keys'] = obj.describe_configuration()
         for key, val in obj.read_configuration().items():
-            config[obj.name]['data'][key] = sanitize_np(val['value'])
+            config[obj.name]['data'][key] = val['value']
             config[obj.name]['timestamps'][key] = val['timestamp']
         object_keys = {obj.name: list(data_keys)}
         hints = {}
@@ -1524,7 +1524,7 @@ class RunEngine:
         # Merge list of readings into single dict.
         readings = {k: v for d in self._read_cache for k, v in d.items()}
         for key in readings:
-            readings[key]['value'] = sanitize_np(readings[key]['value'])
+            readings[key]['value'] = readings[key]['value']
         data, timestamps = _rearrange_into_parallel_dicts(readings)
         doc = dict(descriptor=descriptor_uid,
                    time=ttime.time(), data=data, timestamps=timestamps,
@@ -1684,7 +1684,7 @@ class RunEngine:
 
             reading = ev['data']
             for key in ev['data']:
-                reading[key] = sanitize_np(reading[key])
+                reading[key] = reading[key]
             ev['data'] = reading
             ev['descriptor'] = descriptor_uid
             ev['seq_num'] = seq_num

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -281,7 +281,12 @@ def test_zmq(fresh_RE):
     def local_cb(name, doc):
         local_accumulator.append((name, doc))
 
-    RE([Msg('open_run'), Msg('close_run')], local_cb)
+    # Check that numpy stuff is sanitized by putting some in the start doc.
+    md = {'stuff': {'nested': np.array([1, 2, 3])},
+          'scalar_stuff': np.float64(3),
+          'array_stuff': np.ones((3, 3))}
+
+    RE([Msg('open_run', **md), Msg('close_run')], local_cb)
     time.sleep(1)
 
     # Get the two documents from the queue (or timeout --- test will fail)

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -917,3 +917,22 @@ def make_decorator(wrapper):
             return dec_inner
         return dec
     return dec_outer
+
+
+def apply_to_dict_recursively(d, f):
+    """Recursively apply function to a document
+
+    This modifies the dict in place and returns it.
+
+    Parameters
+    ----------
+    d: dict
+        e.g. event_model Document
+    f: function
+       any func to be performed on d recursively
+    """
+    for key, val in d.items():
+        if hasattr(val, 'items'):
+            d[key] = apply_to_dict_recursively(d=val, f=f)
+        d[key] = f(val)
+    return d


### PR DESCRIPTION
## Description

Remove `sanitize_np` everywhere it is used in run_engine.py.

## Motivation and Context

We are currently 'sanitizing' numpy arrays returned by devices into lists (or lists of lists, etc.) so that they can go safely into pymongo (which doesn't know what to do this numpy arrays). This should done on the databroker/metadatastore side, not in bluesky, because some callbacks need numpy arrays and it's wasteful to convert to lists and then back to arrays.

**This should not be merged until there is a corresponding PR in databroker providing this functionality there.**

Closes #636 

## How Has This Been Tested?

This will definitely fail tests until databroker is updated.