### PR TITLE
ENH: ReaderWithFilestore uses its own read

### DIFF
--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -501,7 +501,7 @@ class ReaderWithFileStore(Reader):
     def trigger(self):
         # save file stash file name
         self._result.clear()
-        for idx, (name, reading) in enumerate(super().read().items()):
+        for idx, (name, reading) in enumerate(self.read().items()):
             # Save the actual reading['value'] to disk and create a record
             # in FileStore.
             np.save('{}_{}.npy'.format(self._path_stem, idx), reading['value'])
@@ -525,7 +525,7 @@ class ReaderWithFileStore(Reader):
         return NullStatus()
 
     def read(self):
-        return self._result
+        return super().read()
 
     def describe(self):
         res = super().describe()

--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -501,7 +501,7 @@ class ReaderWithFileStore(Reader):
     def trigger(self):
         # save file stash file name
         self._result.clear()
-        for idx, (name, reading) in enumerate(self.read().items()):
+        for idx, (name, reading) in enumerate(self.trigger_read().items()):
             # Save the actual reading['value'] to disk and create a record
             # in FileStore.
             np.save('{}_{}.npy'.format(self._path_stem, idx), reading['value'])
@@ -524,8 +524,11 @@ class ReaderWithFileStore(Reader):
 
         return NullStatus()
 
-    def read(self):
+    def trigger_read(self):
         return super().read()
+
+    def read(self):
+        return self._result
 
     def describe(self):
         res = super().describe()


### PR DESCRIPTION
This way `trigger_read` can be overridden to deal with more complex readers
eg readers with shutters

## Motivation and Context
This allows for a more flexible setup, where the data can be modified from the `Reader` after the read but before the data is stashed into FS

## How Has This Been Tested?
I ran the existing tests.