### PR TITLE
ENH: check if events are filled before asking filestore for the data

### DIFF
--- a/bluesky/callbacks/broker.py
+++ b/bluesky/callbacks/broker.py
@@ -30,10 +30,12 @@ class LiveImage(CallbackBase):
         self.fs = fs
 
     def event(self, doc):
-        uid = doc['data'][self.field]
         if 'filled' not in doc.keys() or \
                         doc['filled'].get(self.field, False) is False:
+            uid = doc['data'][self.field]
             data = self.fs.retrieve(uid)
+        else:
+            data = doc['data'][self.field]
         self.update(data)
         super().event(doc)
 

--- a/bluesky/callbacks/broker.py
+++ b/bluesky/callbacks/broker.py
@@ -44,7 +44,7 @@ class LiveImage(CallbackBase):
         self.fs = fs
 
     def event(self, doc):
-        if doc.get('filled', {}).get(self.field):
+        if doc.get('filled', {}).get(self.field) and self.fs is not None:
             uid = doc['data'][self.field]
             data = self.fs.retrieve(uid)
         else:

--- a/bluesky/callbacks/broker.py
+++ b/bluesky/callbacks/broker.py
@@ -15,6 +15,18 @@ class LiveImage(CallbackBase):
     ----------
     field : string
         name of data field in an Event
+    fs: FileStore instance
+        The FileStore instance to pull the data from
+    cmap : str,  colormap, or None
+        color map to use.  Defaults to gray
+    norm : Normalize or None
+       Normalization function to use
+    limit_func : callable, optional
+        function that takes in the image and returns clim values
+    auto_redraw : bool, optional
+    interpolation : str, optional
+        Interpolation method to use. List of valid options can be found in
+        CrossSection2DView.interpolation
     """
 
     def __init__(self, field, *, fs=None, cmap=None, norm=None,

--- a/bluesky/callbacks/broker.py
+++ b/bluesky/callbacks/broker.py
@@ -17,13 +17,15 @@ class LiveImage(CallbackBase):
         name of data field in an Event
     """
 
-    def __init__(self, field, *, fs=None):
+    def __init__(self, field, *, fs=None, cmap=None, norm=None,
+                 limit_func=None, auto_redraw=True, interpolation=None):
         from xray_vision.backend.mpl.cross_section_2d import CrossSection
         import matplotlib.pyplot as plt
         super().__init__()
         self.field = field
         fig = plt.figure()
-        self.cs = CrossSection(fig)
+        self.cs = CrossSection(fig, cmap, norm,
+                 limit_func, auto_redraw, interpolation)
         self.cs._fig.show()
         if fs is None:
             import filestore.api as fs

--- a/bluesky/callbacks/broker.py
+++ b/bluesky/callbacks/broker.py
@@ -32,8 +32,7 @@ class LiveImage(CallbackBase):
         self.fs = fs
 
     def event(self, doc):
-        if 'filled' not in doc.keys() or \
-                        doc['filled'].get(self.field, False) is False:
+        if doc.get('filled', {}).get(self.field):
             uid = doc['data'][self.field]
             data = self.fs.retrieve(uid)
         else:

--- a/bluesky/callbacks/broker.py
+++ b/bluesky/callbacks/broker.py
@@ -4,6 +4,7 @@ from .core import CallbackBase
 from ..utils import ensure_uid
 import numpy as np
 import doct
+import matplotlib.pyplot as plt
 
 
 class LiveImage(CallbackBase):
@@ -15,6 +16,7 @@ class LiveImage(CallbackBase):
     field : string
         name of data field in an Event
     """
+
     def __init__(self, field, *, fs=None):
         from xray_vision.backend.mpl.cross_section_2d import CrossSection
         import matplotlib.pyplot as plt
@@ -29,7 +31,9 @@ class LiveImage(CallbackBase):
 
     def event(self, doc):
         uid = doc['data'][self.field]
-        data = self.fs.retrieve(uid)
+        if 'filled' not in doc.keys() or \
+                        doc['filled'].get(self.field, False) is False:
+            data = self.fs.retrieve(uid)
         self.update(data)
         super().event(doc)
 
@@ -100,6 +104,7 @@ def post_run(callback, db=None, fill=False):
         # not yet have the 'stop' document that we currently have, so we'll
         # use our copy instead of expecting the header to include one.
         callback('stop', doc)
+
     return f
 
 
@@ -137,6 +142,7 @@ def make_restreamer(callback, db=None):
 
     def cb(value, **kwargs):
         return process(db[value], callback)
+
     return cb
 
 
@@ -192,6 +198,7 @@ class LiveTiffExporter(CallbackBase):
     ----------
     filenames : list of filenames written in ongoing or most recent run
     """
+
     def __init__(self, field, template, dryrun=False, overwrite=False,
                  db=None):
         try:


### PR DESCRIPTION
Check if event doc is filled before trying to fill it in `LiveImage` callback

## Motivation and Context
Data analysis pipelines will hand down filled documents, this change allows data to be poured into this callback