### PR TITLE
TST: do not skip ophyd tests if libca is not installed

### DIFF
--- a/bluesky/tests/__init__.py
+++ b/bluesky/tests/__init__.py
@@ -5,18 +5,10 @@ reason = ''
 
 try:
     import ophyd
-    from ophyd import setup_ophyd
 except ImportError as ie:
     # pytestmark = pytest.mark.skip
     ophyd = None
     reason = str(ie)
-else:
-    try:
-        setup_ophyd()
-        # define the classes only if ophyd is available
-    except Exception as E:
-        ophyd = None
-        reason = str(E)
 
 # define a skip condition based on if ophyd is available or not
 requires_ophyd = pytest.mark.skipif(ophyd is None, reason=reason)

--- a/bluesky/tests/test_devices.py
+++ b/bluesky/tests/test_devices.py
@@ -8,7 +8,11 @@ from bluesky.tests import requires_ophyd, ophyd
 
 if ophyd:
     from ophyd import Component as Cpt, Device, Signal
-    ophyd.setup_ophyd()
+    import epics
+    try:
+        ophyd.setup_ophyd()
+    except epics.ca.ChannelAccessException:
+        pass
 
     class A(Device):
         s1 = Cpt(Signal, value=0)


### PR DESCRIPTION
This relies on a not-yet-merged change to ophyd