### PR TITLE
ENH: Simple install_kicker()

### DIFF
--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 import asyncio
 import os
+import sys
 import signal
 import operator
 import uuid
@@ -687,6 +688,22 @@ def get_history():
 _QT_KICKER_INSTALLED = {}
 _NB_KICKER_INSTALLED = {}
 
+def install_kicker(loop=None):
+    """Install the proper kicker (qt_kicker or nb_kicker) based on where 
+    the code is running
+    """
+    def is_ipython():
+        ip = True
+        if 'ipykernel' in sys.modules:
+            ip = False # Notebook
+        elif 'IPython' in sys.modules:
+            ip = True # Shell
+        return ip
+
+    if is_ipython():
+        install_qt_kicker(loop=loop)
+    else:
+        install_nb_kicker(loop=loop)
 
 def install_qt_kicker(loop=None, update_rate=0.03):
     """Install a periodic callback to integrate qt and asyncio event loops


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Usually users need to call either ```install_qt_kicker``` or ```install_nb_kicker``` in order to get the live plots and other callbacks to work properly. The idea of this PR is to add a functionality that I added to LIX while working there to make it easier for the user by just installing the correct one based on how they are running the code.

## Description
<!--- Describe your changes in detail -->
Added a method at utils.py named ```install_kicker``` which based on the environment will install either qt_kicker or nb_kicker.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It simplifies the setup of the kicker.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally tested.

<!--
## Screenshots (if appropriate):
-->