### PR TITLE
FIX: make sure motors are in the right order

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2469,7 +2469,8 @@ def inner_product_scan(detectors, num, *args, per_step=None, md=None):
     """
     md_args = list(chain(*((repr(motor), start, stop)
                            for motor, start, stop in partition(3, args))))
-
+    motor_names = tuple(motor.name for motor, start, stop
+                        in partition(3, args))
     _md = {'plan_args': {'detectors': list(map(repr, detectors)),
                          'num': num, 'args': md_args,
                          'per_step': repr(per_step)},
@@ -2477,6 +2478,7 @@ def inner_product_scan(detectors, num, *args, per_step=None, md=None):
            'plan_pattern': 'inner_product',
            'plan_pattern_module': plan_patterns.__name__,
            'plan_pattern_args': dict(num=num, args=md_args),
+           'motors': motor_names
            }
     _md.update(md or {})
 
@@ -2522,11 +2524,13 @@ def outer_product_scan(detectors, *args, per_step=None, md=None):
     chunk_args = list(plan_patterns.chunk_outer_product_args(args))
 
     md_args = []
+    motor_names = []
     for i, (motor, start, stop, num, snake) in enumerate(chunk_args):
         md_args.extend([repr(motor), start, stop, num])
         if i > 0:
             # snake argument only shows up after the first motor
             md_args.append(snake)
+        motor_names.append(motor.name)
 
     _md = {'shape': tuple(num for motor, start, stop, num, snake
                           in chunk_args),
@@ -2542,6 +2546,7 @@ def outer_product_scan(detectors, *args, per_step=None, md=None):
            'plan_pattern': 'outer_product',
            'plan_pattern_args': dict(args=md_args),
            'plan_pattern_module': plan_patterns.__name__,
+           'motors': tuple(motor_names)
           }
     _md.update(md or {})
 

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -1,0 +1,64 @@
+import pytest
+
+from bluesky.tests.utils import DocCollector
+import bluesky.plans as bp
+from bluesky.examples import motor, motor1, motor2, det
+
+
+def _validate_start(start, expected_values):
+    '''Basic metadata validtion'''
+
+    plan_md_key = [
+        'plan_pattern_module',
+        'plan_pattern_args',
+        'plan_type',
+        'plan_pattern',
+        'plan_name',
+        'num_points',
+        'plan_args',
+        'detectors']
+
+    for k in plan_md_key:
+        assert k in start
+    for k, v in expected_values.items():
+        assert start[k] == v
+
+
+def _make_plan_marker():
+    args = []
+    ids = []
+
+    ##
+    args.append((bp.outer_product_scan([det],
+                                       motor, 1, 2, 3,
+                                       motor1, 4, 5, 6, True,
+                                       motor2, 7, 8, 9, True),
+                 {'motors': ('motor', 'motor1', 'motor2'),
+                  'extents': ([1, 2], [4, 5], [7, 8]),
+                  'shape': (3, 6, 9),
+                  'snaking': (False, True, True),
+                  'plan_pattern_module': 'bluesky.plan_patterns',
+                  'plan_pattern': 'outer_product',
+                  'plan_name': 'outer_product_scan'}))
+    ids.append('outer_product_scan')
+
+    ##
+    args.append((bp.inner_product_scan([det], 9,
+                                       motor, 1, 2,
+                                       motor1, 4, 5,
+                                       motor2, 7, 8),
+                {'motors': ('motor', 'motor1', 'motor2')}))
+    ids.append('inner_product_scan')
+
+    return pytest.mark.parametrize('plan,target',
+                                   args,
+                                   ids=ids)
+
+
+@_make_plan_marker()
+def test_plan_header(fresh_RE, plan, target):
+    RE = fresh_RE
+    c = DocCollector()
+    RE(plan, c.insert)
+    for s in c.start:
+        _validate_start(s, target)

--- a/bluesky/tests/utils.py
+++ b/bluesky/tests/utils.py
@@ -35,3 +35,22 @@ class MsgCollector:
         self.msgs.append(msg)
         if self.msg_hook:
             self.msg_hook(msg)
+
+
+class DocCollector:
+    def __init__(self):
+        self.start = []
+        self.stop = {}
+        self.descriptor = {}
+        self.event = {}
+
+    def insert(self, name, doc):
+        if name == 'start':
+            self.start.append(doc)
+        elif name == 'stop':
+            self.stop[doc['run_start']] = doc
+        elif name == 'descriptor':
+            self.descriptor[doc['run_start']] = doc
+            self.event[doc['uid']] = []
+        else:
+            self.event[doc['descriptor']].append(doc)


### PR DESCRIPTION
closes #680

<!--- Provide a general summary of your changes in the Title above -->
Fix bug where the motors in inner and outer scans were randomized

## Description
<!--- Describe your changes in detail -->
Added motors in order when we add extents friends to the start document

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #680 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New tests added

<!--
## Screenshots (if appropriate):
-->
