### PR TITLE
BLD: Remove traitlets from requirements; it is not used at all.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
   - |
     if [ $CONDA_ENV ]; then
-       conda create -n testenv python=$TRAVIS_PYTHON_VERSION scipy matplotlib numpy h5py traitlets jsonschema databroker pip doct xray-vision lmfit pyzmq ophyd filestore event-model dill ophyd pims mongoquery pytest $EXTRA_C_CHAN -c lightsource2-tag -c conda-forge -c soft-matter -c defaults --override-channels
+       conda create -n testenv python=$TRAVIS_PYTHON_VERSION scipy matplotlib numpy h5py jsonschema databroker pip doct xray-vision lmfit pyzmq ophyd filestore event-model dill ophyd pims mongoquery pytest $EXTRA_C_CHAN -c lightsource2-tag -c conda-forge -c soft-matter -c defaults --override-channels
        source activate testenv
        pip install https://github.com/NSLS-II/event-model/zipball/master#egg=event_model
        source activate testenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ numpy
 super_state_machine
 toolz
 tqdm
-traitlets


### PR DESCRIPTION
Our dependency on traitlets went about with global state. We do not used it anywhere
(confirmed with `git grep traitlets`).

This removes it from requirements.txt and .travis.yml.