### PR TITLE
TST: change example code to match new Asset naming

### DIFF
--- a/bluesky/callbacks/broker.py
+++ b/bluesky/callbacks/broker.py
@@ -15,8 +15,8 @@ class LiveImage(CallbackBase):
     ----------
     field : string
         name of data field in an Event
-    fs: FileStore instance
-        The FileStore instance to pull the data from
+    fs: Registry instance
+        The Registry instance to pull the data from
     cmap : str,  colormap, or None
         color map to use.  Defaults to gray
     norm : Normalize or None

--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -452,7 +452,7 @@ class Syn2DGauss(Reader):
         super().__init__(name, {name: func})
 
 
-class ReaderWithFileStore(Reader):
+class ReaderWithRegistry(Reader):
     """
 
     Parameters
@@ -470,8 +470,8 @@ class ReaderWithFileStore(Reader):
     loop : asyncio.EventLoop, optional
         used for ``subscribe`` updates; uses ``asyncio.get_event_loop()`` if
         unspecified
-    fs : FileStore
-        FileStore object that supports inserting resource and datum documents
+    fs : Registry
+        Registry object that supports inserting resource and datum documents
     save_path : str, optional
         Path to save files to, if None make a temp dir, defaults to None.
 
@@ -503,13 +503,13 @@ class ReaderWithFileStore(Reader):
         self._result.clear()
         for idx, (name, reading) in enumerate(self.trigger_read().items()):
             # Save the actual reading['value'] to disk and create a record
-            # in FileStore.
+            # in Registry.
             np.save('{}_{}.npy'.format(self._path_stem, idx), reading['value'])
             datum_id = new_uid()
             self.fs.insert_datum(self._resource_id, datum_id,
                                  dict(index=idx))
             # And now change the reading in place, replacing the value with
-            # a reference to FileStore.
+            # a reference to Registry.
             reading['value'] = datum_id
             self._result[name] = reading
 
@@ -668,7 +668,7 @@ class MockFlyer:
         pass
 
 
-class GeneralReaderWithFileStore(Reader):
+class GeneralReaderWithRegistry(Reader):
     """
 
     Parameters
@@ -686,8 +686,8 @@ class GeneralReaderWithFileStore(Reader):
     loop : asyncio.EventLoop, optional
         used for ``subscribe`` updates; uses ``asyncio.get_event_loop()`` if
         unspecified
-    fs : FileStore
-        FileStore object that supports inserting resource and datum documents
+    fs : Registry
+        Registry object that supports inserting resource and datum documents
     save_path : str, optional
         Path to save files to, if None make a temp dir, defaults to None.
     save_func : function, optional
@@ -730,14 +730,14 @@ class GeneralReaderWithFileStore(Reader):
         self._result.clear()
         for idx, (name, reading) in enumerate(super().read().items()):
             # Save the actual reading['value'] to disk and create a record
-            # in FileStore.
+            # in Registry.
             self.save_func('{}_{}.{}'.format(self._path_stem, idx,
                                              self.save_ext), reading['value'])
             datum_id = new_uid()
             self.fs.insert_datum(self._resource_id, datum_id,
                                  dict(index=idx))
             # And now change the reading in place, replacing the value with
-            # a reference to FileStore.
+            # a reference to Registry.
             reading['value'] = datum_id
             self._result[name] = reading
         return NullStatus()

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -683,16 +683,16 @@ def test_async_trigger_delay(motor_det, fresh_RE):
     _time_test(bp.abs_set, .5, motor, 1, wait=True)
 
 
-def test_fs_reader(db):
-    fs = db.fs
-    fs.register_handler('RWFS_NPY', ReaderWithFSHandler)
+def test_reg_reader(db):
+    reg = db.fs
+    reg.register_handler('RWFS_NPY', ReaderWithFSHandler)
     det = ReaderWithRegistry('det',
                               {'img': lambda: np.array(np.ones((10, 10)))},
-                              fs=fs)
+                              reg=reg)
     det.stage()
     det.trigger()
     reading = det.read().copy()
     det.unstage()
     datum_id = reading['img']['value']
-    arr = fs.retrieve(datum_id)
+    arr = reg.retrieve(datum_id)
     assert_array_equal(np.ones((10, 10)), arr)

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -4,7 +4,7 @@ from bluesky.examples import (motor, simple_scan, det, sleepy, wait_one,
                               checkpoint_forever, simple_scan_saving,
                               stepscan, MockFlyer, fly_gen,
                               conditional_break, SynGauss, flyer1,
-                              ReaderWithFileStore, ReaderWithFSHandler
+                              ReaderWithRegistry, ReaderWithFSHandler
                               )
 from bluesky.callbacks import LivePlot
 from bluesky import (Msg, IllegalMessageSequence,
@@ -686,7 +686,7 @@ def test_async_trigger_delay(motor_det, fresh_RE):
 def test_fs_reader(db):
     fs = db.fs
     fs.register_handler('RWFS_NPY', ReaderWithFSHandler)
-    det = ReaderWithFileStore('det',
+    det = ReaderWithRegistry('det',
                               {'img': lambda: np.array(np.ones((10, 10)))},
                               fs=fs)
     det.stage()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes to Bluesky due to changes in Databroker
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We are re-working how the internal of `Registry` (nee `FileStore`) objects work.  The bluesky examples will need to keep up.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The working branch on databroker has been changed to install from this branch which will take care of testing the interaction.

<!--
## Screenshots (if appropriate):
-->
