### PR TITLE
Mnt bec 2 d plotting

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -72,7 +72,7 @@ class BestEffortCallback(CallbackBase):
             return
 
         super().__call__(name, doc)
-    
+
     def start(self, doc):
         self.clear()
         self._start_doc = doc
@@ -101,9 +101,9 @@ class BestEffortCallback(CallbackBase):
                  "combine streams.")
         self.dim_fields = [f
                            for field, stream_name in dimensions
-                               for f in field]
-        _, self.dim_stream  = dimensions[0]
-    
+                           for f in field]
+        _, self.dim_stream = dimensions[0]
+
     def descriptor(self, doc):
         self._descriptors[doc['uid']] = doc
         stream_name = doc.get('name', 'primary')  # fall back for old docs
@@ -115,7 +115,7 @@ class BestEffortCallback(CallbackBase):
 
         columns = hinted_fields(doc)
 
-        ### This deals with old documents. ### 
+        # ## This deals with old documents. ## #
 
         if stream_name == 'primary' and self._cleanup_motor_heuristic:
             # We stashed object names in self.dim_fields, which we now need to
@@ -130,8 +130,8 @@ class BestEffortCallback(CallbackBase):
                 fixed_dim_fields.extend(fields)
             self.dim_fields = fixed_dim_fields
 
-        ### TABLE ###
-        
+        # ## TABLE ## #
+
         if stream_name == self.dim_stream:
             # Ensure that no independent variables ('dimensions') are
             # duplicated here.
@@ -142,15 +142,15 @@ class BestEffortCallback(CallbackBase):
                 self._table('start', self._start_doc)
                 self._table('descriptor', doc)
 
-        ### DECIDE WHICH KIND OF PLOT CAN BE USED ###
+        # ## DECIDE WHICH KIND OF PLOT CAN BE USED ## #
 
         if not self._plots_enabled:
             return
         if stream_name in self.noplot_streams:
             return
         if ((self._start_doc.get('num_points') == 1) and
-            (stream_name == self.dim_stream) and
-            self.omit_single_point_plot):
+                (stream_name == self.dim_stream) and
+                self.omit_single_point_plot):
             return
 
         # This is a heuristic approach until we think of how to hint this in a
@@ -197,7 +197,7 @@ class BestEffortCallback(CallbackBase):
             fig.tight_layout()
         axes = fig.axes
 
-        ### LIVE PLOT AND PEAK ANALYSIS ###
+        # ## LIVE PLOT AND PEAK ANALYSIS ## #
 
         if len(dim_fields) == 1:
             self._live_plots[doc['uid']] = {}
@@ -231,7 +231,7 @@ class BestEffortCallback(CallbackBase):
                     shape = self._start_doc['shape']
                 except KeyError:
                     warn("Need both 'shape' and 'extents' in plan metadata to "
-                        "create LiveGrid.")
+                         "create LiveGrid.")
                 else:
                     for I_key, ax in zip(columns, axes):
                         live_grid = LiveGrid(shape, I_key,

--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -192,6 +192,7 @@ class BestEffortCallback(CallbackBase):
             # The complexity here is due to making a shared x axis. This can be
             # simplified when Figure supports the `subplots` method in a future
             # release of matplotlib.
+            fig.set_size_inches(6.4, min(950, len(columns) * 400) / fig.dpi)
             for i in range(len(columns)):
                 if i == 0:
                     ax = fig.add_subplot(len(columns), 1, 1 + i)

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -356,7 +356,7 @@ class LiveScatter(CallbackBase):
                              norm=self._norm, cmap=self.cmap, **self.kwargs)
         self._sc.append(sc)
         self.sc = sc
-        cb = self.ax.figure.colorbar(sc)
+        cb = self.ax.figure.colorbar(sc, ax=self.ax)
         cb.set_label(self.I)
         super().start(doc)
 
@@ -473,7 +473,7 @@ class LiveGrid(CallbackBase):
                                                       uid=doc['uid'][:6]))
         self.snaking = doc.get('snaking', (False, False))
 
-        cb = self.ax.figure.colorbar(im)
+        cb = self.ax.figure.colorbar(im, ax=self.ax)
         cb.set_label(self.I)
         super().start(doc)
 

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -440,7 +440,7 @@ class LiveGrid(CallbackBase):
         self.I = I
         ax.set_xlabel(xlabel)
         ax.set_ylabel(ylabel)
-        ax.set_aspect('equal')
+        ax.set_aspect(aspect)
         self.ax = ax
         self._Idata = np.ones(raster_shape) * np.nan
         self._norm = mcolors.Normalize()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The fixed aspect + shared axis where producing sub-optimal plots for multiple detectors plotted with BEC.

BEC now also guesses if the image should have equal aspect ratio (for example scanning two motors in the same units) or automatic aspect (which makes sense for motor vs E or something like that).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->

```python
import matplotlib
matplotlib.use('Qt5Agg')
import matplotlib.pyplot as plt
plt.ion()
from bluesky.examples import motor, motor1, det, det1
from bluesky import RunEngine
from bluesky.callbacks.best_effort import BestEffortCallback
import bluesky.plans as bp
from bluesky.utils import install_qt_kicker
install_qt_kicker()

RE = RunEngine()
bec = BestEffortCallback()
RE.subscribe(bec)

```


```python
RE(bp.outer_product_scan([det1, det], motor, -1, 1, 5, motor1, 10, 20, 3, False))
```
![so](https://user-images.githubusercontent.com/199813/29980310-4643b8b0-8f17-11e7-952b-7a3dffe0613c.png)

```python
RE(bp.outer_product_scan([det1, det], motor, -1, 1, 3, motor1, 0, 2, 3, False))
```
![so](https://user-images.githubusercontent.com/199813/29980419-d71384a6-8f17-11e7-8ce5-911e7846ac42.png)
