### PR TITLE
Fix validate uniform eventstream

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1525,7 +1525,7 @@ class RunEngine:
         desc_key = self._bundle_name
         d_objs, doc = self._descriptors.get(desc_key, (None, None))
         if d_objs is not None and d_objs != objs_read:
-            raise RuntimeError("Miss matched objects read, expected {!s}, "
+            raise RuntimeError("Mismatched objects read, expected {!s}, "
                                "got {!s}".format(d_objs, objs_read))
         if doc is None:
             # We don't not have an Event Descriptor for this set.
@@ -1703,8 +1703,9 @@ class RunEngine:
         local_descriptors = {}  # hashed on obj_read, not (name, objs_read)
         for stream_name, data_keys in named_data_keys.items():
             desc_key = stream_name
+            d_objs = frozenset(data_keys)
             if desc_key not in self._descriptors:
-                objs_read = frozenset(data_keys)
+                objs_read = d_objs
                 # We don't not have an Event Descriptor for this set.
                 descriptor_uid = new_uid()
                 object_keys = {obj.name: list(data_keys)}
@@ -1723,11 +1724,10 @@ class RunEngine:
                 self._sequence_counters[desc_key] = count(1)
             else:
                 objs_read, doc = self._descriptors[desc_key]
-                d_objs = frozenset(data_keys)
-                if d_objs != objs_read:
-                    raise RuntimeError("Miss matched objects read, "
-                                       "expected {!s}, "
-                                       "got {!s}".format(d_objs, objs_read))
+            if d_objs != objs_read:
+                raise RuntimeError("Mismatched objects read, "
+                                   "expected {!s}, "
+                                   "got {!s}".format(d_objs, objs_read))
 
             descriptor_uid = doc['uid']
             local_descriptors[objs_read] = (stream_name, descriptor_uid)

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -243,9 +243,9 @@ class RunEngine:
         self._config_desc_cache = dict()  # " obj.describe_configuration()
         self._config_values_cache = dict()  # " obj.read_configuration() values
         self._config_ts_cache = dict()  # " obj.read_configuration() timestamps
-        self._descriptors = dict()  # cache of {(name, objs_frozen_set): doc}
+        self._descriptors = dict()  # cache of {name: (objs_frozen_set, doc)}
         self._monitor_params = dict()  # cache of {obj: (cb, kwargs)}
-        self._sequence_counters = dict()  # a seq_num counter per Descriptor
+        self._sequence_counters = dict()  # a seq_num counter per stream
         self._teed_sequence_counters = dict()  # for if we redo data-points
         self._suspenders = set()  # set holding suspenders
         self._groups = defaultdict(set)  # sets of Events to wait for

--- a/bluesky/tests/test_devices.py
+++ b/bluesky/tests/test_devices.py
@@ -115,29 +115,54 @@ def test_monitor_with_pause_resume(fresh_RE):
 def test_overlapping_read(fresh_RE):
 
     dcm = DCM('', name='dcm')
-    dcm2 = DCM('', name='dcm')
+    dcm2 = DCM('', name='dcm2')
 
     def collect(name, doc):
         docs[name].append(doc)
 
+    with pytest.raises(RuntimeError):
+        fresh_RE(([Msg('open_run')] +
+                  list(trigger_and_read([dcm.th])) +
+                  list(trigger_and_read([dcm])) +
+                  [Msg('close_run')]))
+
+    with pytest.raises(RuntimeError):
+        fresh_RE(([Msg('open_run')] +
+                  list(trigger_and_read([dcm])) +
+                  list(trigger_and_read([dcm.th])) +
+                  [Msg('close_run')]))
+
+    with pytest.raises(RuntimeError):
+        fresh_RE(([Msg('open_run')] +
+                  list(trigger_and_read([dcm])) +
+                  list(trigger_and_read([dcm2])) +
+                  [Msg('close_run')]))
+
     docs = defaultdict(list)
     fresh_RE(([Msg('open_run')] +
               list(trigger_and_read([dcm.th])) +
-              list(trigger_and_read([dcm])) +
+              list(trigger_and_read([dcm], name='other')) +
               [Msg('close_run')]), collect)
     assert len(docs['descriptor']) == 2
 
     docs = defaultdict(list)
     fresh_RE(([Msg('open_run')] +
               list(trigger_and_read([dcm])) +
-              list(trigger_and_read([dcm.th])) +
+              list(trigger_and_read([dcm], name='other')) +
               [Msg('close_run')]), collect)
     assert len(docs['descriptor']) == 2
 
     docs = defaultdict(list)
     fresh_RE(([Msg('open_run')] +
               list(trigger_and_read([dcm])) +
-              list(trigger_and_read([dcm2])) +
+              list(trigger_and_read([dcm.th], name='other')) +
+              [Msg('close_run')]), collect)
+    assert len(docs['descriptor']) == 2
+
+    docs = defaultdict(list)
+    fresh_RE(([Msg('open_run')] +
+              list(trigger_and_read([dcm])) +
+              list(trigger_and_read([dcm2], name='other')) +
               [Msg('close_run')]), collect)
     assert len(docs['descriptor']) == 2
 

--- a/bluesky/tests/test_devices.py
+++ b/bluesky/tests/test_devices.py
@@ -37,8 +37,8 @@ def test_ancestry():
 
 @requires_ophyd
 def test_share_ancestor():
-    b1 = B('')
-    b2 = B('')
+    b1 = B('', name='b1')
+    b2 = B('', name='b2')
     assert share_ancestor(b1, b1)
     assert share_ancestor(b1, b1.a1)
     assert share_ancestor(b1, b1.a1.s1)
@@ -66,7 +66,7 @@ def test_monitor(fresh_RE):
     def collect(name, doc):
         docs.append(doc)
 
-    a = A('')
+    a = A('', name='a')
 
     def plan():
         yield Msg('open_run')
@@ -84,7 +84,7 @@ def test_monitor_with_pause_resume(fresh_RE):
     def collect(name, doc):
         docs.append(doc)
 
-    a = A('')
+    a = A('', name='a')
 
     def plan():
         yield Msg('open_run')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

We have always said that an event stream is homogeneous in terms of data keys.  We had been enforcing that this was true per descriptor, but not per stream name. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This was noted during review of #853

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Had to update a few tests that were verifying the behavior on a per-descriptor level.

Fixed some tests that are broken by ophyd changes to Device.

<!--
## Screenshots (if appropriate):
-->
