### PR TITLE
ENH: make RE pause message an attribute.

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -166,6 +166,12 @@ class RunEngine:
         For built-in Python interpreter, set to 2. For IPython, set to 11
         (tested on IPython 5.1.0; other versions may vary).
 
+    pause_msg : str
+        The message printed when a run is interrupted. This message
+        includes instructions of changing the state of the RunEngine.
+        It is set to ``bluesky.run_engine.PAUSE_MSG`` by default and
+        can be modified based on needs.
+
     """
 
     state = LoggingPropertyMachine(RunEngineStateMachine)
@@ -201,6 +207,7 @@ class RunEngine:
         self.state_hook = None
         self.waiting_hook = None
         self.record_interruptions = False
+        self.pause_msg = PAUSE_MSG
 
         # The RunEngine keeps track of a *lot* of state.
         # All flags and caches are defined here with a comment. Good luck.
@@ -1056,7 +1063,7 @@ class RunEngine:
                           "KeyboardInterrupt. Intercepting and triggering "
                           "a HALT.")
                     self.loop.call_soon(self.halt)
-                    print(PAUSE_MSG)
+                    print(self.pause_msg)
                 except asyncio.CancelledError as e:
                     # if we are handling this twice, raise and leave the plans
                     # alone
@@ -1157,7 +1164,7 @@ class RunEngine:
                     self.log.debug("RunEngine detected two SIGINTs. "
                                    "A hard pause will be requested.")
                     self.loop.call_soon(self.request_pause, False)
-                    print(PAUSE_MSG)
+                    print(self.pause_msg)
             else:
                 # No new SIGINTs to process.
                 if self._num_sigints_processed > 0:


### PR DESCRIPTION
Make ``RE`` pause message configurable

## Description
Adding an attribute ``pause_msg`` to ``RE`` (default to ``bluesky.run_engine.PAUSE_MSG``), so that the message printed when a run is interrupted can be modified if needed.

## Motivation and Context
As the discussion [in an issue from separate repo](https://github.com/xpdAcq/mission-control/issues/52), it might be good if the pause message is configurable. Here is summary of this PR:

1. The name of ``RunEngine`` instance might not always be ``RE``. If the name of this ``RE`` instance is ``foo`` then the user would need to do ``foo.abort()`` to about the run from ``foo``. However, current pause message instructs the user to do ``RE.abort()`` regardless the name of ``RE`` instance.

2. It's likely that people might want to customize the pause message even more heavily (or omit it altogether).

## How Has This Been Tested?
This change has been tested within ``bluesky``. Please see the code block below.

````
In [31]: from bluesky.run_engine import RunEngine

In [32]: import bluesky.plans as bp

In [33]: import bluesky.examples as be

In [34]: myRE = RunEngine()

In [35]: print(myRE.pause_msg)

Your RunEngine is entering a paused state. These are your options for changing
the state of the RunEngine:

RE.resume()    Resume the plan.
RE.abort()     Perform cleanup, then kill plan. Mark exit_stats='aborted'.
RE.stop()      Perform cleanup, then kill plan. Mark exit_status='success'.
RE.halt()      Emergency Stop: Do not perform cleanup --- just stop.


In [36]: customized_pause_msg = """
    ...: Your RunEngine is entering a paused state. These are your options for changing 
    ...: the state of the RunEngine:
    ...: 
    ...: myRE.resume()    Resume the plan.
    ...: myRE.abort()     Perform cleanup, then kill plan. Mark exit_stats='aborted'.
    ...: myRE.stop()      Perform cleanup, then kill plan. Mark exit_status='success'.
    ...: myRE.halt()      Emergency Stop: Do not perform cleanup --- just stop.
    ...: """

In [37]: myRE.pause_msg = customized_pause_msg

In [38]: print(myRE.pause_msg)

Your RunEngine is entering a paused state. These are your options for changing 
the state of the RunEngine:

myRE.resume()    Resume the plan.
myRE.abort()     Perform cleanup, then kill plan. Mark exit_stats='aborted'.
myRE.stop()      Perform cleanup, then kill plan. Mark exit_status='success'.
myRE.halt()      Emergency Stop: Do not perform cleanup --- just stop.


In [39]: plan = bp.count([be.det], num=10, delay=2)

In [40]: myRE(plan)
^CA 'deferred pause' has been requested. The RunEngine will pause at the next checkpoint. To pause immediately, hit Ctrl+C again in the next 10 seconds.
Deferred pause acknowledged. Continuing to checkpoint.
^C
Your RunEngine is entering a paused state. These are your options for changing 
the state of the RunEngine:

myRE.resume()    Resume the plan.
myRE.abort()     Perform cleanup, then kill plan. Mark exit_stats='aborted'.
myRE.stop()      Perform cleanup, then kill plan. Mark exit_status='success'.
myRE.halt()      Emergency Stop: Do not perform cleanup --- just stop.

Pausing...
Out[40]: ('e5484451-6285-4dc7-8ef7-2e5ed9a26dbf',)

In [41]: myRE.abort()
Aborting: running cleanup and marking exit_status as 'abort'...
````
