### PR TITLE
API: make hints an attribute / property instead of method

### DIFF
--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -349,6 +349,7 @@ class Mover(Reader):
                       'precision': 2}
         return ret
 
+    @property
     def hints(self):
         return {'fields': [list(self._fields)[0]]}
 

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2136,7 +2136,7 @@ def list_scan(detectors, motor, steps, *, per_step=None, md=None):
            'hints': {},
           }
     try:
-        dimensions = [('primary', motor.hints()['fields'])]
+        dimensions = [('primary', motor.hints['fields'])]
     except (AttributeError, KeyError):
         pass
     else:
@@ -2229,7 +2229,7 @@ def scan(detectors, motor, start, stop, num, *, per_step=None, md=None):
            'hints': {},
           }
     try:
-        dimensions = [('primary', motor.hints()['fields'])]
+        dimensions = [('primary', motor.hints['fields'])]
     except (AttributeError, KeyError):
         pass
     else:
@@ -2330,7 +2330,7 @@ def log_scan(detectors, motor, start, stop, num, *, per_step=None, md=None):
            'hints': {},
           }
     try:
-        dimensions = [('primary', motor.hints()['fields'])]
+        dimensions = [('primary', motor.hints['fields'])]
     except (AttributeError, KeyError):
         pass
     else:
@@ -2441,7 +2441,7 @@ def adaptive_scan(detectors, target_field, motor, start, stop,
            'hints': {},
           }
     try:
-        dimensions = [('primary', motor.hints()['fields'])]
+        dimensions = [('primary', motor.hints['fields'])]
     except (AttributeError, KeyError):
         pass
     else:
@@ -2607,7 +2607,7 @@ def scan_nd(detectors, cycler, *, per_step=None, md=None):
            'hints': {},
           }
     try:
-        dimensions = [('primary', motor.hints()['fields'])
+        dimensions = [('primary', motor.hints['fields'])
                       for motor in cycler.keys]
     except (AttributeError, KeyError):
         # Not all motors provide a 'fields' hint, so we have to skip it.
@@ -2852,7 +2852,7 @@ def tweak(detector, target_field, motor, step, *, md=None):
            'hints': {},
           }
     try:
-        dimensions = [('primary', motor.hints()['fields'])]
+        dimensions = [('primary', motor.hints['fields'])]
     except (AttributeError, KeyError):
         pass
     else:
@@ -2962,8 +2962,8 @@ def spiral_fermat(detectors, x_motor, y_motor, x_start, y_start, x_range,
            'hints': {},
           }
     try:
-        dimensions = [('primary', x_motor.hints()['fields']),
-                      ('primary', y_motor.hints()['fields'])]
+        dimensions = [('primary', x_motor.hints['fields']),
+                      ('primary', y_motor.hints['fields'])]
     except (AttributeError, KeyError):
         pass
     else:
@@ -3075,8 +3075,8 @@ def spiral(detectors, x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
            'hints': {},
           }
     try:
-        dimensions = [('primary', x_motor.hints()['fields']),
-                      ('primary', y_motor.hints()['fields'])]
+        dimensions = [('primary', x_motor.hints['fields']),
+                      ('primary', y_motor.hints['fields'])]
     except (AttributeError, KeyError):
         pass
     else:

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1406,7 +1406,7 @@ class RunEngine:
         object_keys = {obj.name: list(data_keys)}
         hints = {}
         if hasattr(obj, 'hints'):
-            hints.update({obj.name: obj.hints()})
+            hints.update({obj.name: obj.hints})
         desc_doc = dict(run_start=self._run_start_uid, time=ttime.time(),
                         data_keys=data_keys, uid=descriptor_uid,
                         configuration=config, hints=hints, name=name,
@@ -1496,7 +1496,7 @@ class RunEngine:
                 config[name]['timestamps'] = self._config_ts_cache[obj]
                 config[name]['data_keys'] = self._config_desc_cache[obj]
                 if hasattr(obj, 'hints'):
-                    hints[name] = obj.hints()
+                    hints[name] = obj.hints
             descriptor_uid = new_uid()
             doc = dict(run_start=self._run_start_uid, time=ttime.time(),
                        data_keys=data_keys, uid=descriptor_uid,
@@ -1660,7 +1660,7 @@ class RunEngine:
                 object_keys = {obj.name: list(data_keys)}
                 hints = {}
                 if hasattr(obj, 'hints'):
-                    hints.update({obj.name: obj.hints()})
+                    hints.update({obj.name: obj.hints})
                 doc = dict(run_start=self._run_start_uid, time=ttime.time(),
                            data_keys=data_keys, uid=descriptor_uid,
                            name=stream_name, hints=hints,

--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -1,7 +1,4 @@
 import ast
-from bluesky.examples import motor
-from bluesky.plans import scan
-from bluesky.utils import install_qt_kicker
 from bluesky.examples import motor, det3
 from bluesky.plans import scan, SupplementalData
 from bluesky.callbacks.best_effort import BestEffortCallback
@@ -12,7 +9,7 @@ import random
 def test_hints(fresh_RE):
     RE = fresh_RE
     expected_hint = {'fields': [motor.name]}
-    assert motor.hints() == expected_hint
+    assert motor.hints == expected_hint
     collector = []
 
     def collect(*args):
@@ -22,12 +19,15 @@ def test_hints(fresh_RE):
     name, doc = collector.pop()
     assert doc['hints'][motor.name] == expected_hint
 
+
 now = time.time
+
 
 class Detector:
     name = 'det'
     parent = None
     root = None
+    hints = {'fields': ['a']}
 
     def read(self):
         return {'a': {'value': random.random(), 'timestamp': now()},
@@ -43,9 +43,6 @@ class Detector:
     def describe_configuration(self):
         return {}
 
-    def hints(self):
-        return {'fields': ['a']}
-
 
 def test_simple(fresh_RE):
     RE = fresh_RE
@@ -53,6 +50,7 @@ def test_simple(fresh_RE):
     bec = BestEffortCallback()
     RE.subscribe(bec)
     RE(scan([det], motor, 1, 5, 5))
+
 
 def test_disable(fresh_RE):
     RE = fresh_RE

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1169,6 +1169,7 @@ def test_hints(fresh_RE):
         def __init__(self, name):
             self.name = name
             self.parent = None
+            self.hints = {'vis': 'placeholder'}
 
         def read(self):
             return {}
@@ -1181,9 +1182,6 @@ def test_hints(fresh_RE):
 
         def describe_configuration(self):
             return {}
-
-        def hints(self):
-            return {'vis': 'placeholder'}
 
     det = Detector('det')
 

--- a/bluesky/tests/test_simple_api.py
+++ b/bluesky/tests/test_simple_api.py
@@ -1,6 +1,6 @@
 from bluesky.examples import (motor, motor1, motor2, det, det1, det2,
                               MockFlyer, NullStatus)
-                            
+
 import pytest
 import bluesky.plans as bp
 from bluesky.callbacks.best_effort import BestEffortCallback
@@ -33,7 +33,7 @@ class MotorEmptyHints:
         self.name = name
         self.parent = None
         self.position = 0
-
+        self.hints = {}
     def read(self):
         return {}
 
@@ -49,8 +49,6 @@ class MotorEmptyHints:
     def set(self, val):
         return NullStatus()
 
-    def hints(self):
-        return {}
 
 
 def checker(name, doc):
@@ -87,7 +85,7 @@ _motor2 = MotorNoHints('motor2')
 
 
 @pytest.mark.parametrize('pln,args,kwargs', [
-    # repeat with motor objects that do not have hints()
+    # repeat with motor objects that do not have hints
     (bp.scan, (_motor, 1, 2, 2), {}),
     (bp.inner_product_scan, (2, _motor, 1, 2), {}),
     (bp.relative_inner_product_scan, (2, _motor, 1, 2), {}),
@@ -109,7 +107,7 @@ _motor2 = MotorEmptyHints('motor2')
 
 
 @pytest.mark.parametrize('pln,args,kwargs', [
-    # repeat with motor objects that do not have hints()
+    # repeat with motor objects that do not have hints
     (bp.scan, (_motor, 1, 2, 2), {}),
     (bp.inner_product_scan, (2, _motor, 1, 2), {}),
     (bp.relative_inner_product_scan, (2, _motor, 1, 2), {}),


### PR DESCRIPTION
There are no plans to pass it anything to control what is returned
and by making it an attribute it makes configuration easier.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
