### PR TITLE
Fix mark success on abort

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -21,7 +21,7 @@ from .utils import (Struct, Subs, normalize_subs_input, root_ancestor,
                     separate_devices, apply_sub_factories, update_sub_lists,
                     all_safe_rewind, Msg, ensure_generator, single_gen,
                     short_uid as _short_uid, RampFail, make_decorator,
-                    RunEngineControlExceptions)
+                    RunEngineControlException)
 
 
 def planify(func):
@@ -934,7 +934,7 @@ def run_wrapper(plan, *, md=None):
     rs_uid = yield from open_run(md)
 
     def except_plan(e):
-        if isinstance(e, RunEngineControlExceptions):
+        if isinstance(e, RunEngineControlException):
             yield from close_run()
         else:
             yield from close_run(exit_status='fail', reason=str(e))

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1059,7 +1059,7 @@ def open_run(md=None):
     return (yield Msg('open_run', **(md or {})))
 
 
-def close_run():
+def close_run(exit_status=None, reason=None):
     """
     Mark the end of the current 'run'. Emit a RunStop document.
 
@@ -1067,12 +1067,16 @@ def close_run():
     ------
     msg : Msg
         Msg('close_run')
+    exit_status : {None, 'success', 'abort', 'fail'}
+        The exit status to report in the Stop document
+    reason : str, optional
+        Long-form description of why the run ended
 
     See Also
     --------
     :func:`bluesky.plans.open_run`
     """
-    return (yield Msg('close_run'))
+    return (yield Msg('close_run', exit_status=exit_status, reason=reason))
 
 
 def wait_for(futures, **kwargs):

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -897,6 +897,7 @@ class RunEngine:
         self._task.cancel()
         for task in self._status_tasks:
             task.cancel()
+        self._exit_status = 'abort'
         if self.state == 'paused':
             self._resume_event_loop()
         return self._run_start_uids
@@ -936,6 +937,7 @@ class RunEngine:
               "'abort'...")
         self._interrupted = True
         self._exception = PlanHalt()
+        self._exit_status = 'abort'
         self._task.cancel()
         if self.state == 'paused':
             self._resume_event_loop()

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1284,7 +1284,10 @@ class RunEngine:
 
         Expected message object is:
 
-            Msg('close_run')
+            Msg('close_run', None, exit_status=None, reason=None)
+
+        if *exit_stats* and *reason* are not provided, use the values
+        stashed on the RE.
         """
         if not self._run_is_open:
             raise IllegalMessageSequence("A 'close_run' message was received "
@@ -1304,10 +1307,16 @@ class RunEngine:
                 # rare but possible via Msg('create')
                 continue
             num_events[bundle_name] = next(counter) - 1
+        reason = msg.kwargs.get('reason', None)
+        if reason is None:
+            reason = self._reason
+        exit_status = msg.kwargs.get('exit_status', None)
+        if exit_status is None:
+            exit_status = self._exit_status
         doc = dict(run_start=self._run_start_uid,
                    time=ttime.time(), uid=new_uid(),
-                   exit_status=self._exit_status,
-                   reason=self._reason,
+                   exit_status=exit_status,
+                   reason=reason,
                    num_events=num_events)
         self._clear_run_cache()
         yield from self.emit(DocumentNames.stop, doc)

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -899,6 +899,7 @@ class RunEngine:
             task.cancel()
         if self.state == 'paused':
             self._resume_event_loop()
+        return self._run_start_uids
 
     def stop(self):
         """
@@ -918,6 +919,7 @@ class RunEngine:
         self._task.cancel()
         if self.state == 'paused':
             self._resume_event_loop()
+        return self._run_start_uids
 
     def halt(self):
         '''
@@ -937,6 +939,7 @@ class RunEngine:
         self._task.cancel()
         if self.state == 'paused':
             self._resume_event_loop()
+        return self._run_start_uids
 
     def _stop_movable_objects(self, *, success=True):
         "Call obj.stop() for all objects we have moved. Log any exceptions."

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -94,7 +94,7 @@ def cb(name, doc):
      (unsubscribe, (1,), {}, [Msg('unsubscribe', None, token=1)]),
      (open_run, (), {}, [Msg('open_run')]),
      (open_run, (), {'md': {'a': 1}}, [Msg('open_run', a=1)]),
-     (close_run, (), {}, [Msg('close_run')]),
+     (close_run, (), {}, [Msg('close_run', reason=None, exit_status=None)]),
      (wait_for, (['fut1', 'fut2'],), {}, [Msg('wait_for', None, ['fut1', 'fut2'])]),
     ])
 def test_stub_plans(plan, plan_args, plan_kwargs, msgs):

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1337,11 +1337,11 @@ def test_exceptions_exit_status(fresh_RE):
         yield Msg('null')
         raise Snowflake('boo')
 
-    with pytest.raises(Snowflake):
+    with pytest.raises(Snowflake) as sf:
         RE(bad_plan())
 
     assert len(d.start) == 1
     rs = d.start[0]['uid']
     assert len(d.stop) == 1
     assert d.stop[rs]['exit_status'] == 'fail'
-    assert len(d.stop[rs]['reason']) > 0
+    assert d.stop[rs]['reason'] == str(sf.value)

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -17,7 +17,7 @@ from functools import partial
 from bluesky.examples import (det, Mover, TrivialFlyer, SynGauss, SimpleStatus,
                               ReaderWithRegistry)
 import bluesky.plans as bp
-from bluesky.tests.utils import MsgCollector
+from bluesky.tests.utils import MsgCollector, DocCollector
 
 
 def test_states():
@@ -1298,3 +1298,27 @@ def test_num_events(fresh_RE, db):
 def test_raise_if_interrupted_deprecation(fresh_RE):
     with pytest.warns(UserWarning):
         fresh_RE([], raise_if_interrupted=True)
+
+
+@pytest.mark.parametrize('bail_func,status', (('resume', 'success'),
+                                              ('stop', 'success'),
+                                              ('abort', 'abort'),
+                                              ('halt', 'abort')))
+def test_force_stop_exit_status(bail_func, status, fresh_RE):
+    RE = fresh_RE
+    d = DocCollector()
+    RE.subscribe(d.insert)
+
+    @bp.run_decorator()
+    def bad_plan():
+        yield Msg('pause')
+    try:
+        RE(bad_plan())
+    except:
+        ...
+    rs, = getattr(RE, bail_func)()
+
+    assert len(d.start) == 1
+    assert d.start[0]['uid'] == rs
+    assert len(d.stop) == 1
+    assert d.stop[rs]['exit_status'] == status

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -17,7 +17,6 @@ from cycler import cycler
 import logging
 import datetime
 from functools import wraps, partial
-import sys
 import threading
 import time
 from tqdm import tqdm

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -36,15 +36,15 @@ class Msg(namedtuple('Msg_base', ['command', 'obj', 'args', 'kwargs'])):
             self.command, self.obj, self.args, self.kwargs)
 
 
-class RunEngineControlExceptions(Exception):
+class RunEngineControlException(Exception):
     pass
 
 
-class RequestAbort(RunEngineControlExceptions):
+class RequestAbort(RunEngineControlException):
     pass
 
 
-class RequestStop(RunEngineControlExceptions):
+class RequestStop(RunEngineControlException):
     pass
 
 

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -36,19 +36,23 @@ class Msg(namedtuple('Msg_base', ['command', 'obj', 'args', 'kwargs'])):
             self.command, self.obj, self.args, self.kwargs)
 
 
-class NoReplayAllowed(Exception):
+class RunEngineControlExceptions(Exception):
     pass
 
 
-class RequestAbort(Exception):
+class RequestAbort(RunEngineControlExceptions):
     pass
 
 
-class RequestStop(Exception):
+class RequestStop(RunEngineControlExceptions):
     pass
 
 
 class RunEngineInterrupted(Exception):
+    pass
+
+
+class NoReplayAllowed(Exception):
     pass
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`run_wrapper` and friends ensure that the plan always yields a run_stop which means the fall through in the RunEngine which sets the exit_status before hitting the run_close of lost resort.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fixs #847 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

added a test

<!--
## Screenshots (if appropriate):
-->
