### PR TITLE
DOC: Document suggestions for defining IPython magics for bluesky.

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -47,6 +47,7 @@ Index
    async
    debugging
    run_engine_api
+   magics
 
 .. toctree::
    :caption: Developer Documentation

--- a/doc/source/magics.rst
+++ b/doc/source/magics.rst
@@ -1,0 +1,205 @@
+*******************************
+Writing Custom IPython 'Magics'
+*******************************
+
+This section is not about bluesky itself; it highlights a feature of
+IPython.
+
+Bluesky is designed to be usable in an interactive session and also as a
+library for building higher-level tools, such as a Graphical User Interface.
+Presently, there is no officially-supported GUI for bluesky. (We may provide
+tools for building bluesky GUIs in the future.) There is, however, a way to
+build a terse command-line interface on top of bluesky using a feature of
+IPython.
+
+IPython is an interactive Python interpreter designed for and by scientists. It
+includes a feature called "magics" --- convenience commands that aren't part of
+the Python language itself. For example, ``%history`` is a magic:
+
+.. ipython:: python
+
+    a = 1
+    b = 2
+    %history
+
+The IPython documentation documents the
+`complete list of built-in magics <https://ipython.readthedocs.io/en/stable/interactive/magics.html>`_
+and, further,
+`how to define custom magics <https://ipython.readthedocs.io/en/stable/config/custommagics.html>`_.
+
+What follows are some examples for defining IPython magics for bluesky and some
+suggestions on using them effectively. We emphasize that these examples are not
+part of the official bluesky interface; they merely illustrate a reasonable
+pattern for user customization.
+
+Suppose you have imported the some plans, defined a RunEngine ``RE``, and
+created a list of detectors ``d``.
+
+.. code-block:: python
+
+    from bluesky import RunEngine
+    from bluesky.examples import det1, det2, motor  # simulated hardware
+    from bluesky.plans import count, mv
+
+    RE = RunEngine({})
+    d = [det1, det2]
+
+.. ipython:: python
+    :suppress:
+
+    from bluesky import RunEngine
+    RE = RunEngine({})
+    from bluesky.examples import det1, det2, motor  # simulated hardware
+    d = [det1, det2]
+    from bluesky.plans import count, mv
+
+
+And suppose that, in typical interactive use, you often take a reading from
+these detectors, move a motor, and repeat.
+
+.. ipython:: python
+
+    RE(count(d))
+    RE(mv(motor, 3))
+
+We can define IPython magics for these commands (see script below) to create
+shortcuts, such as:
+
+.. ipython:: python
+    :suppress:
+
+    import ast
+    from IPython.core.magic import register_line_magic
+    import bluesky.plans as bp
+    def ct(line):
+        global d
+        global RE
+        print('---> RE(count(d))')
+        return RE(bp.count(d))
+
+    register_line_magic(ct)
+    def mov(line):
+        global RE
+        motor_varname, pos = line.split()
+        motor = globals()[motor_varname]
+        pos = ast.literal_eval(pos)
+        print('---> RE(mv({motor}, {pos}))'.format(motor=motor_varname, pos=pos))
+        return RE(bp.mv(motor, pos))
+
+    register_line_magic(mov)
+    del ct, mov
+
+.. ipython:: python
+
+    %ct
+
+.. ipython:: python
+
+    %mov motor 3
+
+IPython's 'automagic' will even let you drop the ``%`` as long as the meaning
+is unambiguous:
+
+.. ipython:: python
+
+    ct
+    ct = 3  # Now ct is a variable so automagic will not work...
+    ct
+    # ... but the magic still works.
+    %ct
+
+It's still possible to capture the output of execution in a variable:
+
+.. ipython:: python
+
+    uids = %ct
+
+.. ipython:: python
+
+    uids
+
+But it's not possible to access the underlying plan with introspection tools:
+
+.. code-block:: python
+
+    print_summary(count(d))  # This works
+    print_summary(%ct)  # This does not!
+
+Magics invoking the bluesky RunEngine do not combine well and should not be
+used as building blocks. They should only be run one at a time. **Do not put
+them into loops or scripts like this.**
+
+.. ipython:: python
+
+    # DANGER: This can go badly if it is interrupted with Ctrl+C!!!
+    for i in range(3):
+        %ct
+
+Instead, :ref:`compose plans properly <composing_plans>`, writing
+user-defined plans like:
+
+.. ipython:: python
+
+    def multi_count(N):
+        for i in range(N):
+            yield from count(d)
+
+and executing them
+
+.. ipython:: python
+    
+    RE(multi_count(3))
+
+Then, if you wish, define a new magic for invoking your custom plan. Or skip
+it and just use the plan directly, as above. The shortcuts are best for quick,
+simple operations with few parameters and no need for simluation.
+
+Wrting custom plans retains correct interruption behavior and retains your
+ability to simulate the plans for error-checking, time estimation,
+pre-visualization, etc.  Resist the temptation to invent a private macro
+language out of magics. You'll find that there are unexpected corner-cases
+everywhere, and that inventing a language is hard! Stick to Python for writing
+any program logic, and use magics as one-off shortcuts.
+
+The ``%ct`` and ``%mov`` magics were defined by execting this script:
+
+.. code-block:: python
+
+    # magics.py
+
+    # This file must be run in the global namespace, not imported as a module.
+    # This can be done using an IPython profile startup directory or with
+    # `%run -i magics.py`.
+
+    import ast
+    from IPython.core.magic import register_line_magic
+    from bluesky.plans import count, mv
+
+
+    @register_line_magic
+    def ct(line):
+        # %ct --> RE(count(d))
+        # Expect this magic to be defined and executed in a namespace with a
+        # RunEngine instance named RE and a list of detectors named d.
+        global d
+        global RE
+        print('---> RE(count(d))')
+        return RE(count(d))
+
+
+    @register_line_magic
+    def mov(line):
+        # %mov theta 3 --> RE(mv(theta, 3))
+        # Expect this magic to be defined and executed in a namespace with a
+        # RunEngine instance named RE.
+        # Avoid clobbering the name '%mv', the built-in magic for moving files.
+        global RE
+        motor_varname, pos = line.split()
+        motor = globals()[motor_varname]
+        pos = ast.literal_eval(pos)
+        print('---> RE(mv({motor}, {pos}))'.format(motor=motor_varname, pos=pos))
+        return RE(mv(motor, pos))
+
+    # In an interactive session, we need to delete these to avoid
+    # name conflicts for automagic to work.
+    del ct, mov

--- a/doc/source/plans_intro.rst
+++ b/doc/source/plans_intro.rst
@@ -271,6 +271,8 @@ The ``yield from`` syntax is just more succinct.
 
     list(double_f())
 
+.. _composing_plans:
+
 Combining Plans
 ---------------
 


### PR DESCRIPTION
Since last fall, we have considered introducing an IPython magic that would work save users from typing `RE()`. I first show normal usage for comparison.

```python
In  [1]: 1 + 1
Out [1]: 2

In [2]: RE(count(d))
Out [2]: ['some uid']

In [3]: %REmode
# You are now in RunEngine mode! Type plans to execute them or Ctrl+D to exit to normal IPython.

RE [3]: count(d)
Out [3]: ['some_uid']

RE [4]: 1 + 1  # raises an error -- only plans are allowed in RE mode

^D
# You are now in normal IPython.
In [5]:
```

I have been pushing discussion on this as much as anyone, but I am still lukewarm on this particular compromise. It makes key features of bluesky less accessible, and it doesn't give users much in return.  Specifically, because every input in 'RunEngine mode' is expected to be a valid plan, there isn't a natural way to capture a uid in a variable:

```python
uids = RE(count(d))  # capture the uids in a variable
```

or provide metadata in line:

```python
RE(count(d), sample='A')
```

It also places `print_summary`, `check_limits`, and other plan tools further out of reach. (You have to leave 'RE mode' to use them.)

Even having sacrificed these things, the approach doesn't actually go very far toward solving the problem it is trying to solve: providing a terse command line interface optimized for interactive beamline debugging. In the context of driving sophisticated data acquisition routines, users generally agree that the complexity of bluesky is justified and that the rich syntax of Python is helpful. In a debugging context -- doing thing like quickly moving a motor or taking a one-off reading -- validation, rich metadata, and in general the full power of Python are less compelling.

From the developer's perspective, we aspire to improve software culture in synchrotron science, which we believe to be necessary and inevitable in a future where experiments become more complex. As stated in #705, integrating with modern hardware and modern software ecosystems requires a general-purpose language that is necessarily less terse than what served in the past. Hacking the language to make it seem simpler than it is -- or making one tool look like another -- is a recipe for confusion.

From a user's perspective, if I were configuring a beamline, even with my deep understanding of bluesky and facility with Python, I can imagine getting tripped up on brackets in:

```python
d = [det]
RE(count(d), LiveTable(['det']))
```

Our plans for the next release of bluesky (see #677) will help that, reducing common cases to:

```python
d = [det]
RE(count(d))
```

Even so, I can imagine myself defining IPython magics for common beamline debugging tasks, such as `%ct` or `%mov motor 5`. This kind of hack is exactly why IPython is so valuable as a practical tool. It's not rich enough to build custom plans, but it's useful for common simple cases that might occur when my mind is focused on hardware problems. The documentation in this PR is an attempt to guide users to use IPython magics effectively and sparingly -- and not get tempted to invent a custom language.

This approach would answer a need that we have never answered to the satisfaction of our users. Additionally, it's a viable replacement for ophyd's "command API", which was un-documented a long time ago but is still frequently used at some beamlines.