### PR TITLE
API: Always raise when interrupted. Reserve no kwargs in RE.__call__.

### DIFF
--- a/bluesky/magics.py
+++ b/bluesky/magics.py
@@ -8,7 +8,7 @@
 import asyncio
 import bluesky.plans as bp
 from bluesky.utils import ProgressBarManager
-from bluesky import RunEngine
+from bluesky import RunEngine, RunEngineInterrupted
 from IPython.core.magic import Magics, magics_class, line_magic
 import numpy as np
 from operator import attrgetter
@@ -62,7 +62,10 @@ class BlueskyMagics(Magics):
             args.append(eval(pos, self.shell.user_ns))
         plan = bp.mv(*args)
         self.RE.waiting_hook = self.pbar_manager
-        self.RE(plan)
+        try:
+            self.RE(plan)
+        except RunEngineInterrupted:
+            ...
         self.RE.waiting_hook = None
         self._ensure_idle()
         return None
@@ -78,7 +81,10 @@ class BlueskyMagics(Magics):
             args.append(eval(pos, self.shell.user_ns))
         plan = bp.mvr(*args)
         self.RE.waiting_hook = self.pbar_manager
-        self.RE(plan)
+        try:
+            self.RE(plan)
+        except RunEngineInterrupted:
+            ...
         self.RE.waiting_hook = None
         self._ensure_idle()
         return None
@@ -94,7 +100,10 @@ class BlueskyMagics(Magics):
         plan = bp.count(dets)
         print("[This data will not be saved. "
               "Use the RunEngine to collect data.]")
-        self.RE(plan, _ct_callback)
+        try:
+            self.RE(plan, _ct_callback)
+        except RunEngineInterrupted:
+            ...
         self._ensure_idle()
         return None
 

--- a/bluesky/tests/test_devices.py
+++ b/bluesky/tests/test_devices.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 from bluesky.utils import ancestry, share_ancestor, separate_devices
 from bluesky.plans import trigger_and_read
-from bluesky import Msg
+from bluesky import Msg, RunEngineInterrupted
 import pytest
 from bluesky.tests import requires_ophyd, ophyd
 
@@ -94,7 +94,9 @@ def test_monitor_with_pause_resume(fresh_RE):
         yield Msg('pause')
         a.s1._run_subs(sub_type='value')
         yield Msg('close_run')
-    fresh_RE(plan(), collect)
+
+    with pytest.raises(RunEngineInterrupted):
+        fresh_RE(plan(), collect)
     assert len(docs) == 3  # RunStart, EventDescriptor, one Event
     # All but one of these will be ignored. Why is one not ignored, you ask?
     # Beacuse ophyd runs subscriptions when they are (re-)subscriped.

--- a/bluesky/tests/test_documents.py
+++ b/bluesky/tests/test_documents.py
@@ -15,7 +15,7 @@ def test_custom_metadata():
         assert 'animal' in doc
         assert doc['animal'] == 'lion'
 
-    RE(simple_scan(motor), animal='lion', subs={'start': assert_lion})
+    RE(simple_scan(motor), {'start': assert_lion}, animal='lion')
     # Note: Because assert_lion is processed on the main thread, it can
     # fail the test. I checked by writing a failing version of it.  - D.A.
 

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -1,6 +1,6 @@
 from collections import deque, defaultdict
 import pytest
-from bluesky import Msg
+from bluesky import Msg, RunEngineInterrupted
 from bluesky.examples import (det, det1, det2, Mover, NullStatus, motor,
                               SynGauss, Reader, motor1, motor2)
 from bluesky.plans import (create, save, read, monitor, unmonitor, null,
@@ -626,7 +626,8 @@ def test_infinite_count(fresh_RE):
     def collector(name, doc):
         docs[name].append(doc)
 
-    fresh_RE(count([det], num=None), collector)
+    with pytest.raises(RunEngineInterrupted):
+        fresh_RE(count([det], num=None), collector)
 
     assert len(docs['start']) == 1
     assert len(docs['stop']) == 1

--- a/bluesky/tests/test_scans.py
+++ b/bluesky/tests/test_scans.py
@@ -26,7 +26,7 @@ RE = setup_test_run_engine()
 def traj_checker(scan, expected_traj):
     actual_traj = []
     callback = collector('motor', actual_traj)
-    RE(scan, subs={'event': callback})
+    RE(scan, {'event': callback})
     assert actual_traj == list(expected_traj)
 
 
@@ -36,7 +36,7 @@ def multi_traj_checker(scan, expected_data):
     def collect_data(name, event):
         actual_data.append(event['data'])
 
-    RE(scan, subs={'event': collect_data})
+    RE(scan, {'event': collect_data})
     assert actual_data == expected_data
 
 
@@ -46,7 +46,7 @@ def approx_multi_traj_checker(RE, scan, expected_data, *, decimal=2):
     def collect_data(name, event):
         actual_data.append(event['data'])
 
-    RE(scan, subs={'event': collect_data})
+    RE(scan, {'event': collect_data})
     keys = sorted(expected_data[0].keys())
     actual_values = [[row[key] for key in keys]
                      for row in actual_data]
@@ -227,8 +227,8 @@ def test_adaptive_ascan():
     counter1 = CallbackCounter()
     counter2 = CallbackCounter()
 
-    RE(scan1, subs={'event': [col, counter1]})
-    RE(scan2, subs={'event': counter2})
+    RE(scan1, {'event': [col, counter1]})
+    RE(scan2, {'event': counter2})
     assert counter1.value > counter2.value
     assert actual_traj[0] == 0
 
@@ -250,8 +250,8 @@ def test_adaptive_dscan():
     counter2 = CallbackCounter()
 
     motor.set(1)
-    RE(scan1, subs={'event': [col, counter1]})
-    RE(scan2, subs={'event': counter2})
+    RE(scan1, {'event': [col, counter1]})
+    RE(scan2, {'event': counter2})
     assert counter1.value > counter2.value
     assert actual_traj[0] == 1
 
@@ -267,14 +267,14 @@ def test_count():
     col = collector('det', actual_intensity)
     motor.set(0)
     scan = Count([det])
-    RE(scan, subs={'event': col})
+    RE(scan, {'event': col})
     assert actual_intensity[0] == 1.
 
     # multiple counts, via updating attribute
     actual_intensity = []
     col = collector('det', actual_intensity)
     scan = Count([det], num=3, delay=0.05)
-    RE(scan, subs={'event': col})
+    RE(scan, {'event': col})
     assert scan.num == 3
     assert actual_intensity == [1., 1., 1.]
 
@@ -282,13 +282,13 @@ def test_count():
     actual_intensity = []
     col = collector('det', actual_intensity)
     scan = Count([det], num=3, delay=0.05)
-    RE(scan(num=2), subs={'event': col})
+    RE(scan(num=2), {'event': col})
     assert actual_intensity == [1., 1.]
     # attribute should still be 3
     assert scan.num == 3
     actual_intensity = []
     col = collector('det', actual_intensity)
-    RE(scan, subs={'event': col})
+    RE(scan, {'event': col})
     assert actual_intensity == [1., 1., 1.]
 
 

--- a/bluesky/tests/test_suspenders.py
+++ b/bluesky/tests/test_suspenders.py
@@ -139,7 +139,8 @@ def test_pause_from_suspend(fresh_RE):
     RE._loop.call_later(1, RE.request_pause)
     RE._loop.call_later(2, sig.put, 0)
     RE.msg_hook = accum
-    RE(scan)
+    with pytest.raises(RunEngineInterrupted):
+        RE(scan)
     assert [m[0] for m in msg_lst] == ['wait_for']
     RE.resume()
     assert ['wait_for', 'wait_for', 'checkpoint'] == [m[0] for m in msg_lst]
@@ -163,7 +164,8 @@ def test_deferred_pause_from_suspend(fresh_RE):
     RE._loop.call_later(1, RE.request_pause, True)
     RE._loop.call_later(4, sig.put, 0)
     RE.msg_hook = accum
-    RE(scan)
+    with pytest.raises(RunEngineInterrupted):
+        RE(scan)
     assert [m[0] for m in msg_lst] == ['wait_for', 'checkpoint']
     RE.resume()
     assert ['wait_for', 'checkpoint', 'null'] == [m[0] for m in msg_lst]
@@ -183,6 +185,6 @@ def test_unresumable_suspend_fail(fresh_RE):
     loop.call_later(1, ev.set)
     start = time.time()
     with pytest.raises(RunEngineInterrupted):
-        RE(scan, raise_if_interrupted=True)
+        RE(scan)
     stop = time.time()
     assert .1 < stop - start < 1

--- a/bluesky/tests/test_vertical_integration.py
+++ b/bluesky/tests/test_vertical_integration.py
@@ -22,7 +22,7 @@ def test_post_run(fresh_RE, db):
     def do_nothing(doctype, doc):
         output[doctype].append(doc)
 
-    RE(stepscan(det, motor), subs={'stop': [post_run(do_nothing, db=db)]})
+    RE(stepscan(det, motor), {'stop': [post_run(do_nothing, db=db)]})
     assert len(output)
     assert len(output['start']) == 1
     assert len(output['stop']) == 1
@@ -35,4 +35,4 @@ def test_verify_files_saved(fresh_RE, db):
     RE.subscribe(db.insert)
 
     vfs = partial(verify_files_saved, db=db)
-    RE(stepscan(det, motor), subs={'stop': vfs})
+    RE(stepscan(det, motor), {'stop': vfs})


### PR DESCRIPTION
~There are couple more tests to fix before this is done, but let's kick off discussion in the meantime....~ Update: tests pass.

## Part I: Always raise when interrupted.

When the RunEngine is paused by Ctrl+C or by a plan (using `Msg('pause')`) it does not raise an exception by default. This is usually "nice" for interactive use (no ugly tracebacks!) but it is bad behavior as a library. This kind of thing is dangerous:

```python
def f():
    RE(plan1)  # if this catches Ctrl+C and goes into a paused state
    RE(plan2)  # this will immediate start running! bad!
```

Even here at NSLS-II where @tacaswell and I prowl the ring with clubs and bludgeon scientists about avoiding this, it happens all the time. It is just too obvious of thing to do, and users naturally discover it. We should continue to tell them not to. (Don't worry, @tacaswell, I'm not compromising my position on that.) But as an extra safely measure, I think the RunEngine should always raise when interrupted so that the function above will _not_ execute `plan2` if `plan1` is interrupted.

Before:

```python
In [5]: RE(count([], delay=2, num=2))
^CA 'deferred pause' has been requested. The RunEngine will pause at the next checkpoint. To pause immediately, hit Ctrl+C again in the next 10 seconds.
Deferred pause acknowledged. Continuing to checkpoint.
^C
Your RunEngine is entering a paused state. These are your options for changing
the state of the RunEngine:

RE.resume()    Resume the plan.
RE.abort()     Perform cleanup, then kill plan. Mark exit_stats='aborted'.
RE.stop()      Perform cleanup, then kill plan. Mark exit_status='success'.
RE.halt()      Emergency Stop: Do not perform cleanup --- just stop.

Pausing...
```

After:

```python
In [4]: RE(count([], delay=2, num=2))
^CA 'deferred pause' has been requested. The RunEngine will pause at the next checkpoint. To pause immediately, hit Ctrl+C again in the next 10 seconds.
Deferred pause acknowledged. Continuing to checkpoint.
^CPausing...
---------------------------------------------------------------------------
RunEngineInterrupted                      Traceback (most recent call last)
<ipython-input-4-764cff068f39> in <module>()
----> 1 RE(count([], delay=2, num=2))

~/Documents/Repos/bluesky/bluesky/run_engine.py in __call__(self, *args, **metadata_kw)
    650
    651             if self._interrupted:
--> 652                 raise RunEngineInterrupted(PAUSE_MSG) from None
    653
    654         return tuple(self._run_start_uids)

RunEngineInterrupted:
Your RunEngine is entering a paused state. These are your options for changing
the state of the RunEngine:

RE.resume()    Resume the plan.
RE.abort()     Perform cleanup, then kill plan. Mark exit_stats='aborted'.
RE.stop()      Perform cleanup, then kill plan. Mark exit_status='success'.
RE.halt()      Emergency Stop: Do not perform cleanup --- just stop.
```

It's a bit uglier, but the important thing is that it correctly raises an exception that will propagate up the stack!

There is a special kwargs in `RE.__call__` to optionally turn on behavior like this -- `RE(..., raise_if_interrupted=True)` -- but generally no one who needs it knows that they do or thinks to look for it. We should just remove it. Which brings me to...

## Part II: Reserve no kwargs in `RE.__call__`.

Removing the `raise_if_interrupted` keyword argument solves an unrelated problem: we can now say without reservation that _all_ keyword arguments passed to `RunEngine.__call__` are treated as user metadata. We can even avoid shadowing the terms 'plan' and 'subs' by using some tricks with `Signature` to make them positional-only arguments, reserving all keyword arguments for the user. It's a minor thing, but it's nice to be able to say "All keyword args are interpreted as metadata," without going on to qualify that with some (admittedly hard-to-hit) exceptions.

Thoughts?

Closes #704 