### PR TITLE
ENH: Include 'filled' key in events.

### DIFF
--- a/bluesky/callbacks/broker.py
+++ b/bluesky/callbacks/broker.py
@@ -57,7 +57,7 @@ class LiveImage(CallbackBase):
         self.cs._fig.canvas.draw_idle()
 
 
-def post_run(callback, db=None, fill=False):
+def post_run(callback, db, fill=False):
     """Trigger a callback to process all the Documents from a run at the end.
 
     This function does not receive the Document stream during collection.
@@ -72,9 +72,7 @@ def post_run(callback, db=None, fill=False):
             def func(doc_name, doc):
                 pass
 
-    db : Broker, optional
-        The databroker instance to use, if not provided use databroker
-        singleton
+    db : Broker
 
     fill : boolean, optional
         Whether to deference externally-stored data in the documents.

--- a/bluesky/callbacks/broker.py
+++ b/bluesky/callbacks/broker.py
@@ -98,25 +98,13 @@ def post_run(callback, db, fill=False):
     +------------+-------------------+----------------+----------------+
 
     """
-
-    if db is None:
-        from databroker import DataBroker as db
-
     def f(name, doc):
         if name != 'stop':
             return
         uid = ensure_uid(doc['run_start'])
         header = db[uid]
-        callback('start', header['start'])
-        for descriptor in header['descriptors']:
-            callback('descriptor', descriptor)
-        for event in db.get_events(header, fill=fill):
-            callback('event', event)
-        # Depending on the order that this callback and the
-        # databroker-insertion callback were called in, the databroker might
-        # not yet have the 'stop' document that we currently have, so we'll
-        # use our copy instead of expecting the header to include one.
-        callback('stop', doc)
+        for name, doc in header.documents():
+            callback(name, doc)
 
     return f
 

--- a/bluesky/tests/conftest.py
+++ b/bluesky/tests/conftest.py
@@ -36,30 +36,5 @@ def motor_det(request):
 def db(request):
     """Return a data broker
     """
-    from portable_mds.sqlite.mds import MDS
-    from filestore.utils import install_sentinels
-    import filestore.fs
-    from databroker import Broker
-    import tempfile
-    import shutil
-    from uuid import uuid4
-    td = tempfile.mkdtemp()
-    db_name = "fs_testing_v1_disposable_{}".format(str(uuid4()))
-    test_conf = dict(database=db_name, host='localhost',
-                     port=27017)
-    install_sentinels(test_conf, 1)
-    fs = filestore.fs.FileStoreMoving(test_conf,
-                                      version=1)
-
-    def delete_dm():
-        print("DROPPING DB")
-        fs._connection.drop_database(db_name)
-
-    request.addfinalizer(delete_dm)
-
-    def delete_tmpdir():
-        shutil.rmtree(td)
-
-    request.addfinalizer(delete_tmpdir)
-
-    return Broker(MDS({'directory': td, 'timezone': 'US/Eastern'}), fs)
+    from databroker import temp_config, Broker
+    return Broker.from_config(temp_config())

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -684,7 +684,7 @@ def test_async_trigger_delay(motor_det, fresh_RE):
 
 
 def test_reg_reader(db):
-    reg = db.fs
+    reg = db.reg
     reg.register_handler('RWFS_NPY', ReaderWithRegistryHandler)
     det = ReaderWithRegistry('det',
                               {'img': lambda: np.array(np.ones((10, 10)))},

--- a/bluesky/tests/test_vertical_integration.py
+++ b/bluesky/tests/test_vertical_integration.py
@@ -6,23 +6,21 @@ from functools import partial
 
 def test_scan_and_get_data(fresh_RE, db):
     RE = fresh_RE
-    RE.subscribe(db.mds.insert)
+    RE.subscribe(db.insert)
     uid, = RE(stepscan(det, motor), group='foo', beamline_id='testing',
               config={})
 
     hdr = db[uid]
-    db.fetch_events(hdr)
+    list(hdr.events())
 
 
 def test_post_run(fresh_RE, db):
     RE = fresh_RE
-    RE.subscribe(db.mds.insert)
+    RE.subscribe(db.insert)
     output = defaultdict(list)
 
     def do_nothing(doctype, doc):
         output[doctype].append(doc)
-
-    RE.ignore_callback_exceptions = False
 
     RE(stepscan(det, motor), subs={'stop': [post_run(do_nothing, db=db)]})
     assert len(output)
@@ -34,7 +32,7 @@ def test_post_run(fresh_RE, db):
 
 def test_verify_files_saved(fresh_RE, db):
     RE = fresh_RE
-    RE.subscribe(db.mds.insert)
+    RE.subscribe(db.insert)
 
     vfs = partial(verify_files_saved, db=db)
     RE(stepscan(det, motor), subs={'stop': vfs})


### PR DESCRIPTION
This is the final step in making a RunEngine and a Broker
(configured with a suitable prepare_hook) return identical
documents. It should remove some annoying edge cases for
consumers that want to receive from both.

This also includes some commits to update bluesky to the new
databroker API.