### PR TITLE
FIX: dimension hints on outer_product_scan

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2893,8 +2893,12 @@ def outer_product_scan(detectors, *args, per_step=None, md=None):
           }
     _md.update(md or {})
     _md['hints'].setdefault('gridding', 'rectilinear')
-    _md['hints'].setdefault('dimensions', [(m.hints['fields'], 'primary')
-                                           for m in motors])
+    try:
+        _md['hints'].setdefault('dimensions', [(m.hints['fields'], 'primary')
+                                               for m in motors])
+    except (AttributeError, KeyError):
+        ...
+
     return (yield from scan_nd(detectors, full_cycler,
                                per_step=per_step, md=_md))
 

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2866,13 +2866,14 @@ def outer_product_scan(detectors, *args, per_step=None, md=None):
 
     md_args = []
     motor_names = []
+    motors = []
     for i, (motor, start, stop, num, snake) in enumerate(chunk_args):
         md_args.extend([repr(motor), start, stop, num])
         if i > 0:
             # snake argument only shows up after the first motor
             md_args.append(snake)
         motor_names.append(motor.name)
-
+        motors.append(motor)
     _md = {'shape': tuple(num for motor, start, stop, num, snake
                           in chunk_args),
            'extents': tuple([start, stop] for motor, start, stop, num, snake
@@ -2892,7 +2893,8 @@ def outer_product_scan(detectors, *args, per_step=None, md=None):
           }
     _md.update(md or {})
     _md['hints'].setdefault('gridding', 'rectilinear')
-
+    _md['hints'].setdefault('dimensions', [(m.hints['fields'], 'primary')
+                                           for m in motors])
     return (yield from scan_nd(detectors, full_cycler,
                                per_step=per_step, md=_md))
 

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -62,3 +62,19 @@ def test_plan_header(fresh_RE, plan, target):
     RE(plan, c.insert)
     for s in c.start:
         _validate_start(s, target)
+
+
+def test_ops_dimension_hints(fresh_RE):
+    RE = fresh_RE
+    c = DocCollector()
+    RE.subscribe(c.insert)
+    rs, = RE(bp.outer_product_scan([det],
+                                   motor, -1, 1, 7,
+                                   motor1, 0, 2, 3, False))
+
+    st = c.start[0]
+
+    assert 'dimensions' in st['hints']
+
+    assert st['hints']['dimensions'] == [
+        (m.hints['fields'], 'primary') for m in (motor, motor1)]


### PR DESCRIPTION
They were being implicitly set in scan_nd in the opposite order.

closes #874
