### PR TITLE
Spiral aspect

### DIFF
--- a/bluesky/plan_patterns.py
+++ b/bluesky/plan_patterns.py
@@ -13,7 +13,7 @@ from .utils import snake_cyclers
 
 
 def spiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth, *,
-           tilt=0.0):
+           dr_y=None, tilt=0.0):
     '''Spiral scan, centered around (x_start, y_start)
 
     Parameters
@@ -31,7 +31,9 @@ def spiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth, *,
     y_range : float
         y width of spiral
     dr : float
-        Delta radius
+        Delta radius along the minor axis of the ellipse.
+    dr_y : float, optional
+        Delta radius along the major axis of the ellipse, if not specifed defaults to dr
     nth : float
         Number of theta steps
     tilt : float, optional
@@ -41,8 +43,13 @@ def spiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth, *,
     -------
     cyc : cycler
     '''
+    if dr_y is None:
+        dr_aspect = 1
+    else:
+        dr_aspect = dr_y/dr
+    
     half_x = x_range / 2
-    half_y = y_range / 2
+    half_y = y_range / (2 * dr_aspect)
 
     r_max = np.sqrt(half_x ** 2 + half_y ** 2)
     num_ring = 1 + int(r_max / dr)
@@ -57,8 +64,9 @@ def spiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth, *,
         for i_angle in range(int(i_ring * nth)):
             angle = i_angle * angle_step
             x = radius * np.cos(angle)
-            y = radius * np.sin(angle)
-            if ((abs(x - y / tilt_tan) <= half_x) and (abs(y) <= half_y)):
+            y = radius * np.sin(angle) * dr_aspect
+            if ((abs(x - (y/dr_aspect) / tilt_tan) <= half_x) and 
+                    (abs(y/dr_aspect) <= half_y)):
                 x_points.append(x_start + x)
                 y_points.append(y_start + y)
 
@@ -201,7 +209,7 @@ def spiral_square_pattern(x_motor, y_motor, x_center, y_center,
 
 
 def spiral_fermat(x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
-                  factor, *, tilt=0.0):
+                  factor, *, dr_y=None, tilt=0.0):
     '''Absolute fermat spiral scan, centered around (x_start, y_start)
 
     Parameters
@@ -219,7 +227,9 @@ def spiral_fermat(x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
     y_range : float
         y width of spiral
     dr : float
-        delta radius
+        delta radius along the minor axis of the ellipse.
+    dr_y : float, optional
+        Delta radius along the major axis of the ellipse, if not specifed defaults to dr
     factor : float
         radius gets divided by this
     tilt : float, optional
@@ -229,10 +239,15 @@ def spiral_fermat(x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
     -------
     cyc : cycler
     '''
+    if dr_y is None:
+        dr_aspect = 1
+    else:
+        dr_aspect = dr_y / dr
+    
     phi = 137.508 * np.pi / 180.
 
     half_x = x_range / 2
-    half_y = y_range / 2
+    half_y = y_range / (2 * dr_aspect)
     tilt_tan = np.tan(tilt + np.pi / 2.)
 
     x_points, y_points = [], []
@@ -243,9 +258,9 @@ def spiral_fermat(x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
         radius = np.sqrt(i_ring) * dr / factor
         angle = phi * i_ring
         x = radius * np.cos(angle)
-        y = radius * np.sin(angle)
+        y = radius * np.sin(angle) * dr_aspect
 
-        if ((abs(x - y / tilt_tan) <= half_x) and (abs(y) <= half_y)):
+        if ((abs(x - (y/dr_aspect) / tilt_tan) <= half_x) and (abs(y) <= half_y)):
             x_points.append(x_start + x)
             y_points.append(y_start + y)
 

--- a/bluesky/plan_patterns.py
+++ b/bluesky/plan_patterns.py
@@ -46,7 +46,7 @@ def spiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth, *,
     if dr_y is None:
         dr_aspect = 1
     else:
-        dr_aspect = dr_y/dr
+        dr_aspect = dr_y / dr
     
     half_x = x_range / 2
     half_y = y_range / (2 * dr_aspect)
@@ -65,8 +65,8 @@ def spiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth, *,
             angle = i_angle * angle_step
             x = radius * np.cos(angle)
             y = radius * np.sin(angle) * dr_aspect
-            if ((abs(x - (y/dr_aspect) / tilt_tan) <= half_x) and 
-                    (abs(y/dr_aspect) <= half_y)):
+            if ((abs(x - (y / dr_aspect) / tilt_tan) <= half_x) and 
+                    (abs(y / dr_aspect) <= half_y)):
                 x_points.append(x_start + x)
                 y_points.append(y_start + y)
 
@@ -260,7 +260,7 @@ def spiral_fermat(x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
         x = radius * np.cos(angle)
         y = radius * np.sin(angle) * dr_aspect
 
-        if ((abs(x - (y/dr_aspect) / tilt_tan) <= half_x) and (abs(y) <= half_y)):
+        if ((abs(x - (y / dr_aspect) / tilt_tan) <= half_x) and (abs(y) <= half_y)):
             x_points.append(x_start + x)
             y_points.append(y_start + y)
 

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1224,7 +1224,7 @@ def rel_spiral_fermat(detectors, x_motor, y_motor, x_range, y_range, dr,
 
 
 def spiral(detectors, x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
-           nth, *, tilt=0.0, per_step=None, md=None):
+           nth, *, dr_y=None, tilt=0.0, per_step=None, md=None):
     '''Spiral scan, centered around (x_start, y_start)
 
     Parameters
@@ -1242,7 +1242,10 @@ def spiral(detectors, x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
     y_range : float
         y width of spiral
     dr : float
-        Delta radius
+        Delta radius along the minor axis of the ellipse. 
+    dr_y : float, optional
+        Delta radius along the major axis of the ellipse. If None, defaults to
+        dr.
     nth : float
         Number of theta steps
     tilt : float, optional
@@ -1262,7 +1265,7 @@ def spiral(detectors, x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
     '''
     pattern_args = dict(x_motor=x_motor, y_motor=y_motor, x_start=x_start,
                         y_start=y_start, x_range=x_range, y_range=y_range,
-                        dr=dr, nth=nth, tilt=tilt)
+                        dr=dr, nth=nth, dr_y=dr_y, tilt=tilt)
     cyc = plan_patterns.spiral(**pattern_args)
 
     # Before including pattern_args in metadata, replace objects with reprs.
@@ -1272,7 +1275,7 @@ def spiral(detectors, x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
                          'x_motor': repr(x_motor), 'y_motor': repr(y_motor),
                          'x_start': x_start, 'y_start': y_start,
                          'x_range': x_range, 'y_range': y_range,
-                         'dr': dr, 'nth': nth, 'tilt': tilt,
+                         'dr': dr, 'dr_y': dr_y, 'nth': nth, 'tilt': tilt,
                          'per_step': repr(per_step)},
            'extents': tuple([[x_start - x_range, x_start + x_range],
                              [y_start - y_range, y_start + y_range]]),
@@ -1295,7 +1298,8 @@ def spiral(detectors, x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
 
 
 def rel_spiral(detectors, x_motor, y_motor, x_range, y_range, dr, nth,
-               *, tilt=0.0, per_step=None, md=None):
+               *, dr_y=None, tilt=0.0, per_step=None, md=None):
+
     '''Relative spiral scan
 
     Parameters
@@ -1313,7 +1317,10 @@ def rel_spiral(detectors, x_motor, y_motor, x_range, y_range, dr, nth,
     y_range : float
         y width of spiral
     dr : float
-        Delta radius
+        Delta radius along the minor axis of the ellipse. 
+    dr_y : float, optional
+        Delta radius along the major axis of the ellipse. If None, it
+        defaults to dr.
     nth : float
         Number of theta steps
     tilt : float, optional
@@ -1338,7 +1345,8 @@ def rel_spiral(detectors, x_motor, y_motor, x_range, y_range, dr, nth,
     def inner_relative_spiral():
         return (yield from spiral(detectors, x_motor, y_motor,
                                   0, 0,
-                                  x_range, y_range, dr, nth, tilt=tilt,
+                                  x_range, y_range, dr, nth,
+                                  dr_y=dr_y, tilt=tilt,
                                   per_step=per_step, md=_md))
 
     return (yield from inner_relative_spiral())


### PR DESCRIPTION
Combines ~~#653,~~ #655, #656. Completes the 'spiral' plans by allowing the user to control all the degrees of freedom.

@awalter-bnl Thanks for this contribution to bluesky. I know we've said it before, but it bears repeating: it's great to see beamline scientists contributing upstream!

I merged your two commits (from your `patch-1` and `patch-2` branches) into this one PR and made the following revisions on top:

* Fixed a place where the 'asym' argument was accepted but then not used.
* Renamed 'asym' to 'aspect_ratio' (as discussed [previously](https://github.com/NSLS-II/bluesky/pull/656#issuecomment-284383082)) because Tom and I agree that that is more clear to general users. In the event of ambiguity, the docstring clarifies the exact meaning.
* Addressed minor style and whitespace issues.