### PR TITLE
MAINT: LiveFitPlot should reference ydata before updating

### DIFF
--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -801,8 +801,8 @@ class LiveFit(CallbackBase):
     def update_fit(self):
         N = len(self.model.param_names)
         if len(self.ydata) < N:
-            print("LiveFitPlot cannot update fit until there are at least {} "
-                  "data points".format(N))
+            warnings.warn("LiveFitPlot cannot update fit until there are at least {} "
+                          "data points".format(N))
         else:
             kwargs = {}
             kwargs.update(self.independent_vars_data)

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -778,7 +778,7 @@ class LiveFit(CallbackBase):
 
         # Maybe update the fit or maybe wait.
         if self.update_every is not None:
-            i = doc['seq_num']
+            i = len(self.ydata)
             N = len(self.model.param_names)
             if i < N:
                 # not enough points to fit yet
@@ -801,13 +801,14 @@ class LiveFit(CallbackBase):
     def update_fit(self):
         N = len(self.model.param_names)
         if len(self.ydata) < N:
-            raise RuntimeError("cannot update fit until there are least {} "
-                               "data points".format(N))
-        kwargs = {}
-        kwargs.update(self.independent_vars_data)
-        kwargs.update(self.init_guess)
-        self.result = self.model.fit(self.ydata, **kwargs)
-        self.__stale = False
+            print("LiveFitPlot cannot update fit until there are at least {} "
+                  "data points".format(N))
+        else:
+            kwargs = {}
+            kwargs.update(self.independent_vars_data)
+            kwargs.update(self.init_guess)
+            self.result = self.model.fit(self.ydata, **kwargs)
+            self.__stale = False
 
 
 class LiveFitPlot(LivePlot):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Solution for issue #684. Reference the length of the stored `ydata` instead of the sequence numbering before updating the `lmfit` model
## Description
<!--- Describe your changes in detail -->
* Instead of referencing the sequence number we see check the `ydata` array directly
* I replaced the `RuntimeError` with a print statement. It seems to me the operating model is that even when they are misconfigured the callbacks should not raise exceptions. For example, if you enter the wrong key name in `LivePlot` it doesn't break your scan, it just doesn't display well. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are a number of situations where checking the sequence number is less advantageous. For instance, if you have multiple groups being read out and your y data is not present in every emitted event document. If the first sequence number you see the y data key is document five the LiveFit would have tried to update itself.

As far as replacing the `RuntimeError`, I've run into a few places where this has been super annoying. For instance, your scan takes a single measurement  then an exception is raised, calling `stop`. Which in turns raising the `RuntimeError` on the callback because it tries to update the fit. This makes it hard to debug as the traceback just shows that the `LiveFit` raised an exception. 