### PR TITLE
Sanitize all docs

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1230,7 +1230,7 @@ class RunEngine:
         # Use copy for some reasonable (admittedly not total) protection
         # against users mutating the md with their validator.
         self.md_validator(dict(md))
-
+        apply_to_dict_recursively(d=dict(md), f=sanitize_np)
         doc = dict(uid=self._run_start_uid, time=ttime.time(), **md)
         yield from self.emit(DocumentNames.start, doc)
         self.log.debug("Emitted RunStart (uid=%r)", doc['uid'])
@@ -2063,6 +2063,7 @@ class RunEngine:
     def emit(self, name, doc):
         "Process blocking callbacks and schedule non-blocking callbacks."
         jsonschema.validate(doc, schemas[name])
+        apply_to_dict_recursively(d=doc, f=sanitize_np)
         self.dispatcher.process(name, doc)
 
 

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1403,7 +1403,7 @@ class RunEngine:
         data_keys = obj.describe()
         config = {obj.name: {'data': {}, 'timestamps': {}}}
         config[obj.name]['data_keys'] = obj.describe_configuration()
-        apply_to_dict_recursively(d=obj.read_configuration,
+        apply_to_dict_recursively(d=obj.read_configuration(),
                                   f=sanitize_np)
         for key, val in obj.read_configuration().items():
             # config[obj.name]['data'][key] = sanitize_np(val['value'])

--- a/bluesky/tests/test_utils.py
+++ b/bluesky/tests/test_utils.py
@@ -1,5 +1,6 @@
 from bluesky.utils import ensure_generator, Msg
-
+from bluesky.examples import stepscan, det, motor
+import numpy as np
 
 def test_single_msg_to_gen():
     m = Msg('set', None, 0)
@@ -8,3 +9,10 @@ def test_single_msg_to_gen():
 
     assert len(m_list) == 1
     assert m_list[0] == m
+
+def test_illegal_np(fresh_RE, db):
+    RE = fresh_RE
+    illegal_field = np.asarray(range(10))
+    RE.subscribe(db.mds.insert)
+    uid, = RE(stepscan(det, motor), group='foo', beamline_id='testing',
+              config={}, illegal_field=illegal_field)

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -930,5 +930,6 @@ def apply_to_dict_recursively(d, f):
     """
     for key, val in d.items():
         if hasattr(val, 'items'):
-            d[key] = apply_to_dict_recursively(val, f)
-            d[key] = f(val)
+            d[key] = apply_to_dict_recursively(d=val, f=f)
+        d[key] = f(val)
+    return d

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -917,3 +917,18 @@ def make_decorator(wrapper):
             return dec_inner
         return dec
     return dec_outer
+
+
+def apply_to_dict_recursively(d, f):
+    """Recursively apply function to a document
+    Parameters
+    ----------
+    d: dict
+        e.g. event_model Document
+    f: function
+       any func to be performed on d recursively
+    """
+    for key, val in d.items():
+        if hasattr(val, 'items'):
+            d[key] = apply_to_dict_recursively(val, f)
+            d[key] = f(val)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Recursively sanitizes documents that are emitted by the RunEngine from np types
## Description
<!--- Describe your changes in detail -->

Basically added two functions, one sanitizes the docs from np.generic and np.ndarray and another one that applies this(or any other) function to a doc recursively.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See https://github.com/NSLS-II/bluesky/issues/710

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
test_utils/test_illegal_np emulates what happened at HXN the other day.

More testing recommendations are welcome.
<!--
## Screenshots (if appropriate):
-->
