### PR TITLE
TST: Close any matplotlib figures that were opened during a test.

### DIFF
--- a/bluesky/tests/conftest.py
+++ b/bluesky/tests/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 from bluesky.run_engine import RunEngine
+import matplotlib.pyplot as plt
 import numpy as np
 import os
 import pytest
@@ -52,3 +53,9 @@ def db(request):
     db = build_sqlite_backed_broker(request)
     db.reg.register_handler('NPY_SEQ', NumpySeqHandler)
     return db
+
+
+@pytest.fixture(autouse=True)
+def cleanup_any_figures(request):
+    "Close any matplotlib figures that were opened during a test."
+    plt.close('all')


### PR DESCRIPTION
With this last fix, the tests will run with 0 warnings.

We were getting a warning from matplotlib that more than 20 figures
were open.

This borrows an idea from matplotlib's test suite, automatically
applying a pytest fixture to _all_ tests that closing any figures
when the test completes.