### PR TITLE
API: Remove shim module deprecated in April 2016.

### DIFF
--- a/bluesky/qt_kicker.py
+++ b/bluesky/qt_kicker.py
@@ -1,8 +1,0 @@
-import warnings
-from .utils import install_qt_kicker as _install_qt_kicker
-
-
-def install_qt_kicker():
-    warnings.warn("The qt_kicker module is deprecated. Instead, use "
-                  "`from bluesky.utils import install_qt_kicker`")
-    _install_qt_kicker()


### PR DESCRIPTION
The usage:

```python
from bluesky.qt_kicker import install_qt_kicker
```

has been issuing a warning since April 2016. The new usage is:

```python
from bluesky.utils import install_qt_kicker
```

I propose removing the old shim module now.