### PR TITLE
ENH: Add update_rate as kwarg in kicker utils

### DIFF
--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -688,7 +688,7 @@ _QT_KICKER_INSTALLED = {}
 _NB_KICKER_INSTALLED = {}
 
 
-def install_qt_kicker(loop=None):
+def install_qt_kicker(loop=None, update_rate=0.03):
     """Install a periodic callback to integrate qt and asyncio event loops
 
     If a version of the qt bindings are not already imported, this function
@@ -724,12 +724,12 @@ def install_qt_kicker(loop=None):
         _draw_all()
 
         qApp.processEvents()
-        loop.call_later(0.03, _qt_kicker)
+        loop.call_later(update_rate, _qt_kicker)
 
     _QT_KICKER_INSTALLED[loop] = loop.call_soon(_qt_kicker)
 
 
-def install_nb_kicker(loop=None):
+def install_nb_kicker(loop=None, update_rate=0.03):
     """
     The RunEngine Event Loop interferes with the qt event loop. Here we
     kick it to keep it going.
@@ -752,7 +752,7 @@ def install_nb_kicker(loop=None):
             if f_mgr.canvas.figure.stale:
                 f_mgr.canvas.draw()
 
-        loop.call_later(0.03, _nbagg_kicker)
+        loop.call_later(update_rate, _nbagg_kicker)
 
     _NB_KICKER_INSTALLED[loop] = loop.call_soon(_nbagg_kicker)
 


### PR DESCRIPTION
## Description
Allow users to select the update_rate of either the `nb_kicker` or `qt_kicker` at call time. 

## Motivation and Context
Doesn't seem like it could hurt anything. Main motivation is we are experimenting with putting the RunEngine behind a PyQT UI and 0.03s between updates is too unresponsive

Have you experimented with controlling the RunEngine through Qt? We might end up just launching multiple threads to have completely separate event loops, so this may end up being moot. However, the option seems like it would be nice to have.

