### PR TITLE
ENH: Include heading with IDs, times in BEC.

### DIFF
--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -80,6 +80,8 @@ def test_disable(fresh_RE):
     bec.enable_plots()
     bec.disable_baseline()
     bec.enable_baseline()
+    bec.disable_heading()
+    bec.enable_heading()
 
 
 def test_blank_hints(fresh_RE):

--- a/doc/source/callbacks.rst
+++ b/doc/source/callbacks.rst
@@ -631,6 +631,8 @@ Use these methods to toggle on or off parts of the functionality.
 .. autosummary::
     :toctree: generated
 
+    BestEffortCallback.enable_heading
+    BestEffortCallback.disable_heading
     BestEffortCallback.enable_table
     BestEffortCallback.disable_table
     BestEffortCallback.enable_baseline


### PR DESCRIPTION
A commonly-used callback prints the scan IDs and timestamps
above the LiveTable. This pulls that upstream into BEC
and adds switches for toggling it on and off.