### PR TITLE
API/DOC: Rethink magics.

### DIFF
--- a/bluesky/magics.py
+++ b/bluesky/magics.py
@@ -1,14 +1,14 @@
-# These are experimental IPython magics for executing a plan using a syntax
-# familiar to users of SPEC.
+# These are experimental IPython magics, providing quick shortcuts for simple
+# tasks. None of these save any data.
 
 # To use, run this in an IPython shell:
 # ip = get_ipython()
 # ip.register_magics(BlueskyMagics)
-# ip.register_magics(SPECMagics)
 
 from IPython.core.magic import Magics, magics_class, line_magic
 from ast import literal_eval as le
 import bluesky.plans as bp
+from bluesky import RunEngine
 import numpy as np
 from operator import attrgetter
 
@@ -19,162 +19,50 @@ except ImportError:
     from toolz import partition
 
 
-# Wrap the user namespace to provide newbie-friendly KeyError messages.
-class Namespace:
-    def __init__(self, ns):
-        self.ns = ns
-
-    def __getitem__(self, key):
-        try:
-            return self.ns[key]
-        except KeyError:
-            raise KeyError("No variable named {!r} is defined in the "
-                           "user namespace. Define it and try again."
-                           "".format(key))
-
 @magics_class
 class BlueskyMagics(Magics):
+
+    RE = RunEngine({})
 
     @line_magic
     def mov(self, line):
         if len(line.split()) % 2 != 0:
             raise TypeError("Wrong parameters. Expected: "
                             "%mov motor position (or several pairs like that)")
-        ns = Namespace(self.shell.user_ns)
-        RE = ns['RE']
         args = []
         strs = []
         for motor, pos in partition(2, line.split()):
-            args.extend([ns[motor], le(pos)])
-            strs.extend([motor, pos])
-        print('---> RE(mv({}))'.format(', '.join(strs)))
+            args.extend([self.shell.user_ns[motor], le(pos)])
         plan = bp.mv(*args)
-        return RE(plan)
+        self.RE(plan)
+        return None
 
     @line_magic
     def movr(self, line):
         if len(line.split()) % 2 != 0:
             raise TypeError("Wrong parameters. Expected: "
                             "%mov motor position (or several pairs like that)")
-        ns = Namespace(self.shell.user_ns)
-        RE = ns['RE']
         args = []
         strs = []
         for motor, pos in partition(2, line.split()):
-            args.extend([ns[motor], le(pos)])
-            strs.extend([motor, pos])
-        print('---> RE(mvr({}))'.format(', '.join(strs)))
+            args.extend([self.shell.user_ns[motor], le(pos)])
         plan = bp.mvr(*args)
-        return RE(plan)
+        self.RE(plan)
+        return None
 
-@magics_class
-class SPECMagics(Magics):
+    dets = []
 
     @line_magic
     def ct(self, line):
         if line.strip():
-            raise TypeError("No parameters expected, just %ct")
-        print('---> RE(count(dets))')
-        ns = Namespace(self.shell.user_ns)
-        RE = ns['RE']
-        plan = bp.count(ns['dets'])
-        return RE(plan)
-
-    @line_magic
-    def ascan(self, line):
-        # SPEC's ascan expects number of *intervals*, as opposed to the number
-        # of points (intervals = points - 1). We follow SPEC's API but try to
-        # make the difference clear in the string we print.
-        try:
-            motor, start, stop, intervals = line.split()
-        except ValueError:
-            raise TypeError("Wrong parameters. Expected: "
-                            "%ascan motor start stop intervals")
-        print('---> RE(scan(dets, {}, {}, {}, {} + 1))'
-              ''.format(motor, start, stop, intervals))
-        ns = Namespace(self.shell.user_ns)
-        RE = ns['RE']
-        plan = bp.scan(ns['dets'], ns[motor],
-                       le(start), le(stop), 1 + le(intervals))
-        return RE(plan)
-
-    @line_magic
-    def dscan(self, line):
-        try:
-            motor, start, stop, intervals = line.split()
-        except ValueError:
-            raise TypeError("Wrong parameters. Expected: "
-                            "%dscan motor start stop intervals")
-        print('---> RE(relative_scan(dets, {}, {}, {}, {} + 1))'
-              ''.format(motor, start, stop, intervals))
-        ns = Namespace(self.shell.user_ns)
-        RE = ns['RE']
-        plan = bp.relative_scan(ns['dets'], ns[motor],
-                                le(start), le(stop), 1 + le(intervals))
-        return RE(plan)
-
-    @line_magic
-    def a2scan(self, line):
-        try:
-            (motor1, start1, stop1,
-             motor2, start2, stop2,
-             intervals) = line.split()
-        except ValueError:
-            raise TypeError("Wrong parameters. Expected: "
-                            "%a2scan motor1 start1 stop1 "
-                            "motor2 start2 stop2 intervals")
-        print('---> RE(inner_product_scan(dets, {} + 1, {}, {}, {}, '
-              '{}, {}, {}))'.format(intervals,
-                                    motor1, start1, stop1,
-                                    motor2, start2, stop2))
-        ns = Namespace(self.shell.user_ns)
-        RE = ns['RE']
-        plan = bp.inner_product_scan(ns['dets'], 1 + le(intervals),
-                                     ns[motor1], le(start1), le(stop1),
-                                     ns[motor2], le(start2), le(stop2))
-        return RE(plan)
-
-    @line_magic
-    def d2scan(self, line):
-        try:
-            (motor1, start1, stop1,
-             motor2, start2, stop2,
-             intervals) = line.split()
-        except ValueError:
-            raise TypeError("Wrong parameters. Expected: "
-                            "%d2scan motor1 start1 stop1 "
-                            "motor2 start2 stop2 intervals")
-        print('---> RE(relative_inner_product_scan(dets, {} + 1, {}, {}, {}, '
-              '{}, {}, {}))'.format(intervals,
-                                    motor1, start1, stop1,
-                                    motor2, start2, stop2))
-        ns = Namespace(self.shell.user_ns)
-        RE = ns['RE']
-        plan = bp.relative_inner_product_scan(
-            ns['dets'], 1 + le(intervals),
-            ns[motor1], le(start1), le(stop1),
-            ns[motor2], le(start2), le(stop2))
-        return RE(plan)
-
-    @line_magic
-    def mesh(self, line):
-        try:
-            (motor1, start1, stop1, intervals1,
-             motor2, start2, stop2, intervals2) = line.split()
-        except ValueError:
-            raise TypeError("Wrong parameters. Expected: "
-                            "%mesh motor1 start1 stop1 intervals1"
-                            "motor2 start2 stop2 intervals2")
-        print('---> RE(outer_product_scan(dets, {} + 1, {}, {}, {}, '
-              '{}, {}, {}, False))'.format(motor1, start1, stop1, intervals1,
-                                    motor2, start2, stop2, intervals2))
-        ns = Namespace(self.shell.user_ns)
-        RE = ns['RE']
-        plan = bp.outer_product_scan(
-            ns['dets'],
-            ns[motor1], le(start1), le(stop1), 1 + le(intervals1),
-            ns[motor2], le(start2), le(stop2), 1 + le(intervals2), False)
-        return RE(plan)
+            dets = eval(line, self.shell.user_ns)
+        else:
+            dets = self.dets  # default is SPECMagic.dets
+        plan = bp.count(dets)
+        print("[This data will not be saved. "
+              "Use the RunEngine to collect data.]")
+        self.RE(plan, _ct_callback)
+        return None
 
     positioners = []
     FMT_PREC = 6
@@ -183,8 +71,10 @@ class SPECMagics(Magics):
     def wa(self, line):
         "List positioner info. 'wa' stands for 'where all'."
         if line.strip():
-            raise TypeError("No parameters expected, just %wa")
-        positioners = sorted(set(self.positioners), key=attrgetter('name'))
+            positioners = eval(line, self.shell.user_ns)
+        else:
+            positioners = self.positioners
+        positioners = sorted(set(positioners), key=attrgetter('name'))
         values = []
         for p in positioners:
             try:
@@ -212,3 +102,10 @@ class SPECMagics(Magics):
 
             lines.append(LINE_FMT.format(p.name, value, low_limit, high_limit))
         print('\n'.join(lines))
+
+
+def _ct_callback(name, doc):
+    if name != 'event':
+        return
+    for k, v in doc['data'].items():
+        print('{: <30} {}'.format(k, v))

--- a/bluesky/magics.py
+++ b/bluesky/magics.py
@@ -5,10 +5,11 @@
 # ip = get_ipython()
 # ip.register_magics(BlueskyMagics)
 
-from IPython.core.magic import Magics, magics_class, line_magic
 from ast import literal_eval as le
+import asyncio
 import bluesky.plans as bp
 from bluesky import RunEngine
+from IPython.core.magic import Magics, magics_class, line_magic
 import numpy as np
 from operator import attrgetter
 
@@ -22,7 +23,7 @@ except ImportError:
 @magics_class
 class BlueskyMagics(Magics):
 
-    RE = RunEngine({})
+    RE = RunEngine({}, loop = asyncio.new_event_loop())
 
     @line_magic
     def mov(self, line):

--- a/bluesky/tests/test_magics.py
+++ b/bluesky/tests/test_magics.py
@@ -1,6 +1,6 @@
-from bluesky.magics import SPECMagics, BlueskyMagics
+from bluesky.magics import BlueskyMagics
 import bluesky.plans as bp
-from bluesky.examples import det, motor1, motor2
+from bluesky.examples import det, motor1, motor2, det1, det2
 import pytest
 
 
@@ -17,29 +17,34 @@ def compare_msgs(actual, expected):
         assert a == e
 
 dets = [det]
+default_dets = [det1, det2]
 
 @pytest.mark.parametrize('pln,magic,line', [
     (bp.mv(motor1, 2), 'mov', 'motor1 2'),
     (bp.mv(motor1, 2, motor2, 3), 'mov', 'motor1 2 motor2 3'),
     (bp.mvr(motor1, 2), 'movr', 'motor1 2'),
     (bp.mvr(motor1, 2, motor2, 3), 'movr', 'motor1 2 motor2 3'),
+    (bp.count(dets), 'ct', 'dets'),
+    (bp.count(default_dets), 'ct', ''),
     ])
 def test_bluesky_magics(pln, line, magic, fresh_RE):
     RE = fresh_RE
 
-    # Spy on all msgs processed by RE.
-    msgs = []
-
-    def collect(msg):
-        msgs.append(msg)
-
-    RE.msg_hook = collect
-
     # Build a FakeIPython instance to use the magics with.
 
-    ip = FakeIPython({'RE': RE, 'dets': dets, 'motor1': motor1, 'motor2':
-                      motor2})
+    dets = [det]
+    ip = FakeIPython({'motor1': motor1, 'motor2': motor2, 'dets': dets})
     sm = BlueskyMagics(ip)
+    sm.dets = default_dets
+
+    # Spy on all msgs processed by RE.
+    msgs = []
+
+    def collect(msg):
+        msgs.append(msg)
+
+    RE.msg_hook = collect
+    sm.RE.msg_hook = collect
 
     # Test magics cause the RunEngine to execute the messages we expect.
     RE(bp.mv(motor1, 10, motor2, 10))  # ensure known initial state
@@ -51,91 +56,20 @@ def test_bluesky_magics(pln, line, magic, fresh_RE):
     actual = msgs.copy()
     msgs.clear()
     compare_msgs(actual, expected)
-
-@pytest.mark.parametrize('pln,magic,line', [
-    (bp.count(dets), 'ct', ''),
-    (bp.scan(dets, motor1, 1, 2, 1 + 3), 'ascan', 'motor1 1 2 3'),
-    (bp.relative_scan(dets, motor1, 1, 2, 1 + 3), 'dscan', 'motor1 1 2 3'),
-    (bp.inner_product_scan(dets, 1 + 2, motor1, 1, 3, motor2, 4, 6), 'a2scan',
-     'motor1 1 3 motor2 4 6 2'),
-    (bp.relative_inner_product_scan(dets, 1 + 2, motor1, 1, 3, motor2, 4, 6),
-     'd2scan', 'motor1 1 3 motor2 4 6 2'),
-    (bp.outer_product_scan(dets, motor1, 1, 3, 1 + 2, motor2, 4, 6, 1 + 5,
-                           False),
-     'mesh', 'motor1 1 3 2 motor2 4 6 5'),
-    ])
-def test_spec_magics(pln, line, magic, fresh_RE):
-    RE = fresh_RE
-
-    # Spy on all msgs processed by RE.
-    msgs = []
-
-    def collect(msg):
-        msgs.append(msg)
-
-    RE.msg_hook = collect
-
-    # Build a FakeIPython instance to use the magics with.
-
-    ip = FakeIPython({'RE': RE, 'dets': dets, 'motor1': motor1, 'motor2':
-                      motor2})
-    sm = SPECMagics(ip)
-
-    # Test magics cause the RunEngine to execute the messages we expect.
-    RE(bp.mv(motor1, 10, motor2, 10))  # ensure known initial state
-    RE(pln)
-    expected = msgs.copy()
-    msgs.clear()
-    RE(bp.mv(motor1, 10, motor2, 10))  # ensure known initial state
-    getattr(sm, magic)(line)
-    actual = msgs.copy()
-    msgs.clear()
-    compare_msgs(actual, expected)
-
-
-@pytest.mark.parametrize('pln,magic,line', [
-    (bp.count(dets), 'ct', 'foo'),
-    (bp.scan(dets, motor1, 1, 2, 1 + 3), 'ascan', 'motor1 1 2 3 wrong'),
-    (bp.relative_scan(dets, motor1, 1, 2, 1 + 3), 'dscan', 'motor1 1 2 3 wrong'),
-    (bp.inner_product_scan(dets, 2, motor1, 1, 3, motor2, 4, 6), 'a2scan',
-     'motor1 1 3 motor2 4 wrong'),
-    (bp.relative_inner_product_scan(dets, 2, motor1, 1, 3, motor2, 4, 6),
-     'd2scan', 'motor1 1 3 motor2 4 wrong'),
-    (bp.outer_product_scan(dets, motor1, 1, 3, 2, motor2, 4, 6, 5, False),
-     'mesh', 'motor1 1 3 2 motor2 4 6 5 wrong'),
-    ])
-def test_spec_magics_bad_args(pln, line, magic, fresh_RE):
-    RE = fresh_RE
-
-    # Spy on all msgs processed by RE.
-    msgs = []
-
-    def collect(msg):
-        msgs.append(msg)
-
-    RE.msg_hook = collect
-
-    # Build a FakeIPython instance to use the magics with.
-
-    ip = FakeIPython({'RE': RE, 'dets': dets, 'motor1': motor1, 'motor2':
-                      motor2})
-    sm = SPECMagics(ip)
-
-    # Test magics cause the RunEngine to execute the messages we expect.
-    with pytest.raises(TypeError):
-        getattr(sm, magic)(line)
 
 
 # The %wa magic doesn't use a RunEngine or a plan.
 def test_wa():
     from bluesky.examples import motor
-    ip = FakeIPython({})
-    sm = SPECMagics(ip)
+    ip = FakeIPython({'motor': motor})
+    sm = BlueskyMagics(ip)
     # Test an empty list.
     sm.wa('')
 
     sm.positioners.extend([motor])
     sm.wa('')
+
+    sm.wa('[motor]')
 
 
 def test_magics_missing_ns_key(fresh_RE):

--- a/doc/source/magics.rst
+++ b/doc/source/magics.rst
@@ -7,12 +7,8 @@ IPython 'Magics' [Experimental]
     This section covers an experimental feature of bluesky. It may be altered
     or removed in the future.
 
-Bluesky is designed to be usable in an interactive session and also as a
-library for building higher-level tools, such as a Graphical User Interface.
-Presently, there is no officially-supported GUI for bluesky. (We may provide
-tools for building bluesky GUIs in the future.) There is, however, a way to
-build a terse command-line interface on top of bluesky using a feature of
-IPython.
+What Are 'Magics'?
+------------------
 
 IPython is an interactive Python interpreter designed for and by scientists. It
 includes a feature called "magics" --- convenience commands that aren't part of
@@ -29,60 +25,72 @@ The IPython documentation documents the
 and, further,
 `how to define custom magics <https://ipython.readthedocs.io/en/stable/config/custommagics.html>`_.
 
-Suppose you have imported the some plans, defined a RunEngine ``RE``, and
-created a list of detectors ``dets``, like so:
+Bluesky Magics
+--------------
+
+Bundled with bluesky are some IPython magics. They are intended for maintenance
+tasks or casual sanity checks.  **Intentionally, none of the magics save data;
+for that you should use the RunEngine and plans.**
+
+To use the magics, first register them with IPython:
+
+.. ipython:: python
+
+    from bluesky.magics import BlueskyMagics
+    get_ipython().register_magics(BlueskyMagics)
+
+For this example we'll use some simulated hardware.
+
+.. ipython:: python
+
+    from bluesky.examples import det1, det2, motor1, motor2
+
+Suppose you want to move a motor interactively. You can use the ``%mov`` magic:
+
+.. ipython:: python
+
+    %mov motor1 42
+
+This is equivanent to:
 
 .. code-block:: python
 
-    from bluesky import RunEngine
-    from bluesky.examples import det1, det2, motor  # simulated hardware
-    from bluesky.plans import count, mv
+    from bluesky.plans import mv
 
-    RE = RunEngine({})
+    RE(mv(motor1, 42))
+
+but less to type. There is also a ``%movr`` magic for "relative move". They can
+move multiple devices in parallel like so:
+
+.. ipython:: python
+
+    %mov motor1 -3 motor2 3
+
+Now suppose you want to take a quick reading of some devices and print the
+results to the screen without saving them or doing any fancy processing. Use
+the ``%ct`` magic:
+
+.. ipython:: python
+
+    %ct [det1, det2]
+
+or, equivalently,
+
+.. ipython:: python
+
     dets = [det1, det2]
+    %ct dets
 
-.. ipython:: python
-    :suppress:
-
-    from bluesky import RunEngine
-    RE = RunEngine({})
-    from bluesky.examples import det1, det2, motor  # simulated hardware
-    dets = [det1, det2]
-    from bluesky.plans import count, mv
-
-And suppose that, in typical interactive use, you often take a reading from
-these detectors, move a motor, and repeat.
+You can set a default list of detectors and them use ``%ct`` without any
+parameters:
 
 .. ipython:: python
 
-    RE(count(dets))
-    RE(mv(motor, 3))
-
-Bundled with bluesky are some IPython magics for executing these commands more
-succinctly. To use them, register them with IPython:
-
-.. ipython:: python
-
-    from bluesky.magics import SPECMagics
-    get_ipython().register_magics(SPECMagics)
-
-The magics expect to find an instance of the RunEngine named ``RE`` and (when
-applicable) a list of detectors named ``dets`` pre-defined by the user in the
-global namespace. If those expectations are satisfied, ``RE(count(dets))`` can
-be handily invoked like this:
-
-.. ipython:: python
-
+    BlueskyMagics.dets = [det1, det2]
     %ct
 
-And ``RE(mv(motor, 3))`` can be run like this:
-
-.. ipython:: python
-
-    %mov motor 3
-
 If IPython’s ‘automagic’ feature is enabled, IPython will even let you drop the
-% as long as the meaning is unambiguous:
+``%`` as long as the meaning is unambiguous:
 
 .. ipython:: python
 
@@ -95,74 +103,29 @@ If IPython’s ‘automagic’ feature is enabled, IPython will even let you dro
 For what it’s worth, we recommend disabling 'automagic'. The ``%`` is useful
 for flagging what follows as magical, non-Python code.
 
-Using the magics, it’s still possible to capture the output of execution in a
-variable:
+Finally, the ``%wa`` magic displays the current positions of movable
+devices. Like ``%ct``, it accepts a list of devices
 
 .. ipython:: python
 
-    uids = %ct
-
-.. ipython:: python
-
-    uids
-
-But it's not possible to access the underlying plan with introspection tools:
-
-.. code-block:: python
-
-    summarize_plan(count(dets))  # This works
-    sumamrize_plan(%ct)  # This does not!
-
-Magics invoking the bluesky RunEngine do not combine well and should not be
-used as building blocks. They should only be run one at a time. **Do not put
-them into loops or scripts like this.**
-
-.. ipython:: python
-
-    # DANGER: This can go badly if it is interrupted with Ctrl+C!!!
-    for i in range(3):
-        %ct
-
-Instead, :ref:`compose plans properly <composing_plans>`, writing
-user-defined plans like:
-
-.. ipython:: python
-
-    def multi_count(N):
-        for i in range(N):
-            yield from count(dets)
-
-and executing them
-
-.. ipython:: python
+    %wa [motor1, motor2]
     
-    RE(multi_count(3))
+or, if blank, falls back on a defaults list configured like so:
 
-The shortcuts are best for quick, simple operations with few parameters and no
-need for simluation.
+.. ipython:: python
 
-Resist the temptation to invent a private macro language out of magics. You'll
-find that there are unexpected corner-cases everywhere, and that inventing a
-language is hard! Stick to Python for writing any program logic, and use magics
-as one-off shortcuts.
-
-Built-in Magics
----------------
+    BlueskyMagics.positioners = [motor1, motor2]
+    %wa
 
 The names of these magics, and the order of the parameters they take, are meant
-to feel familiar to users of :doc:`SPEC <comparison-with-spec>`. They encompass
-only a subset of the plans available in bluesky.
-
-These magics expect to find an instance of the RunEngine named ``RE`` and (when 
-applicable) a list of detectors named ``dets`` pre-defined by the user in the
-global namespace.
+to feel familiar to users of :doc:`SPEC <comparison-with-spec>`.
 
 Again, they must be registered with IPython before they can be used:
 
 .. code-block:: python
 
-    from bluesky.magics import SPECMagics
-    get_ipython().register_magics(SPECMagics)
+    from bluesky.magics import BlueskyMagics
+    get_ipython().register_magics(BlueskyMagics)
 
 .. currentmodule:: bluesky.plans
 
@@ -172,23 +135,5 @@ Magic                                                                   Plan Inv
 ``%mov``                                                                :func:`mv`
 ``%movr``                                                               :func:`mvr`
 ``%ct``                                                                 :func:`count`
-``%ascan motor start stop intervals``                                   :func:`scan`
-``%dscan motor start stop intervals``                                   :func:`relative_scan`
-``%a2scan motor1 start1 stop1 motor2 start2 stop2 intervals``           :func:`inner_product_scan`
-``%d2scan motor1 start1 stop1 motor2 start2 stop2 intervals``           :func:`relative_inner_product_scan`
-``%mesh motor1 start1 stop1 intervals1 motor2 start2 stop2 intervals2`` :func:`outer_product_scan`
 ``%wa``                                                                 ("where all") Survey positioners*
 ======================================================================= ==============================
-
-\*The magic ``%wa`` differs from the others; it does not execute a plan. It
-also requires some special configuration: it relies on a list of "positioners"
-at ``SPECMagics.positioners`` that must be configured in advance. For example:
-
-.. code-block:: python
-
-    MY_POSITIONERS = [eta,
-                      delta,
-                      gamma,
-                      temperature]
-
-    SPECMagics.positioners.extend(MY_POSITIONERS)


### PR DESCRIPTION
Meetings with beamline staff raised concerns that IPython magics for
data-taking plans like '%ascan' were more confusing than helpful.

On the other hand, magics like '%wa' and '%mov' seem harmless.
'%wa' just reads hardware and prints to the screen. '%mov' touches
hardware, but it does not generate any documents.

We realized that the important distinction is that these magics
do not save data. The ones that save data ('%ascan', '%mesh', etc.)
are more troubling because they do not combine well and could easily
lead users astray. This PR removes them.

We have kept '%ct' but changed what it does: instead of executing
`RE(count(dets))` with the user's RunEngine, it uses a private
RunEngine that is not subscribed to the databroker; thus it does not
save data. It just prints results to the screen --- along with a
message reminding users that nothing has been saved. This seems like
a useful tool for quick diagnostics by beamline staff.

We all had some reservations about deploying this as it was, and
we generally feel better about this way of delineating good and bad
uses of magics in bluesky.

If anyone is still excited about '%ascan', we can reopen the
discussion for a future release, once we see how these are received.
And of course, clever users can always write these for themselves or
lift them from bluesky source history.

[Edit: Closes #756]