### PR TITLE
#875 introduce tune_centroid() plan

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2710,7 +2710,7 @@ def tune_centroid(
     
     Set `snake=True` if your positions are reproducible
     moving from either direction.  This will not necessarily
-    decrease the number of steps required to reach convergence.
+    decrease the number of traversals required to reach convergence.
     Snake motion reduces the total time spent on motion
     to reset the positioner.  For some positioners, such as 
     those with hysteresis, snake scanning may not be appropriate.  

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2746,7 +2746,7 @@ def tune_centroid(
     Example
     -------
     motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
-    det = SynGauss('det', m1, 'm1', center=-1.3, Imax=1e5, sigma=0.05)
+    det = SynGauss('det', motor, 'motor', center=-1.3, Imax=1e5, sigma=0.05)
     RE(tune_centroid([det], "det", motor, -1.5, -0.5, 0.01, 10))
     """
     if step_factor <= 0:

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2694,9 +2694,9 @@ def relative_adaptive_scan(detectors, target_field, motor, start, stop,
 def tune_centroid(
         detectors, signal, motor, 
         start, stop, min_step, 
-        num_points = 10, 
-        step_factor = 2,
-        snake = False,
+        num_points=10, 
+        step_factor=2,
+        snake=False,
         *, md=None):
     """
     plan: tune a motor to the centroid of signal(motor)

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2694,7 +2694,7 @@ def relative_adaptive_scan(detectors, target_field, motor, start, stop,
 def tune_centroid(
         detectors, signal, motor, 
         start, stop, min_step, 
-        num_points=10, 
+        num=10, 
         step_factor=2,
         snake=False,
         *, md=None):
@@ -2735,8 +2735,8 @@ def tune_centroid(
         end of range, note: start < stop
     min_step : float
         smallest step size to use.
-    num_points : int, optional
-        number of points with each step size, default = 10
+    num : int, optional
+        number of steps with each step size, default = 10
     step_factor : float, optional
         used in calculating range when 
         maximum is found, note: step_factor > 0, default = 2
@@ -2755,9 +2755,9 @@ def tune_centroid(
         raise ValueError("min_step must be positive")
     if step_factor <= 0:
         raise ValueError("step_factor must be positive")
-    if (num_points - 1) <= 2*step_factor:
+    if (num - 1) <= 2*step_factor:
         raise ValueError(
-            "Increase num_points and/or decrease step_factor"
+            "Increase num and/or decrease step_factor"
             " or tune_centroid will never converge to a solution"
         )
     try:
@@ -2770,7 +2770,7 @@ def tune_centroid(
                          'motor': repr(motor),
                          'start': start,
                          'stop': stop,
-                         'num_points': num_points,
+                         'num': num,
                          'min_step': min_step,},
            'plan_name': 'tune_centroid',
            'hints': {},
@@ -2788,9 +2788,9 @@ def tune_centroid(
 
     @stage_decorator(list(detectors) + [motor])
     @run_decorator(md=_md)
-    def _tune_core(start, stop, num_points, signal):
+    def _tune_core(start, stop, num, signal):
         next_pos = start
-        step = (stop - start) / (num_points - 1)
+        step = (stop - start) / num
         peak_position = None
         cur_I = None
         cur_det = {}
@@ -2822,7 +2822,7 @@ def tune_centroid(
                 stop = np.clip(peak_position + step_factor*step, low_limit, high_limit)
                 if snake:
                     start, stop = stop, start
-                step = (stop - start) / (num_points - 1)
+                step = (stop - start) / num
                 next_pos = start
 
         # finally, move to peak position
@@ -2830,7 +2830,7 @@ def tune_centroid(
             # improvement: report final peak_position
             yield from mv(motor, peak_position)
 
-    return (yield from _tune_core(start, stop, num_points, signal))
+    return (yield from _tune_core(start, stop, num, signal))
 
 
 def one_nd_step(detectors, step, pos_cache):

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2783,6 +2783,9 @@ def tune_centroid(
     else:
         _md['hints'].setdefault('dimensions', dimensions)
 
+    low_limit = min(start, stop)
+    high_limit = max(start, stop)
+
     @stage_decorator(list(detectors) + [motor])
     @run_decorator(md=_md)
     def _tune_core(start, stop, num_points, signal):
@@ -2817,6 +2820,8 @@ def tune_centroid(
                 # improvement: report current peak_position somehow
                 start = peak_position - step_factor*step
                 stop = peak_position + step_factor*step
+                start = max(min(start, high_limit), low_limit)
+                stop = max(min(stop, high_limit), low_limit)
                 if snake:
                     start, stop = stop, start
                 step = (stop - start) / (num_points - 1)

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2731,8 +2731,6 @@ def tune_centroid(
         end of range, note: start < stop
     min_step : float
         smallest step size to use.
-        note: For EpicsMotors, ``min_step=min(min_step,motor.MRES)``
-        is used.
     num_points : int, optional
         number of points with each step size, default = 10
     step_factor : float, optional
@@ -2756,8 +2754,6 @@ def tune_centroid(
             "Increase num_points and/or decrease step_factor"
             " or tune_centroid will never converge to a solution"
         )
-    if isinstance(motor, EpicsMotor):
-        min_step = max(min_step, epics.caget(motor.prefix+".MRES"))
     _md = {'detectors': [det.name for det in detectors],
            'motors': [motor.name],
            'plan_args': {'detectors': list(map(repr, detectors)),

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2747,6 +2747,8 @@ def tune_centroid(
     det = SynGauss('det', motor, 'motor', center=-1.3, Imax=1e5, sigma=0.05)
     RE(tune_centroid([det], "det", motor, -1.5, -0.5, 0.01, 10))
     """
+    if min_step <= 0:
+        raise ValueError("min_step must be positive")
     if step_factor <= 0:
         raise ValueError("step_factor must be positive")
     if (num_points - 1) <= 2*step_factor:

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2736,7 +2736,7 @@ def tune_centroid(
     min_step : float
         smallest step size to use.
     num : int, optional
-        number of steps with each step size, default = 10
+        number of points with each traversal, default = 10
     step_factor : float, optional
         used in calculating range when 
         maximum is found, note: step_factor > 0, default = 2
@@ -2755,7 +2755,7 @@ def tune_centroid(
         raise ValueError("min_step must be positive")
     if step_factor <= 0:
         raise ValueError("step_factor must be positive")
-    if (num - 1) <= 2*step_factor:
+    if (num - 2) <= 2*step_factor:
         raise ValueError(
             "Increase num and/or decrease step_factor"
             " or tune_centroid will never converge to a solution"
@@ -2790,7 +2790,7 @@ def tune_centroid(
     @run_decorator(md=_md)
     def _tune_core(start, stop, num, signal):
         next_pos = start
-        step = (stop - start) / num
+        step = (stop - start) / (num - 1)
         peak_position = None
         cur_I = None
         cur_det = {}
@@ -2822,7 +2822,7 @@ def tune_centroid(
                 stop = np.clip(peak_position + step_factor*step, low_limit, high_limit)
                 if snake:
                     start, stop = stop, start
-                step = (stop - start) / num
+                step = (stop - start) / (num - 1)
                 next_pos = start
 
         # finally, move to peak position

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2765,7 +2765,7 @@ def tune_centroid(
     except (AttributeError, ValueError):
         motor_name = motor.name
     _md = {'detectors': [det.name for det in detectors],
-           'motors': [motor_name],
+           'motors': [motor.name],
            'plan_args': {'detectors': list(map(repr, detectors)),
                          'motor': repr(motor),
                          'start': start,
@@ -2818,10 +2818,8 @@ def tune_centroid(
                     return
                 peak_position = sum_xI / sum_I  # centroid
                 # improvement: report current peak_position somehow
-                start = peak_position - step_factor*step
-                stop = peak_position + step_factor*step
-                start = max(min(start, high_limit), low_limit)
-                stop = max(min(stop, high_limit), low_limit)
+                start = np.clip(peak_position - step_factor*step, low_limit, high_limit)
+                stop = np.clip(peak_position + step_factor*step, low_limit, high_limit)
                 if snake:
                     start, stop = stop, start
                 step = (stop - start) / (num_points - 1)

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2691,6 +2691,150 @@ def relative_adaptive_scan(detectors, target_field, motor, start, stop,
     return (yield from inner_relative_adaptive_scan())
 
 
+def tune_centroid(
+        detectors, signal, motor, 
+        start, stop, min_step, 
+        num_points = 10, 
+        step_factor = 2,
+        snake = False,
+        *, md=None):
+    """
+    plan: tune a motor to the centroid of signal(motor)
+    
+    Initially, traverse the range from start to stop with
+    the number of points specified.  Repeat with progressively
+    smaller step size until the minimum step size is reached.
+    Rescans will be centered on the signal centroid
+    (for $I(x)$, centroid$= \sum{I}/\sum{x*I}$)
+    with a scan range of 2*step_factor*step of current scan.
+    
+    Set `snake=True` if your positions are reproducible
+    moving from either direction.  This will not necessarily
+    decrease the number of steps required to reach convergence.
+    Snake motion reduces the total time spent on motion
+    to reset the positioner.  For some positioners, such as 
+    those with hysteresis, snake scanning may not be appropriate.  
+    For such positioners, always approach the positions from the 
+    same direction.
+
+    Parameters
+    ----------
+    detectors : Signal
+        list of 'readable' objects
+    signal : string
+        detector field whose output is to maximize
+    motor : object
+        any 'setable' object (motor, temp controller, etc.)
+    start : float
+        start of range
+    stop : float
+        end of range, note: start < stop
+    min_step : float
+        smallest step size to use.
+        note: For EpicsMotors, ``min_step=min(min_step,motor.MRES)``
+        is used.
+    num_points : int, optional
+        number of points with each step size, default = 10
+    step_factor : float, optional
+        used in calculating range when 
+        maximum is found, note: step_factor > 0, default = 2
+    snake : bool, optional
+        if False (default), always scan from start to stop
+    md : dict, optional
+        metadata
+
+    Example
+    -------
+    motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
+    det = SynGauss('det', m1, 'm1', center=-1.3, Imax=1e5, sigma=0.05)
+    RE(tune_centroid([det], "det", motor, -1.5, -0.5, 0.01, 10))
+    """
+    if step_factor <= 0:
+        raise ValueError("step_factor must be positive")
+    if (num_points - 1) <= 2*step_factor:
+        raise ValueError(
+            "Increase num_points and/or decrease step_factor"
+            " or tune_centroid will never converge to a solution"
+        )
+    if isinstance(motor, EpicsMotor):
+        min_step = max(min_step, epics.caget(motor.prefix+".MRES"))
+    _md = {'detectors': [det.name for det in detectors],
+           'motors': [motor.name],
+           'plan_args': {'detectors': list(map(repr, detectors)),
+                         'motor': repr(motor),
+                         'start': start,
+                         'stop': stop,
+                         'num_points': num_points,
+                         'min_step': min_step,},
+           'plan_name': 'tune_centroid',
+           'hints': {},
+          }
+    _md.update(md or {})
+    try:
+        dimensions = [(motor.hints['fields'], 'primary')]
+    except (AttributeError, KeyError):
+        pass
+    else:
+        _md['hints'].setdefault('dimensions', dimensions)
+
+    @bp.stage_decorator(list(detectors) + [motor])
+    @bp.run_decorator(md=_md)
+    def _tune_core(start, stop, num_points, signal):
+        next_pos = start
+        step = (stop - start) / (num_points - 1)
+        peak_position = None
+        cur_I = None
+        cur_det = {}
+        sum_I = 0       # for peak centroid calculation, I(x)
+        sum_xI = 0
+        
+        while abs(step) >= min_step:
+            yield Msg('checkpoint')
+            yield from bp.mv(motor, next_pos)
+            yield Msg('create', None, name='primary')
+            for det in detectors:
+                yield Msg('trigger', det, group='B')
+            yield Msg('wait', None, 'B')
+            for det in separate_devices(detectors + [motor]):
+                cur_det = yield Msg('read', det)
+                if signal in cur_det:
+                    cur_I = cur_det[signal]['value']
+                    sum_I += cur_I
+                    position = motor.read()[motor.name]["value"]
+                    sum_xI += position * cur_I
+
+            yield Msg('save')
+
+            if (stop - start) < abs(stop - start):
+                in_range = start >= next_pos >= stop  # negative motion
+            else:
+                in_range = start <= next_pos <= stop  # positive motion
+            
+            if in_range:
+                next_pos += step
+            else:
+                if sum_I == 0:
+                    return
+                peak_position = sum_xI / sum_I  # centroid
+                # TODO: report current peak_position in metadata
+                RE.md["peak_position"] = str(peak_position)
+                start = peak_position - step_factor*step
+                stop = peak_position + step_factor*step
+                if snake:
+                    start, stop = stop, start
+                step = (stop - start) / (num_points - 1)
+                next_pos = start
+
+        # finally, move to peak position
+        if peak_position is not None:
+            RE.md["peak_position"] = peak_position
+            yield from bp.mv(motor, peak_position)
+
+    yield from _tune_core(start, stop, num_points, signal)
+    print("Peak at ", RE.md["peak_position"])
+    return
+
+
 def one_nd_step(detectors, step, pos_cache):
     """
     Inner loop of an N-dimensional step scan

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2773,8 +2773,8 @@ def tune_centroid(
     else:
         _md['hints'].setdefault('dimensions', dimensions)
 
-    @bp.stage_decorator(list(detectors) + [motor])
-    @bp.run_decorator(md=_md)
+    @stage_decorator(list(detectors) + [motor])
+    @run_decorator(md=_md)
     def _tune_core(start, stop, num_points, signal):
         next_pos = start
         step = (stop - start) / (num_points - 1)
@@ -2786,7 +2786,7 @@ def tune_centroid(
         
         while abs(step) >= min_step:
             yield Msg('checkpoint')
-            yield from bp.mv(motor, next_pos)
+            yield from mv(motor, next_pos)
             yield Msg('create', None, name='primary')
             for det in detectors:
                 yield Msg('trigger', det, group='B')
@@ -2813,7 +2813,7 @@ def tune_centroid(
                     return
                 peak_position = sum_xI / sum_I  # centroid
                 # TODO: report current peak_position in metadata
-                RE.md["peak_position"] = str(peak_position)
+                # RE.md["peak_position"] = str(peak_position)
                 start = peak_position - step_factor*step
                 stop = peak_position + step_factor*step
                 if snake:
@@ -2823,11 +2823,11 @@ def tune_centroid(
 
         # finally, move to peak position
         if peak_position is not None:
-            RE.md["peak_position"] = peak_position
-            yield from bp.mv(motor, peak_position)
+            # RE.md["peak_position"] = peak_position
+            yield from mv(motor, peak_position)
 
     yield from _tune_core(start, stop, num_points, signal)
-    print("Peak at ", RE.md["peak_position"])
+    # print("Peak at ", RE.md["peak_position"])
     return
 
 

--- a/bluesky/tests/test_scans.py
+++ b/bluesky/tests/test_scans.py
@@ -283,7 +283,7 @@ def test_adaptive_dscan():
 
 def test_tune_centroid():
     scan1 = bp.tune_centroid([det], 'det', motor, 0, 5, 0.1, 10, snake=True)
-    scan2 = bp.tune_centroid([det], 'det', motor, 0, 5, 0.01, 10, True)
+    scan2 = bp.tune_centroid([det], 'det', motor, 0, 5, 0.01, 10, snake=True)
     scan3 = bp.tune_centroid([det], 'det', motor, 0, 5, 0.1, 10, snake=False)
     scan4 = bp.tune_centroid([det], 'det', motor, 5, 0, 0.1, 10, snake=False)
 

--- a/bluesky/tests/test_scans.py
+++ b/bluesky/tests/test_scans.py
@@ -281,6 +281,39 @@ def test_adaptive_dscan():
         RE(scan5)
 
 
+def test_tune_centroid():
+    scan1 = bp.tune_centroid([det], 'det', motor, 0, 5, 0.1, 10, snake=True)
+    scan2 = bp.tune_centroid([det], 'det', motor, 0, 5, 0.01, 10, True)
+    scan3 = bp.tune_centroid([det], 'det', motor, 0, 5, 0.1, 10, snake=False)
+    scan4 = bp.tune_centroid([det], 'det', motor, 5, 0, 0.1, 10, snake=False)
+
+    actual_traj = []
+    col = collector('motor', actual_traj)
+    counter1 = CallbackCounter()
+    counter2 = CallbackCounter()
+
+    RE(scan1, {'event': [col, counter1]})
+    RE(scan2, {'event': counter2})
+    #assert counter1.value > counter2.value
+    assert actual_traj[0] == 0
+
+    actual_traj = []
+    col = collector('motor', actual_traj)
+    RE(scan3, {'event': col})
+    monotonic_increasing = np.all(np.diff(actual_traj) > 0)
+    assert not monotonic_increasing
+
+    actual_traj = []
+    col = collector('motor', actual_traj)
+    RE(scan4, {'event': col})
+    monotonic_decreasing = np.all(np.diff(actual_traj) < 0)
+    assert not monotonic_decreasing
+
+    with pytest.raises(ValueError):  # min step < 0
+        scan5 = bp.tune_centroid([det], 'det', motor, 5, 0, -0.1, 10, snake=False)
+        RE(scan5)
+
+
 def test_count(recwarn):
     actual_intensity = []
     col = collector('det', actual_intensity)

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -52,6 +52,7 @@ documentation.
    relative_spiral_fermat
    adaptive_scan
    relative_adaptive_scan
+   tune_centroid
    tweak
    fly
 


### PR DESCRIPTION
tune a motor to the centroid of signal(motor) with progressively smaller range and step size

Move the motor to the final centroid at the end

## Description
adds `tune_centroid()` plan to bluesky.plans

## Motivation and Context
This algorithm has been used at APS (in SPEC macros) for some years.

## How Has This Been Tested?

Unit test contributed.  Also tested in ipython session using:

    motor = Mover('motor', {'motor': lambda x: x}, {'x': 0})
    det = SynGauss('det', motor, 'motor', center=-1.3, Imax=1e5, sigma=0.05)
    RE(tune_centroid([det], "det", motor, -1.5, -0.5, 0.01, 10))

Also tested (not shown here) using EpicsMotor and EpicsSignalRO with an `swait` record configured as a pseudo-detector.

```
In [1]: bluesky.__version__
Out[1]: '0.10.2.post17+g770df4e'

In [6]:     motor = bluesky.examples.Mover('motor', {'motor': lambda x: x}, {'x': 0})
   ...:     det = bluesky.examples.SynGauss('det', motor, 'motor', center=-1.3, Imax=1e5, sigma=0.021)
   ...:     RE(tune_centroid([det], "det", motor, -1.5, -0.5, 0.01, 10))
   ...: 
Transient Scan ID: 502     Time: 2017/10/25 00:47:13
Persistent Unique Scan ID: 'ed3e2b28-c3d7-4cac-97a1-6580141573d3'
New stream: 'primary'
+-----------+------------+------------+------------+
|   seq_num |       time |      motor |        det |
+-----------+------------+------------+------------+
|         1 | 00:47:13.4 |      -1.50 |       0.00 |
|         2 | 00:47:13.4 |      -1.39 |      12.87 |
|         3 | 00:47:13.4 |      -1.28 |   57126.92 |
|         4 | 00:47:13.4 |      -1.17 |       0.00 |
|         5 | 00:47:13.4 |      -1.06 |       0.00 |
|         6 | 00:47:13.4 |      -0.94 |       0.00 |
|         7 | 00:47:13.4 |      -0.83 |       0.00 |
|         8 | 00:47:13.5 |      -0.72 |       0.00 |
|         9 | 00:47:13.5 |      -0.61 |       0.00 |
|        10 | 00:47:13.5 |      -0.50 |       0.00 |
|        11 | 00:47:13.5 |      -1.50 |       0.00 |
|        12 | 00:47:13.5 |      -1.45 |       0.00 |
|        13 | 00:47:13.6 |      -1.40 |       0.89 |
|        14 | 00:47:13.6 |      -1.35 |    4729.94 |
|        15 | 00:47:13.6 |      -1.30 |   99297.17 |
|        16 | 00:47:13.6 |      -1.25 |    8268.87 |
|        17 | 00:47:13.6 |      -1.20 |       2.73 |
|        18 | 00:47:13.6 |      -1.15 |       0.00 |
|        19 | 00:47:13.6 |      -1.10 |       0.00 |
|        20 | 00:47:13.6 |      -1.06 |       0.00 |
|        21 | 00:47:13.6 |      -1.39 |       6.94 |
|        22 | 00:47:13.7 |      -1.37 |     389.51 |
|        23 | 00:47:13.7 |      -1.35 |    7333.19 |
|        24 | 00:47:13.7 |      -1.33 |   46310.78 |
|        25 | 00:47:13.7 |      -1.30 |   98103.95 |
|        26 | 00:47:13.7 |      -1.28 |   69711.79 |
|        27 | 00:47:13.7 |      -1.26 |   16616.57 |
|        28 | 00:47:13.7 |      -1.24 |    1328.59 |
|        29 | 00:47:13.8 |      -1.22 |      35.63 |
|        30 | 00:47:13.8 |      -1.19 |       0.32 |
|        31 | 00:47:13.8 |      -1.17 |       0.00 |
+-----------+------------+------------+------------+
generator tune_centroid ['ed3e2b'] (scan num: 502)



all documents from last plan in variable: plan_documents
exit status: success
# descriptor(s): 1
# event(s): 31
Peak at  -1.29715791695
Out[6]: ('ed3e2b28-c3d7-4cac-97a1-6580141573d3',)

In [7]: motor.read()
Out[7]: {'motor': {'timestamp': 1508910433.830341, 'value': -1.2971579169521377}}
```

## Screenshot:
![tune_centroid](https://user-images.githubusercontent.com/2279984/31982495-b38174ae-b91e-11e7-981a-4ae5ef0301c4.png)
