### PR TITLE
FIX: Compatibility with numpy 1.13

### DIFF
--- a/bluesky/callbacks/scientific.py
+++ b/bluesky/callbacks/scientific.py
@@ -101,7 +101,7 @@ class PeakStats(CollectThenCompute):
         self.min = x[np.argmin(y)], self.y_data[np.argmin(y)],
         self.com, = np.interp(center_of_mass(y), np.arange(len(x)), x)
         mid = (np.max(y) + np.min(y)) / 2
-        crossings = np.where(np.diff(y > mid))[0]
+        crossings = np.where(np.diff((y > mid).astype(np.int)))[0]
         _cen_list = []
         for cr in crossings.ravel():
             _x = x[cr:cr+2]


### PR DESCRIPTION
Subtracting booleans (via numpy.diff) raises an error in numpy 1.13:

https://docs.scipy.org/doc/numpy/release.html#deprecationwarning-to-error