### PR TITLE
ENH: Merge PseudoPositioner children in plans automatically 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,13 +1,10 @@
 [run]
-source = 
+source =
     bluesky
 [report]
 omit =
     */python?.?/*
     */site-packages/nose/*
-    *test*
-    */tests/*
-    */testing/*
     # ignore _version.py and versioneer.py
     .*version.*
     *_version.py

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -21,7 +21,7 @@ from .utils import (Struct, Subs, normalize_subs_input, root_ancestor,
                     separate_devices, apply_sub_factories, update_sub_lists,
                     all_safe_rewind, Msg, ensure_generator, single_gen,
                     short_uid as _short_uid, RampFail, make_decorator,
-                    RunEngineControlException)
+                    RunEngineControlException, merge_cycler)
 
 
 def planify(func):
@@ -2913,6 +2913,7 @@ def scan_nd(detectors, cycler, *, per_step=None, md=None):
     if per_step is None:
         per_step = one_nd_step
     pos_cache = defaultdict(lambda: None)  # where last position is stashed
+    cycler = merge_cycler(cycler)
     motors = list(cycler.keys)
 
     @stage_decorator(list(detectors) + motors)

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1168,10 +1168,10 @@ def finalize_wrapper(plan, final_plan, *, pause_for_debug=False):
 
 
 def contingency_wrapper(plan, *,
-                 except_plan=None,
-                 else_plan=None,
-                 final_plan=None,
-                 pause_for_debug=False):
+                        except_plan=None,
+                        else_plan=None,
+                        final_plan=None,
+                        pause_for_debug=False):
     '''try...except...else...finally helper
 
     Run the first plan and then the second.  If any of the messages
@@ -1500,6 +1500,7 @@ def stub_wrapper(plan):
         Metadata discovered from `open_run` Msg
     """
     md = {}
+
     def _block_run_control(msg):
         """
         Block open and close run messages
@@ -1514,6 +1515,7 @@ def stub_wrapper(plan):
 
     yield from msg_mutator(plan, _block_run_control)
     return md
+
 
 def monitor_during_wrapper(plan, signals):
     """
@@ -2019,7 +2021,6 @@ def trigger_and_read(devices, name='primary'):
         yield from save()
         return ret
 
-
     return (yield from rewindable_wrapper(inner_trigger_and_read(),
                                           rewindable))
 
@@ -2162,7 +2163,7 @@ def count(detectors, num=1, delay=None, *, md=None):
            'plan_args': {'detectors': list(map(repr, detectors)), 'num': num},
            'plan_name': 'count',
            'hints': {}
-          }
+           }
     _md.update(md or {})
     _md['hints'].setdefault('dimensions', [(('time',), 'primary')])
 
@@ -2185,7 +2186,7 @@ def count(detectors, num=1, delay=None, *, md=None):
     @run_decorator(md=_md)
     def finite_plan():
         for i in range(num):
-            now = time.time() # Intercept the flow in its earliest moment.
+            now = time.time()  # Intercept the flow in its earliest moment.
             yield Msg('checkpoint')
             yield from trigger_and_read(detectors)
             try:
@@ -2265,14 +2266,14 @@ def list_scan(detectors, motor, steps, *, per_step=None, md=None):
            'num_points': len(steps),
            'num_intervals': len(steps) - 1,
            'plan_args': {'detectors': list(map(repr, detectors)),
-                           'motor': repr(motor), 'steps': steps,
-                           'per_step': repr(per_step)},
+                         'motor': repr(motor), 'steps': steps,
+                         'per_step': repr(per_step)},
            'plan_name': 'list_scan',
            'plan_pattern': 'array',
            'plan_pattern_module': 'numpy',
            'plan_pattern_args': dict(object=steps),
            'hints': {},
-          }
+           }
     _md.update(md or {})
     try:
         dimensions = [(motor.hints['fields'], 'primary')]
@@ -2365,7 +2366,7 @@ def scan(detectors, motor, start, stop, num, *, per_step=None, md=None):
            'plan_pattern_module': 'numpy',
            'plan_pattern_args': dict(start=start, stop=stop, num=num),
            'hints': {},
-          }
+           }
     _md.update(md or {})
     try:
         dimensions = [(motor.hints['fields'], 'primary')]
@@ -2466,7 +2467,7 @@ def log_scan(detectors, motor, start, stop, num, *, per_step=None, md=None):
            'plan_pattern_module': 'numpy',
            'plan_pattern_args': dict(start=start, stop=stop, num=num),
            'hints': {},
-          }
+           }
     _md.update(md or {})
 
     try:
@@ -2582,7 +2583,7 @@ def adaptive_scan(detectors, target_field, motor, start, stop,
                          'threshold': threshold},
            'plan_name': 'adaptive_scan',
            'hints': {},
-          }
+           }
     _md.update(md or {})
     try:
         dimensions = [(motor.hints['fields'], 'primary')]
@@ -2894,7 +2895,7 @@ def scan_nd(detectors, cycler, *, per_step=None, md=None):
                          'per_step': repr(per_step)},
            'plan_name': 'scan_nd',
            'hints': {},
-          }
+           }
     _md.update(md or {})
     try:
         dimensions = [(motor.hints['fields'], 'primary')
@@ -3033,7 +3034,7 @@ def outer_product_scan(detectors, *args, per_step=None, md=None):
            'plan_pattern_module': plan_patterns.__name__,
            'motors': tuple(motor_names),
            'hints': {},
-          }
+           }
     _md.update(md or {})
     _md['hints'].setdefault('gridding', 'rectilinear')
     try:
@@ -3153,7 +3154,7 @@ def tweak(detector, target_field, motor, step, *, md=None):
                          'step': step},
            'plan_name': 'tweak',
            'hints': {},
-          }
+           }
     try:
         dimensions = [(motor.hints['fields'], 'primary')]
     except (AttributeError, KeyError):
@@ -3265,7 +3266,7 @@ def spiral_fermat(detectors, x_motor, y_motor, x_start, y_start, x_range,
            'plan_pattern_module': plan_patterns.__name__,
            'plan_pattern_args': pattern_args,
            'hints': {},
-          }
+           }
     try:
         dimensions = [(x_motor.hints['fields'], 'primary'),
                       (y_motor.hints['fields'], 'primary')]
@@ -3380,7 +3381,7 @@ def spiral(detectors, x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
            'plan_pattern_args': pattern_args,
            'plan_pattern_module': plan_patterns.__name__,
            'hints': {},
-          }
+           }
     try:
         dimensions = [(x_motor.hints['fields'], 'primary'),
                       (y_motor.hints['fields'], 'primary')]

--- a/bluesky/tests/conftest.py
+++ b/bluesky/tests/conftest.py
@@ -2,6 +2,12 @@ import asyncio
 from bluesky.run_engine import RunEngine
 from bluesky.examples import Mover, SynGauss
 import pytest
+from types import SimpleNamespace
+from ophyd.pseudopos import (PseudoPositioner, PseudoSingle,
+                             real_position_argument, pseudo_position_argument)
+from ophyd.positioner import SoftPositioner
+from ophyd.signal import Signal
+from ophyd import (Component as C)
 
 
 @pytest.fixture(scope='function')
@@ -40,3 +46,56 @@ def db(request):
     from databroker.tests.utils import build_sqlite_backed_broker
     db = build_sqlite_backed_broker(request)
     return db
+
+
+@pytest.fixture()
+def hw():
+    class SPseudo3x3(PseudoPositioner):
+        pseudo1 = C(PseudoSingle, limits=(-10, 10), egu='a')
+        pseudo2 = C(PseudoSingle, limits=(-10, 10), egu='b')
+        pseudo3 = C(PseudoSingle, limits=None, egu='c')
+        real1 = C(SoftPositioner, init_pos=0)
+        real2 = C(SoftPositioner, init_pos=0)
+        real3 = C(SoftPositioner, init_pos=0)
+
+        sig = C(Signal, value=0)
+
+        @pseudo_position_argument
+        def forward(self, pseudo_pos):
+            pseudo_pos = self.PseudoPosition(*pseudo_pos)
+            # logger.debug('forward %s', pseudo_pos)
+            return self.RealPosition(real1=-pseudo_pos.pseudo1,
+                                     real2=-pseudo_pos.pseudo2,
+                                     real3=-pseudo_pos.pseudo3)
+
+        @real_position_argument
+        def inverse(self, real_pos):
+            real_pos = self.RealPosition(*real_pos)
+            # logger.debug('inverse %s', real_pos)
+            return self.PseudoPosition(pseudo1=-real_pos.real1,
+                                       pseudo2=-real_pos.real2,
+                                       pseudo3=-real_pos.real3)
+
+    class SPseudo1x3(PseudoPositioner):
+        pseudo1 = C(PseudoSingle, limits=(-10, 10))
+        real1 = C(SoftPositioner, init_pos=0)
+        real2 = C(SoftPositioner, init_pos=0)
+        real3 = C(SoftPositioner, init_pos=0)
+
+        @pseudo_position_argument
+        def forward(self, pseudo_pos):
+            pseudo_pos = self.PseudoPosition(*pseudo_pos)
+            # logger.debug('forward %s', pseudo_pos)
+            return self.RealPosition(real1=-pseudo_pos.pseudo1,
+                                     real2=-pseudo_pos.pseudo1,
+                                     real3=-pseudo_pos.pseudo1)
+
+        @real_position_argument
+        def inverse(self, real_pos):
+            real_pos = self.RealPosition(*real_pos)
+            # logger.debug('inverse %s', real_pos)
+            return self.PseudoPosition(pseudo1=-real_pos.real1)
+
+    return SimpleNamespace(pseudo3x3=SPseudo3x3(name='pseudo3x3'),
+                           pseudo1x3=SPseudo1x3(name='pseudo1x3'),
+                           sig=Signal(name='sig', value=0))

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -29,6 +29,7 @@ class DummyMover:
     def __init__(self, name):
         self._value = 0
         self.name = name
+        self.parent = None
 
     def describe(self):
         return {self.name: {}}

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -107,6 +107,7 @@ def test_mesh_pseudo(hw, fresh_RE):
 
 def test_rmesh_pseudo(hw, fresh_RE):
     p3x3 = hw.pseudo3x3
+    p3x3.set(1, -2, 100)
     sig = hw.sig
     RE = fresh_RE
     d = DocCollector()
@@ -126,4 +127,6 @@ def test_rmesh_pseudo(hw, fresh_RE):
         assert k in df
 
     assert all(df[sig.name] == 0)
-    assert all(df[p3x3.pseudo3.name] == 0)
+    assert all(df[p3x3.pseudo3.name] == 100)
+    assert len(df) == 35
+    assert min(df[p3x3.pseudo1.name]) == 1

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -103,3 +103,27 @@ def test_mesh_pseudo(hw, fresh_RE):
 
     assert all(df[sig.name] == 0)
     assert all(df[p3x3.pseudo3.name] == 0)
+
+
+def test_rmesh_pseudo(hw, fresh_RE):
+    p3x3 = hw.pseudo3x3
+    sig = hw.sig
+    RE = fresh_RE
+    d = DocCollector()
+
+    RE.subscribe(d.insert)
+    rs, = RE(bp.relative_outer_product_scan(
+        [sig],
+        p3x3.pseudo1, 0, 3, 5,
+        p3x3.pseudo2, 7, 10, 7, False))
+    df = pd.DataFrame([_['data']
+                       for _ in d.event[d.descriptor[rs][0]['uid']]])
+
+    for k in p3x3.describe():
+        assert k in df
+
+    for k in sig.describe():
+        assert k in df
+
+    assert all(df[sig.name] == 0)
+    assert all(df[p3x3.pseudo3.name] == 0)

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -3,6 +3,7 @@ import pytest
 from bluesky.tests.utils import DocCollector
 import bluesky.plans as bp
 from bluesky.examples import motor, motor1, motor2, det
+import pandas as pd
 
 
 def _validate_start(start, expected_values):
@@ -64,6 +65,7 @@ def test_plan_header(fresh_RE, plan, target):
         _validate_start(s, target)
 
 
+
 def test_ops_dimension_hints(fresh_RE):
     RE = fresh_RE
     c = DocCollector()
@@ -78,3 +80,26 @@ def test_ops_dimension_hints(fresh_RE):
 
     assert st['hints']['dimensions'] == [
         (m.hints['fields'], 'primary') for m in (motor, motor1)]
+
+
+def test_mesh_pseudo(hw, fresh_RE):
+    p3x3 = hw.pseudo3x3
+    sig = hw.sig
+    RE = fresh_RE
+    d = DocCollector()
+
+    RE.subscribe(d.insert)
+    rs, = RE(bp.outer_product_scan([sig],
+                                   p3x3.pseudo1, 0, 3, 5,
+                                   p3x3.pseudo2, 7, 10, 7, False))
+    df = pd.DataFrame([_['data']
+                       for _ in d.event[d.descriptor[rs][0]['uid']]])
+
+    for k in p3x3.describe():
+        assert k in df
+
+    for k in sig.describe():
+        assert k in df
+
+    assert all(df[sig.name] == 0)
+    assert all(df[p3x3.pseudo3.name] == 0)

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -108,6 +108,7 @@ def test_mesh_pseudo(hw, fresh_RE):
 def test_rmesh_pseudo(hw, fresh_RE):
     p3x3 = hw.pseudo3x3
     p3x3.set(1, -2, 100)
+    init_pos = p3x3.position
     sig = hw.sig
     RE = fresh_RE
     d = DocCollector()
@@ -130,3 +131,4 @@ def test_rmesh_pseudo(hw, fresh_RE):
     assert all(df[p3x3.pseudo3.name] == 100)
     assert len(df) == 35
     assert min(df[p3x3.pseudo1.name]) == 1
+    assert init_pos == p3x3.position

--- a/bluesky/tests/test_utils.py
+++ b/bluesky/tests/test_utils.py
@@ -114,6 +114,34 @@ def test_cycler_merge_pseudo_real_clash(hw, children):
 
 
 @pytest.mark.parametrize('children',
+                         (['pseudo1', ],
+                          ['pseudo1', 'pseudo2'],
+                          ['real1'],
+                          ['real1', 'real2']))
+def test_cycler_parent_and_parts_fail(hw, children):
+    p3x3 = hw.pseudo3x3
+    cyc = reduce(operator.add, (cycler(getattr(p3x3, k), range(5))
+                                for k in children))
+    cyc += cycler(p3x3, range(5))
+
+    with pytest.raises(ValueError):
+        merge_cycler(cyc)
+
+
+@pytest.mark.parametrize('children',
+                         (['sig', ],))
+def test_cycler_parent_and_parts_succed(hw, children):
+    p3x3 = hw.pseudo3x3
+    cyc = reduce(operator.add, (cycler(getattr(p3x3, k), range(5))
+                                for k in children))
+    cyc += cycler(p3x3, range(5))
+    mcyc = merge_cycler(cyc)
+
+    assert mcyc.keys == cyc.keys
+    assert mcyc.by_key() == cyc.by_key()
+
+
+@pytest.mark.parametrize('children',
                          (
                              ['pseudo1'],
                              ['pseudo2', 'sig'],

--- a/bluesky/tests/test_utils.py
+++ b/bluesky/tests/test_utils.py
@@ -1,4 +1,12 @@
-from bluesky.utils import ensure_generator, Msg
+import pytest
+from types import SimpleNamespace
+
+from bluesky.utils import ensure_generator, Msg, merge_cycler
+from cycler import cycler
+from ophyd.pseudopos import (PseudoPositioner, PseudoSingle,
+                             real_position_argument, pseudo_position_argument)
+from ophyd.positioner import SoftPositioner
+from ophyd import (Component as C)
 
 
 def test_single_msg_to_gen():
@@ -8,3 +16,69 @@ def test_single_msg_to_gen():
 
     assert len(m_list) == 1
     assert m_list[0] == m
+
+
+@pytest.fixture()
+def hw():
+    class SPseudo3x3(PseudoPositioner):
+        pseudo1 = C(PseudoSingle, limits=(-10, 10), egu='a')
+        pseudo2 = C(PseudoSingle, limits=(-10, 10), egu='b')
+        pseudo3 = C(PseudoSingle, limits=None, egu='c')
+        real1 = C(SoftPositioner, init_pos=0)
+        real2 = C(SoftPositioner, init_pos=0)
+        real3 = C(SoftPositioner, init_pos=0)
+
+        @pseudo_position_argument
+        def forward(self, pseudo_pos):
+            pseudo_pos = self.PseudoPosition(*pseudo_pos)
+            # logger.debug('forward %s', pseudo_pos)
+            return self.RealPosition(real1=-pseudo_pos.pseudo1,
+                                     real2=-pseudo_pos.pseudo2,
+                                     real3=-pseudo_pos.pseudo3)
+
+        @real_position_argument
+        def inverse(self, real_pos):
+            real_pos = self.RealPosition(*real_pos)
+            # logger.debug('inverse %s', real_pos)
+            return self.PseudoPosition(pseudo1=-real_pos.real1,
+                                       pseudo2=-real_pos.real2,
+                                       pseudo3=-real_pos.real3)
+
+    class SPseudo1x3(PseudoPositioner):
+        pseudo1 = C(PseudoSingle, limits=(-10, 10))
+        real1 = C(SoftPositioner, init_pos=0)
+        real2 = C(SoftPositioner, init_pos=0)
+        real3 = C(SoftPositioner, init_pos=0)
+
+        @pseudo_position_argument
+        def forward(self, pseudo_pos):
+            pseudo_pos = self.PseudoPosition(*pseudo_pos)
+            # logger.debug('forward %s', pseudo_pos)
+            return self.RealPosition(real1=-pseudo_pos.pseudo1,
+                                     real2=-pseudo_pos.pseudo1,
+                                     real3=-pseudo_pos.pseudo1)
+
+        @real_position_argument
+        def inverse(self, real_pos):
+            real_pos = self.RealPosition(*real_pos)
+            # logger.debug('inverse %s', real_pos)
+            return self.PseudoPosition(pseudo1=-real_pos.real1)
+
+    return SimpleNamespace(pseudo3x3=SPseudo3x3(name='pseudo3x3'),
+                           pseudo1x3=SPseudo1x3(name='pseudo1x3'))
+
+
+def test_cycler_merge_2pseudo(hw):
+    p3x3 = hw.pseudo3x3
+    # put the real positions at 1, 2, 3
+    p3x3.set(-1, -2, -3)
+    r1_vec = [10, 11, 12]
+    r2_vec = [20, 21, 22]
+    cyc = cycler(p3x3.real1, r1_vec) + cycler(p3x3.real2, r2_vec)
+
+    mcyc = merge_cycler(cyc)
+    expected_merge = [{'real1': r1, 'real2': r2}
+                      for r1, r2 in zip(r1_vec, r2_vec)]
+    assert len(mcyc.keys) == 1
+    assert mcyc.keys == {p3x3}
+    assert mcyc.by_key()[p3x3] == expected_merge

--- a/bluesky/tests/test_utils.py
+++ b/bluesky/tests/test_utils.py
@@ -1,11 +1,14 @@
 import pytest
 from types import SimpleNamespace
+from functools import reduce
+import operator
 
 from bluesky.utils import ensure_generator, Msg, merge_cycler
 from cycler import cycler
 from ophyd.pseudopos import (PseudoPositioner, PseudoSingle,
                              real_position_argument, pseudo_position_argument)
 from ophyd.positioner import SoftPositioner
+from ophyd.signal import Signal
 from ophyd import (Component as C)
 
 
@@ -27,6 +30,8 @@ def hw():
         real1 = C(SoftPositioner, init_pos=0)
         real2 = C(SoftPositioner, init_pos=0)
         real3 = C(SoftPositioner, init_pos=0)
+
+        sig = C(Signal, value=0)
 
         @pseudo_position_argument
         def forward(self, pseudo_pos):
@@ -65,20 +70,63 @@ def hw():
             return self.PseudoPosition(pseudo1=-real_pos.real1)
 
     return SimpleNamespace(pseudo3x3=SPseudo3x3(name='pseudo3x3'),
-                           pseudo1x3=SPseudo1x3(name='pseudo1x3'))
+                           pseudo1x3=SPseudo1x3(name='pseudo1x3'),
+                           sig=Signal(name='sig', value=0))
 
 
-def test_cycler_merge_2pseudo(hw):
+@pytest.mark.parametrize('traj',
+                         ({'pseudo1': [10, 11, 12],
+                           'pseudo2': [20, 21, 22]},
+                          {'pseudo1': [10, 11, 12],
+                           'pseudo2': [20, 21, 22],
+                           'pseudo3': [30, 31, 32]},
+                          )
+                         )
+def test_cycler_merge_pseudo(hw, traj):
     p3x3 = hw.pseudo3x3
-    # put the real positions at 1, 2, 3
-    p3x3.set(-1, -2, -3)
-    r1_vec = [10, 11, 12]
-    r2_vec = [20, 21, 22]
-    cyc = cycler(p3x3.real1, r1_vec) + cycler(p3x3.real2, r2_vec)
+    sig = hw.sig
+    keys = traj.keys()
+    tlen = len(next(iter(traj.values())))
+    expected_merge = [{k: traj[k][j] for k in keys}
+                      for j in range(tlen)]
+
+    cyc = reduce(operator.add, (cycler(getattr(p3x3, k), v)
+                                for k, v in traj.items()))
+
+    mcyc = merge_cycler(cyc + cycler(sig, range(tlen)))
+
+    assert mcyc.keys == {p3x3, sig}
+    assert mcyc.by_key()[p3x3] == expected_merge
+    assert mcyc.by_key()[sig] == list(range(tlen))
+
+
+@pytest.mark.parametrize('children',
+                         (
+                             ['pseudo1', 'real1'],
+                             ['pseudo1', 'pseudo2', 'real1']))
+def test_cycler_merge_pseudo_real_clash(hw, children):
+    p3x3 = hw.pseudo3x3
+    cyc = reduce(operator.add, (cycler(getattr(p3x3, k), range(5))
+                                for k in children))
+
+    with pytest.raises(ValueError):
+        merge_cycler(cyc)
+
+
+@pytest.mark.parametrize('children',
+                         (
+                             ['pseudo1'],
+                             ['pseudo2', 'sig'],
+                             ['real1'],
+                             ['real1', 'real2'],
+                             ['real1', 'real2', 'sig'],
+                         ))
+def test_cycler_merge_mixed(hw, children):
+    p3x3 = hw.pseudo3x3
+    cyc = reduce(operator.add, (cycler(getattr(p3x3, k), range(5))
+                                for k in children))
 
     mcyc = merge_cycler(cyc)
-    expected_merge = [{'real1': r1, 'real2': r2}
-                      for r1, r2 in zip(r1_vec, r2_vec)]
-    assert len(mcyc.keys) == 1
-    assert mcyc.keys == {p3x3}
-    assert mcyc.by_key()[p3x3] == expected_merge
+
+    assert mcyc.keys == cyc.keys
+    assert mcyc.by_key() == cyc.by_key()

--- a/bluesky/tests/test_utils.py
+++ b/bluesky/tests/test_utils.py
@@ -1,15 +1,10 @@
 import pytest
-from types import SimpleNamespace
+
 from functools import reduce
 import operator
 
 from bluesky.utils import ensure_generator, Msg, merge_cycler
 from cycler import cycler
-from ophyd.pseudopos import (PseudoPositioner, PseudoSingle,
-                             real_position_argument, pseudo_position_argument)
-from ophyd.positioner import SoftPositioner
-from ophyd.signal import Signal
-from ophyd import (Component as C)
 
 
 def test_single_msg_to_gen():
@@ -19,59 +14,6 @@ def test_single_msg_to_gen():
 
     assert len(m_list) == 1
     assert m_list[0] == m
-
-
-@pytest.fixture()
-def hw():
-    class SPseudo3x3(PseudoPositioner):
-        pseudo1 = C(PseudoSingle, limits=(-10, 10), egu='a')
-        pseudo2 = C(PseudoSingle, limits=(-10, 10), egu='b')
-        pseudo3 = C(PseudoSingle, limits=None, egu='c')
-        real1 = C(SoftPositioner, init_pos=0)
-        real2 = C(SoftPositioner, init_pos=0)
-        real3 = C(SoftPositioner, init_pos=0)
-
-        sig = C(Signal, value=0)
-
-        @pseudo_position_argument
-        def forward(self, pseudo_pos):
-            pseudo_pos = self.PseudoPosition(*pseudo_pos)
-            # logger.debug('forward %s', pseudo_pos)
-            return self.RealPosition(real1=-pseudo_pos.pseudo1,
-                                     real2=-pseudo_pos.pseudo2,
-                                     real3=-pseudo_pos.pseudo3)
-
-        @real_position_argument
-        def inverse(self, real_pos):
-            real_pos = self.RealPosition(*real_pos)
-            # logger.debug('inverse %s', real_pos)
-            return self.PseudoPosition(pseudo1=-real_pos.real1,
-                                       pseudo2=-real_pos.real2,
-                                       pseudo3=-real_pos.real3)
-
-    class SPseudo1x3(PseudoPositioner):
-        pseudo1 = C(PseudoSingle, limits=(-10, 10))
-        real1 = C(SoftPositioner, init_pos=0)
-        real2 = C(SoftPositioner, init_pos=0)
-        real3 = C(SoftPositioner, init_pos=0)
-
-        @pseudo_position_argument
-        def forward(self, pseudo_pos):
-            pseudo_pos = self.PseudoPosition(*pseudo_pos)
-            # logger.debug('forward %s', pseudo_pos)
-            return self.RealPosition(real1=-pseudo_pos.pseudo1,
-                                     real2=-pseudo_pos.pseudo1,
-                                     real3=-pseudo_pos.pseudo1)
-
-        @real_position_argument
-        def inverse(self, real_pos):
-            real_pos = self.RealPosition(*real_pos)
-            # logger.debug('inverse %s', real_pos)
-            return self.PseudoPosition(pseudo1=-real_pos.real1)
-
-    return SimpleNamespace(pseudo3x3=SPseudo3x3(name='pseudo3x3'),
-                           pseudo1x3=SPseudo1x3(name='pseudo1x3'),
-                           sig=Signal(name='sig', value=0))
 
 
 @pytest.mark.parametrize('traj',

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1147,7 +1147,7 @@ def merge_cycler(cyc):
         return cyc
 
     input_data = cyc.by_key()
-    output_data = [input_data[i] for i in io | co]
+    output_data = [cycler(i, input_data[i]) for i in io | co]
 
     for parent, children in gb.items():
         if parent in co:

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1150,10 +1150,6 @@ def merge_cycler(cyc):
     output_data = [cycler(i, input_data[i]) for i in io | co]
 
     for parent, children in gb.items():
-        if parent in co:
-            raise ValueError("A PseudoPostiioner and its children were both "
-                             "passed in.  We do not yet know how to merge "
-                             "these inputs, failing.")
         real_p = set(parent.real_positioners)
         pseudo_p = set(parent.pseudo_positioners)
         type_map = {'real': [], 'pseudo': [], 'unrelated': []}
@@ -1164,6 +1160,12 @@ def merge_cycler(cyc):
                 type_map['pseudo'].append(c)
             else:
                 type_map['unrelated'].append(c)
+
+        if parent in co and (type_map['pseudo'] or type_map['real']):
+            raise ValueError("A PseudoPostiioner and its children were both "
+                             "passed in.  We do not yet know how to merge "
+                             "these inputs, failing.")
+
         if type_map['real'] and type_map['pseudo']:
             raise ValueError("Passed in a mix of real and pseudo axis.  "
                              "Can not cope, failing")

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1135,8 +1135,6 @@ def merge_cycler(cyc):
         """Get the attribute name of this device on its parent Device
         """
         parent = obj.parent
-        if parent is None:
-            raise ValueError("Not a child component")
         return next(iter([nm for nm in parent.component_names
                           if getattr(parent, nm) is obj]))
 

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1167,12 +1167,16 @@ def merge_cycler(cyc):
         if type_map['real'] and type_map['pseudo']:
             raise ValueError("Passed in a mix of real and pseudo axis.  "
                              "Can not cope, failing")
-
-        if type_map['pseudo']:
+        pseudo_axes = type_map['pseudo']
+        if len(pseudo_axes) > 1:
             p_cyc = reduce(operator.add,
                            (cycler(my_name(c), input_data[c])
                             for c in type_map['pseudo']))
             output_data.append(cycler(parent, list(p_cyc)))
+        elif len(pseudo_axes) == 1:
+            c, = pseudo_axes
+            output_data.append(cycler(c, input_data[c]))
+
         for c in type_map['real'] + type_map['unrelated']:
             output_data.append(cycler(c, input_data[c]))
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,7 +10,7 @@ matplotlib
 mongoquery
 networkx
 nose
-ophyd
+git+git://github.com/NSLS-II/ophyd.git@master#egg=ophyd
 pandas
 pims
 pyepics


### PR DESCRIPTION
 - merge_cycler attempts to find PseudoSingle devices (in a duck-type
   way) that are from the same device and merge them into a single
   cycler entry.
 - after we set up the meta-data in scan_nd, merge the cycler!

