### PR TITLE
ENH: Plan preprocessor to remove run_control

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1397,6 +1397,31 @@ def inject_md_wrapper(plan, md):
     return (yield from msg_mutator(plan, _inject_md))
 
 
+def stub_wrapper(plan):
+    """
+    Remove Msg object in order to use plan as a stub
+
+    This will remove any `open_run`, `close_run`, `stage` and `unstage` `Msg`
+    objects present in the plan in order for it to be run as part of a larger
+    scan.
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        A generator list or similar containing `Msg` objects
+    """
+    def _block_run_control(msg):
+        """
+        Block open and close run messages
+        """
+        if msg.command in ['open_run', 'close_run',
+                           'stage', 'unstage']:
+            return None
+        return msg
+
+    return (yield from msg_mutator(plan, _block_run_control))
+
+
 def monitor_during_wrapper(plan, signals):
     """
     Monitor (asynchronously read) devices during runs.
@@ -2007,6 +2032,7 @@ fly_during_decorator = make_decorator(fly_during_wrapper)
 monitor_during_decorator = make_decorator(monitor_during_wrapper)
 inject_md_decorator = make_decorator(inject_md_wrapper)
 run_decorator = make_decorator(run_wrapper)
+stub_decorator = make_decorator(stub_wrapper)
 configure_count_time_decorator = make_decorator(configure_count_time_wrapper)
 
 

--- a/bluesky/tests/test_generators.py
+++ b/bluesky/tests/test_generators.py
@@ -5,7 +5,7 @@ from itertools import zip_longest
 
 from bluesky import Msg
 
-from bluesky.plans import (msg_mutator, plan_mutator, pchain,
+from bluesky.plans import (msg_mutator, stub_wrapper, plan_mutator, pchain,
                            single_gen as single_message_gen, finalize_wrapper)
 
 from bluesky.utils import ensure_generator, single_gen
@@ -447,3 +447,16 @@ def test_msg_mutator_skip():
                     cmd_sq='abcd',
                     args_sq=[()]*4,
                     kwargs_sq=[{}]*4)
+
+
+def test_stub_wrapper():
+    def plan():
+        yield Msg('open_run')
+        yield Msg('stage')
+        yield Msg('read')
+        yield Msg('unstage')
+        yield Msg('close_run')
+
+    stub_plan = list(stub_wrapper(plan()))
+    assert len(stub_plan) == 1
+    assert stub_plan[0].command == 'read'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A simple plan preprocessor called `stub_wrapper` that strips `open_run`, `closed_run`, `stage` and `unstage`. 
## Description
<!--- Describe your changes in detail -->
I think of this as the inverse method for `run_wrapper`. There is a lot of logic built into the complete plans, but these are slightly awkward to stitch together. This allows you to remove all of the run control and staging functionality and just use the scanning logic.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This opens up a simple way to stitch plans together without having to rewrite things from scratch. For instance, this implementation seems pretty intuitive

```python

list_scan([det], motor, [1,2,3,4,5], per_step=stub_wrapper(count([det], num=5, delay=3)))
```
We have been using this at SLAC in a few places so I figured I would throw it back and see if you found it useful. The nice thing is as a developer you can write a plan that nicely configures metadata e.t.c, but if someone wants to use it as part of a larger scan they are free to rip out the staging / RunEngine control.

The only concern I might have is this opens up a whole new way to put plans together that could be exploited. For instance, do we want users running a grid scan with nested calls of list_scan?

## How Has This Been Tested?
Added a test in `bluesky/tests/test_generators.py`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
