### PR TITLE
API: re-organize / split plans.py for developer convenience 

### DIFF
--- a/bluesky/__init__.py
+++ b/bluesky/__init__.py
@@ -7,25 +7,7 @@ from .utils import IllegalMessageSequence
 from .utils import FailedStatus
 
 from .run_engine import RunEngine
-from .plans import SupplementalData
-
-# for back-compat
-from .plans import PlanBase
-from .plans import Count
-from .plans import AbsListScanPlan
-from .plans import DeltaListScanPlan
-from .plans import AbsScanPlan
-from .plans import LogAbsScanPlan
-from .plans import DeltaScanPlan
-from .plans import LogDeltaScanPlan
-from .plans import AdaptiveAbsScanPlan
-from .plans import AdaptiveDeltaScanPlan
-from .plans import PlanND
-from .plans import InnerProductAbsScanPlan
-from .plans import InnerProductDeltaScanPlan
-from .plans import OuterProductAbsScanPlan
-from .plans import OuterProductDeltaScanPlan
-from .plans import Tweak
+from .preprocessors import SupplementalData
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/bluesky/cntx.py
+++ b/bluesky/cntx.py
@@ -1,0 +1,254 @@
+from functools import wraps
+from contextlib import contextmanager
+import warnings
+
+from .utils import (normalize_subs_input, root_ancestor,
+                    separate_devices,
+                    Msg, single_gen)
+
+from .plan_stubs import (broadcast_msg, trigger_and_read)
+
+
+def planify(func):
+    """Turn a function that returns a list of generators into a coroutine.
+
+    Parameters
+    ----------
+    func : callable
+        expected to return a list of generators that yield messages (`Msg`
+        objects) the function may have an arbitrary signature
+
+    Returns
+    -------
+    gen : generator
+        a single generator that yields messages. The return value from
+        the generator is the return of the last plan in the plan
+        stack.
+
+    """
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        gen_stack = func(*args, **kwargs)
+        ret = None
+        for g in gen_stack:
+            ret = yield from g
+        return ret
+
+    return wrapped
+
+
+@contextmanager
+def subs_context(plan_stack, subs):
+    """
+    Subscribe callbacks to the document stream; then unsubscribe on exit.
+
+    .. deprecated:: 0.10.0
+        Use :func:`subs_wrapper` or :func:`subs_decorator` instead.
+
+    Parameters
+    ----------
+    plan_stack : list-like
+        appendable collection of generators that yield messages (`Msg` objects)
+    subs : callable, list of callables, or dict of lists of callables
+         Documents of each type are routed to a list of functions.
+         Input is normalized to a dict of lists of functions, like so:
+
+         None -> {'all': [], 'start': [], 'stop': [], 'event': [],
+                  'descriptor': []}
+
+         func -> {'all': [func], 'start': [], 'stop': [], 'event': [],
+                  'descriptor': []}
+
+         [f1, f2] -> {'all': [f1, f2], 'start': [], 'stop': [], 'event': [],
+                      'descriptor': []}
+
+         {'event': [func]} ->  {'all': [], 'start': [], 'stop': [],
+                                'event': [func], 'descriptor': []}
+
+         Signature of functions must confirm to `f(name, doc)` where
+         name is one of {'all', 'start', 'stop', 'event', 'descriptor'} and
+         doc is a dictionary.
+    """
+    warnings.warn("subs_context is deprecated. "
+                  "Use subs_wrapper or subs_decorator.")
+    subs = normalize_subs_input(subs)
+    tokens = set()
+
+    def _subscribe():
+        for name, funcs in subs.items():
+            for func in funcs:
+                token = yield Msg('subscribe', None, func, name)
+                tokens.add(token)
+
+    def _unsubscribe():
+        for token in tokens:
+            yield Msg('unsubscribe', None, token=token)
+
+    plan_stack.append(_subscribe())
+    try:
+        yield plan_stack
+    finally:
+        # The RunEngine might never process these if the execution fails,
+        # but it keeps its own cache of tokens and will try to remove them
+        # itself if this plan fails to do so.
+        plan_stack.append(_unsubscribe())
+
+
+@contextmanager
+def run_context(plan_stack, *, md=None):
+    """Enclose in 'open_run' and 'close_run' messages.
+
+    .. deprecated:: 0.10.0
+        Use :func:`run_wrapper` or :func:`run_decorator` instead.
+
+    Parameters
+    ----------
+    plan_stack : list-like
+        appendable collection of generators that yield messages (`Msg` objects)
+    md : dict, optional
+        metadata to be passed into the 'open_run' message
+    """
+    warnings.warn(
+        "run_context is deprecated. Use run_wrapper or run_decorator.")
+    plan_stack.append(single_gen(Msg('open_run', None, **dict(md or {}))))
+    yield plan_stack
+    plan_stack.append(single_gen(Msg('close_run')))
+
+
+@contextmanager
+def event_context(plan_stack, name='primary'):
+    """Bundle readings into an 'event' (a datapoint).
+
+    This encloses the contents in 'create' and 'save' messages.
+
+    .. deprecated:: 0.10.0
+        Use the :func:`create` and :func:`save` plans directly. Also,
+        :func:`trigger_and_read` addresses the common case of reading one or
+        more devices into one Event.
+
+    Parameters
+    ----------
+    plan_stack : list-like
+        appendable collection of generators that yield messages (`Msg` objects)
+    name : string, optional
+        name of event stream; default is 'primary'
+    """
+    warnings.warn(
+        "event_context is deprecated. Use create, save, or trigger_and_read.")
+    plan_stack.append(single_gen(Msg('create', None, name=name)))
+    yield plan_stack
+    plan_stack.append(single_gen(Msg('save')))
+
+
+@contextmanager
+def stage_context(plan_stack, devices):
+    """
+    Stage devices upon entering context and unstage upon exiting.
+
+    .. deprecated:: 0.10.0
+        Use :func:`stage_wrapper` or :func:`stage_decorator`.
+
+    Parameters
+    ----------
+    plan_stack : list-like
+        appendable collection of generators that yield messages (`Msg` objects)
+    devices : collection
+        list of devices to stage immediately on entrance and unstage on exit
+
+    See Also
+    --------
+    :func:`bluesky.plans.lazily_stage`
+    """
+    warnings.warn("stage_context is deprecated. "
+                  "Use stage_wrapper or stage_decorator.")
+    # Resolve unique devices, avoiding redundant staging.
+    devices = separate_devices(root_ancestor(device) for device in devices)
+
+    def stage():
+        # stage devices explicitly passed to 'devices' argument
+        yield from broadcast_msg('stage', devices)
+
+    def unstage():
+        # unstage devices explicitly passed to 'devices' argument
+        yield from broadcast_msg('unstage', reversed(devices))
+
+    plan_stack.append(stage())
+    yield plan_stack
+    plan_stack.append(unstage())
+
+
+@contextmanager
+def baseline_context(plan_stack, devices, name='baseline'):
+    """
+    Read every device once upon entering and exiting the context.
+
+    .. deprecated:: 0.10.0
+        Use :func:`baseline_wrapper` or :func:`baseline_decorator`.
+
+    The readings are designated for a separate event stream named 'baseline'
+    by default.
+
+    Parameters
+    ----------
+    plan_stack : list-like
+        appendable collection of generators that yield messages (`Msg` objects)
+    devices : collection
+        collection of Devices to read
+    name : string, optional
+        name for event stream; by default, 'baseline'
+    """
+    warnings.warn("baseline_context is deprecated. Use baseline_wrapper or "
+                  "baseline_decorator.")
+    plan_stack.append(trigger_and_read(devices, name=name))
+    yield
+    plan_stack.append(trigger_and_read(devices, name=name))
+
+
+@contextmanager
+def monitor_context(plan_stack, signals):
+    """
+    Asynchronously monitor signals, generating separate event streams.
+
+    .. deprecated:: 0.10.0
+        Use :func:`monitor_wrapper` or :func:`monitor_decorator`.
+
+    Upon exiting the context, stop monitoring.
+
+    Parameters
+    ----------
+    plan_stack : list-like
+        appendable collection of generators that yield messages (`Msg` objects)
+    signals : dict or list
+        either a dict mapping Signals to event stream names or simply a list
+        of Signals, in which case the event stream names default to None
+    name : string, optional
+        name for event stream; by default, None
+
+    Examples
+    --------
+    >>> plan_stack = deque()
+
+    With custom event stream names
+
+    >>> with monitor_context(plan_stack, {sig1: 'sig1', sig2: 'sig2'}):
+            ...
+
+    With no event stream names
+
+    >>> with monitor_context(plan_stack, [sig1, sig2]):
+            ...
+    """
+    warnings.warn("monitor_context is deprecated. Use monitor_wrapper or "
+                  "monitor_decorator.")
+    if hasattr(signals, 'items'):
+        # interpret input as dict of signals mapped to event stream names
+        pass
+    else:
+        # interpet input as list of signals
+        signals = {sig: None for sig in signals}
+
+    for sig, name in signals.items():
+        plan_stack.append(single_gen(Msg('monitor', sig, name=name)))
+    yield
+    for sig, name in signals.items():
+        plan_stack.append(single_gen(Msg('unmonitor', sig)))

--- a/bluesky/magics.py
+++ b/bluesky/magics.py
@@ -6,13 +6,13 @@
 # ip.register_magics(BlueskyMagics)
 
 import asyncio
-import bluesky.plans as bp
 from bluesky.utils import ProgressBarManager
 from bluesky import RunEngine, RunEngineInterrupted
 from IPython.core.magic import Magics, magics_class, line_magic
 import numpy as np
 from operator import attrgetter
-
+from . import plans as bp
+from . import plan_stubs as bps
 try:
     # cytools is a drop-in replacement for toolz, implemented in Cython
     from cytools import partition
@@ -42,7 +42,7 @@ class BlueskyMagics(Magics):
     * ``BlueskyMagics.RE``
     * ``BlueskyMagics.pbar_manager``
     """
-    RE = RunEngine({}, loop = asyncio.new_event_loop())
+    RE = RunEngine({}, loop=asyncio.new_event_loop())
     pbar_manager = ProgressBarManager()
 
     def _ensure_idle(self):
@@ -60,7 +60,7 @@ class BlueskyMagics(Magics):
         for motor, pos in partition(2, line.split()):
             args.append(eval(motor, self.shell.user_ns))
             args.append(eval(pos, self.shell.user_ns))
-        plan = bp.mv(*args)
+        plan = bps.mv(*args)
         self.RE.waiting_hook = self.pbar_manager
         try:
             self.RE(plan)
@@ -79,7 +79,7 @@ class BlueskyMagics(Magics):
         for motor, pos in partition(2, line.split()):
             args.append(eval(motor, self.shell.user_ns))
             args.append(eval(pos, self.shell.user_ns))
-        plan = bp.mvr(*args)
+        plan = bps.mvr(*args)
         self.RE.waiting_hook = self.pbar_manager
         try:
             self.RE(plan)

--- a/bluesky/object_plans.py
+++ b/bluesky/object_plans.py
@@ -1,0 +1,337 @@
+from . import utils
+import warnings
+from collections import defaultdict
+
+# The code below adds no new logic, but it wraps the generators above in
+# classes for an alternative interface that is more stateful.
+
+from . import preprocessors as bpp
+from .plans import (count, list_scan, rel_list_scan, log_scan,
+                    rel_scan, adaptive_scan, rel_adaptive_scan,
+                    scan_nd, inner_product_scan, relative_inner_product_scan,
+                    grid_scan, scan, tweak, spiral, spiral_fermat,
+                    rel_spiral_fermat, rel_spiral, rel_log_scan,
+                    rel_grid_scan)
+
+
+class Plan(utils.Struct):
+    """
+    This is a base class for wrapping plan generators in a stateful class.
+
+    To create a new sub-class you need to over-ride two things:
+
+    - an ``__init__`` method *or* a class level ``_fields`` attribute which is
+      used to construct the init signature via meta-class magic
+    - a ``_gen`` method, which should return a generator of Msg objects
+
+    The class provides:
+
+    - state stored in attributes that are used to re-generate a plan generator
+      with the same parameters
+    - a hook for adding "flyable" objects to a plan
+    - attributes for adding subscriptions and subscription factory functions
+    """
+    subs = utils.Subs({})
+    sub_factories = utils.Subs({})
+
+    def __iter__(self):
+        """
+        Return an iterable of messages.
+        """
+        return self()
+
+    def __call__(self, **kwargs):
+        """
+        Return an iterable of messages.
+
+        Any keyword arguments override present settings.
+        """
+        warnings.warn("This plan and all object-oriented plans have been "
+                      "deprecated and will be removed in a future release "
+                      "of bluesky. Instead of Count or Scan use count or "
+                      "scan, etc.", stacklevel=2)
+        subs = defaultdict(list)
+        utils.update_sub_lists(subs, self.subs)
+        utils.update_sub_lists(
+            subs, utils.apply_sub_factories(self.sub_factories, self))
+        flyers = getattr(self, 'flyers', [])
+
+        def cls_plan():
+            current_settings = {}
+            for key, val in kwargs.items():
+                current_settings[key] = getattr(self, key)
+                setattr(self, key, val)
+            try:
+                plan = self._gen()
+                plan = bpp.subs_wrapper(plan, subs)
+                plan = bpp.stage_wrapper(plan, flyers)
+                plan = bpp.fly_during_wrapper(plan, flyers)
+                return (yield from plan)
+            finally:
+                for key, val in current_settings.items():
+                    setattr(self, key, val)
+
+        cls_plan.__name__ = self.__class__.__name__
+        return cls_plan()
+
+    def _gen(self):
+        "Subclasses override this to provide the main plan content."
+        yield from utils.censure_generator([])
+
+
+PlanBase = Plan  # back-compat
+
+
+class Count(Plan):
+    _fields = ['detectors', 'num', 'delay']
+    __doc__ = count.__doc__
+
+    def __init__(self, detectors, num=1, delay=0, *, md=None):
+        self.detectors = detectors
+        self.num = num
+        self.delay = delay
+        self.flyers = []
+        self.md = md
+
+    def _gen(self):
+        return count(self.detectors, self.num, self.delay, md=self.md)
+
+
+class ListScan(Plan):
+    _fields = ['detectors', 'motor', 'steps']
+    __doc__ = list_scan.__doc__
+
+    def _gen(self):
+        return list_scan(self.detectors, self.motor, self.steps,
+                         md=self.md)
+
+
+AbsListScanPlan = ListScan  # back-compat
+
+
+class RelativeListScan(Plan):
+    _fields = ['detectors', 'motor', 'steps']
+    __doc__ = rel_list_scan.__doc__
+
+    def _gen(self):
+        return rel_list_scan(self.detectors, self.motor, self.steps,
+                             md=self.md)
+
+
+DeltaListScanPlan = RelativeListScan  # back-compat
+
+
+class Scan(Plan):
+    _fields = ['detectors', 'motor', 'start', 'stop', 'num']
+    __doc__ = scan.__doc__
+
+    def _gen(self):
+        return scan(self.detectors, self.motor, self.start, self.stop,
+                    self.num, md=self.md)
+
+
+AbsScanPlan = Scan  # back-compat
+
+
+class LogScan(Plan):
+    _fields = ['detectors', 'motor', 'start', 'stop', 'num']
+    __doc__ = log_scan.__doc__
+
+    def _gen(self):
+        return log_scan(self.detectors, self.motor, self.start, self.stop,
+                        self.num, md=self.md)
+
+
+LogAbsScanPlan = LogScan  # back-compat
+
+
+class RelativeScan(Plan):
+    _fields = ['detectors', 'motor', 'start', 'stop', 'num']
+    __doc__ = rel_scan.__doc__
+
+    def _gen(self):
+        return rel_scan(self.detectors, self.motor, self.start, self.stop,
+                        self.num, md=self.md)
+
+
+DeltaScanPlan = RelativeScan  # back-compat
+
+
+class RelativeLogScan(Plan):
+    _fields = ['detectors', 'motor', 'start', 'stop', 'num']
+    __doc__ = rel_log_scan.__doc__
+
+    def _gen(self):
+        return rel_log_scan(self.detectors, self.motor, self.start,
+                            self.stop, self.num, md=self.md)
+
+
+LogDeltaScanPlan = RelativeLogScan  # back-compat
+
+
+class AdaptiveScan(Plan):
+    _fields = ['detectors', 'target_field', 'motor', 'start', 'stop',
+               'min_step', 'max_step', 'target_delta', 'backstep',
+               'threshold']
+    __doc__ = adaptive_scan.__doc__
+
+    def __init__(self, detectors, target_field, motor, start, stop,
+                 min_step, max_step, target_delta, backstep,
+                 threshold=0.8, *, md=None):
+        self.detectors = detectors
+        self.target_field = target_field
+        self.motor = motor
+        self.start = start
+        self.stop = stop
+        self.min_step = min_step
+        self.max_step = max_step
+        self.target_delta = target_delta
+        self.backstep = backstep
+        self.threshold = threshold
+        self.flyers = []
+        self.md = md
+
+    def _gen(self):
+        return adaptive_scan(self.detectors, self.target_field, self.motor,
+                             self.start, self.stop, self.min_step,
+                             self.max_step, self.target_delta,
+                             self.backstep, self.threshold, md=self.md)
+
+
+AdaptiveAbsScanPlan = AdaptiveScan  # back-compat
+
+
+class RelativeAdaptiveScan(AdaptiveAbsScanPlan):
+    __doc__ = rel_adaptive_scan.__doc__
+
+    def _gen(self):
+        return rel_adaptive_scan(self.detectors, self.target_field,
+                                 self.motor, self.start, self.stop,
+                                 self.min_step, self.max_step,
+                                 self.target_delta, self.backstep,
+                                 self.threshold, md=self.md)
+
+
+AdaptiveDeltaScanPlan = RelativeAdaptiveScan  # back-compat
+
+
+class ScanND(PlanBase):
+    _fields = ['detectors', 'cycler']
+    __doc__ = scan_nd.__doc__
+
+    def _gen(self):
+        return scan_nd(self.detectors, self.cycler, md=self.md)
+
+
+PlanND = ScanND  # back-compat
+
+
+class InnerProductScan(Plan):
+    __doc__ = inner_product_scan.__doc__
+
+    def __init__(self, detectors, num, *args, md=None):
+        self.detectors = detectors
+        self.num = num
+        self.args = args
+        self.flyers = []
+        self.md = md
+
+    def _gen(self):
+        return inner_product_scan(self.detectors, self.num, *self.args,
+                                  md=self.md)
+
+
+InnerProductAbsScanPlan = InnerProductScan  # back-compat
+
+
+class RelativeInnerProductScan(InnerProductScan):
+    __doc__ = relative_inner_product_scan.__doc__
+
+    def _gen(self):
+        return relative_inner_product_scan(self.detectors, self.num,
+                                           *self.args, md=self.md)
+
+
+InnerProductDeltaScanPlan = RelativeInnerProductScan  # back-compat
+
+
+class OuterProductScan(Plan):
+    __doc__ = grid_scan.__doc__
+
+    def __init__(self, detectors, *args, md=None):
+        self.detectors = detectors
+        self.args = args
+        self.flyers = []
+        self.md = md
+
+    def _gen(self):
+        return grid_scan(self.detectors, *self.args, md=self.md)
+
+
+OuterProductAbsScanPlan = OuterProductScan  # back-compat
+
+
+class RelativeOuterProductScan(OuterProductScan):
+    __doc__ = rel_grid_scan.__doc__
+
+    def _gen(self):
+        return rel_grid_scan(self.detectors, *self.args,
+                             md=self.md)
+
+
+OuterProductDeltaScanPlan = RelativeOuterProductScan  # back-compat
+
+
+class Tweak(Plan):
+    _fields = ['detector', 'target_field', 'motor', 'step']
+    __doc__ = tweak.__doc__
+
+    def _gen(self):
+        return tweak(self.detector, self.target_field, self.motor, self.step,
+                     md=self.md)
+
+
+class SpiralScan(Plan):
+    _fields = ['detectors', 'x_motor', 'y_motor', 'x_start', 'y_start',
+               'x_range', 'y_range', 'dr', 'nth', 'tilt']
+    __doc__ = spiral.__doc__
+
+    def _gen(self):
+        return spiral(self.detectors, self.x_motor, self.y_motor, self.x_start,
+                      self.y_start, self.x_range, self.y_range, self.dr,
+                      self.nth, tilt=self.tilt, md=self.md)
+
+
+class SpiralFermatScan(Plan):
+    _fields = ['detectors', 'x_motor', 'y_motor', 'x_start', 'y_start',
+               'x_range', 'y_range', 'dr', 'factor', 'tilt']
+    __doc__ = spiral_fermat.__doc__
+
+    def _gen(self):
+        return spiral_fermat(self.detectors, self.x_motor, self.y_motor,
+                             self.x_start, self.y_start, self.x_range,
+                             self.y_range, self.dr, self.factor,
+                             tilt=self.tilt, md=self.md)
+
+
+class RelativeSpiralScan(Plan):
+    _fields = ['detectors', 'x_motor', 'y_motor', 'x_range', 'y_range', 'dr',
+               'nth', 'tilt']
+    __doc__ = rel_spiral.__doc__
+
+    def _gen(self):
+        return rel_spiral(self.detectors, self.x_motor, self.y_motor,
+                          self.x_range, self.y_range, self.dr, self.nth,
+                          tilt=self.tilt, md=self.md)
+
+
+class RelativeSpiralFermatScan(Plan):
+    _fields = ['detectors', 'x_motor', 'y_motor', 'x_range', 'y_range', 'dr',
+               'factor', 'tilt']
+    __doc__ = rel_spiral_fermat.__doc__
+
+    def _gen(self):
+        return rel_spiral_fermat(self.detectors, self.x_motor,
+                                 self.y_motor, self.x_range, self.y_range,
+                                 self.dr, self.factor, tilt=self.tilt,
+                                 md=self.md)

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -1,0 +1,896 @@
+import itertools
+import uuid
+
+try:
+    # cytools is a drop-in replacement for toolz, implemented in Cython
+    from cytools import partition
+except ImportError:
+    from toolz import partition
+
+
+from .utils import (separate_devices, all_safe_rewind, Msg,
+                    short_uid as _short_uid)
+
+
+def create(name='primary'):
+    """
+    Bundle future readings into a new Event document.
+
+    Parameters
+    ----------
+    name : string, optional
+        name given to event stream, used to convenient identification
+        default is 'primary'
+
+    Yields
+    ------
+    msg : Msg
+        Msg('create', name=name)
+
+    See Also
+    --------
+    :func:`bluesky.plans.save`
+    """
+    return (yield Msg('create', name=name))
+
+
+def save():
+    """
+    Close a bundle of readings and emit a completed Event document.
+
+    Yields
+    -------
+    msg : Msg
+        Msg('save')
+
+    See Also
+    --------
+    :func:`bluesky.plans.create`
+    """
+    return (yield Msg('save'))
+
+
+def read(obj):
+    """
+    Take a reading and add it to the current bundle of readings.
+
+    Parameters
+    ----------
+    obj : Device or Signal
+
+    Yields
+    ------
+    msg : Msg
+        Msg('read', obj)
+    """
+    return (yield Msg('read', obj))
+
+
+def monitor(obj, *, name=None, **kwargs):
+    """
+    Asynchronously monitor for new values and emit Event documents.
+
+    Parameters
+    ----------
+    obj : Signal
+    args :
+        passed through to ``obj.subscribe()``
+    name : string, optional
+        name of event stream; default is None
+    kwargs :
+        passed through to ``obj.subscribe()``
+
+    Yields
+    ------
+    msg : Msg
+        ``Msg('monitor', obj, *args, **kwargs)``
+
+    See Also
+    --------
+    :func:`bluesky.plans.unmonitor`
+    """
+    return (yield Msg('monitor', obj, name=name, **kwargs))
+
+
+def unmonitor(obj):
+    """
+    Stop monitoring.
+
+    Parameters
+    ----------
+    obj : Signal
+
+    Yields
+    ------
+    msg : Msg
+        Msg('unmonitor', obj)
+
+    See Also
+    --------
+    :func:`bluesky.plans.monitor`
+    """
+    return (yield Msg('unmonitor', obj))
+
+
+def null():
+    """
+    Yield a no-op Message. (Primarily for debugging and testing.)
+
+    Yields
+    ------
+    msg : Msg
+        Msg('null')
+    """
+    return (yield Msg('null'))
+
+
+def abs_set(obj, *args, group=None, wait=False, **kwargs):
+    """
+    Set a value. Optionally, wait for it to complete before continuing.
+
+    Parameters
+    ----------
+    obj : Device
+    group : string (or any hashable object), optional
+        identifier used by 'wait'
+    wait : boolean, optional
+        If True, wait for completion before processing any more messages.
+        False by default.
+    args :
+        passed to obj.set()
+    kwargs :
+        passed to obj.set()
+
+    Yields
+    ------
+    msg : Msg
+
+    See Also
+    --------
+    :func:`bluesky.plans.rel_set`
+    :func:`bluesky.plans.wait`
+    :func:`bluesky.plans.mv`
+    """
+    if wait and group is None:
+        group = str(uuid.uuid4())
+    ret = yield Msg('set', obj, *args, group=group, **kwargs)
+    if wait:
+        yield Msg('wait', None, group=group)
+    return ret
+
+
+def rel_set(obj, *args, group=None, wait=False, **kwargs):
+    """
+    Set a value relative to current value. Optionally, wait before continuing.
+
+    Parameters
+    ----------
+    obj : Device
+    group : string (or any hashable object), optional
+        identifier used by 'wait'; None by default
+    wait : boolean, optional
+        If True, wait for completion before processing any more messages.
+        False by default.
+    args :
+        passed to obj.set()
+    kwargs :
+        passed to obj.set()
+
+    Yields
+    ------
+    msg : Msg
+
+    See Also
+    --------
+    :func:`bluesky.plans.abs_set`
+    :func:`bluesky.plans.wait`
+    """
+    from .preprocessors import relative_set_wrapper
+    return (yield from relative_set_wrapper(
+        abs_set(obj, *args, group=group, wait=wait, **kwargs)))
+
+
+def mv(*args):
+    """
+    Move one or more devices to a setpoint. Wait for all to complete.
+
+    If more than one device is specifed, the movements are done in parallel.
+
+    Parameters
+    ----------
+    args :
+        device1, value1, device2, value2, ...
+
+    Yields
+    ------
+    msg : Msg
+
+    See Also
+    --------
+    :func:`bluesky.plans.abs_set`
+    :func:`bluesky.plans.mvr`
+    """
+    group = str(uuid.uuid4())
+    status_objects = []
+    for obj, val in partition(2, args):
+        ret = yield Msg('set', obj, val, group=group)
+        status_objects.append(ret)
+    yield Msg('wait', None, group=group)
+    return tuple(status_objects)
+
+
+mov = mv  # synonym
+
+
+def mvr(*args):
+    """
+    Move one or more devices to a relative setpoint. Wait for all to complete.
+
+    If more than one device is specifed, the movements are done in parallel.
+
+    Parameters
+    ----------
+    args :
+        device1, value1, device2, value2, ...
+
+    Yields
+    ------
+    msg : Msg
+
+    See Also
+    --------
+    :func:`bluesky.plans.rel_set`
+    :func:`bluesky.plans.mv`
+    """
+    objs = []
+    for obj, val in partition(2, args):
+        objs.append(obj)
+
+    from .preprocessors import relative_set_decorator
+
+    @relative_set_decorator(objs)
+    def inner_mvr():
+        return (yield from mv(*args))
+
+    return (yield from inner_mvr())
+
+
+movr = mvr  # synonym
+
+
+def stop(obj):
+    """
+    Stop a device.
+
+    Parameters
+    ----------
+    obj : Device
+
+    Yields
+    ------
+    msg : Msg
+    """
+    return (yield Msg('stop', obj))
+
+
+def trigger(obj, *, group=None, wait=False):
+    """
+    Trigger and acquisition. Optionally, wait for it to complete.
+
+    Parameters
+    ----------
+    obj : Device
+    group : string (or any hashable object), optional
+        identifier used by 'wait'; None by default
+    wait : boolean, optional
+        If True, wait for completion before processing any more messages.
+        False by default.
+
+    Yields
+    ------
+    msg : Msg
+    """
+    ret = yield Msg('trigger', obj, group=group)
+    if wait:
+        yield Msg('wait', None, group=group)
+    return ret
+
+
+def sleep(time):
+    """
+    Tell the RunEngine to sleep, while asynchronously doing other processing.
+
+    This is not the same as ``import time; time.sleep()`` because it allows
+    other actions, like interruptions, to be processed during the sleep.
+
+    Parameters
+    ----------
+    time : float
+        seconds
+
+    Yields
+    ------
+    msg : Msg
+        Msg('sleep', None, time)
+    """
+    return (yield Msg('sleep', None, time))
+
+
+def wait(group=None):
+    """
+    Wait for all statuses in a group to report being finished.
+
+    Parameters
+    ----------
+    group : string (or any hashable object), optional
+        idenified given to `abs_set`, `rel_set`, `trigger`; None by default
+
+    Yields
+    ------
+    msg : Msg
+        Msg('wait', None, group=group)
+    """
+    return (yield Msg('wait', None, group=group))
+
+
+_wait = wait  # for internal references to avoid collision with 'wait' kwarg
+
+
+def checkpoint():
+    """
+    If interrupted, rewind to this point.
+
+    Yields
+    ------
+    msg : Msg
+        Msg('checkpoint')
+
+    See Also
+    --------
+    :func:`bluesky.plans.clear_checkpoint`
+    """
+    return (yield Msg('checkpoint'))
+
+
+def clear_checkpoint():
+    """
+    Designate that it is not safe to resume. If interrupted or paused, abort.
+
+    Yields
+    ------
+    msg : Msg
+        Msg('clear_checkpoint')
+
+    See Also
+    --------
+    :func:`bluesky.plans.checkpoint`
+    """
+    return (yield Msg('clear_checkpoint'))
+
+
+def pause():
+    """
+    Pause and wait for the user to resume.
+
+    Yields
+    ------
+    msg : Msg
+        Msg('pause')
+
+    See Also
+    --------
+    :func:`bluesky.plans.deferred_pause`
+    :func:`bluesky.plans.sleep`
+    """
+    return (yield Msg('pause', None, defer=False))
+
+
+def deferred_pause():
+    """
+    Pause at the next checkpoint.
+
+    Yields
+    ------
+    msg : Msg
+        Msg('pause', defer=True)
+
+    See Also
+    --------
+    :func:`bluesky.plans.pause`
+    :func:`bluesky.plans.sleep`
+    """
+    return (yield Msg('pause', None, defer=True))
+
+
+def input_plan(prompt=''):
+    """
+    Prompt the user for text input.
+
+    Parameters
+    ----------
+    prompt : str
+        prompt string, e.g., 'enter user name' or 'enter next position'
+
+    Yields
+    ------
+    msg : Msg
+        Msg('input', prompt=prompt)
+    """
+    return (yield Msg('input', prompt=prompt))
+
+
+def kickoff(obj, *, group=None, wait=False, **kwargs):
+    """
+    Kickoff a fly-scanning device.
+
+    Parameters
+    ----------
+    obj : fly-able
+        Device with 'kickoff', 'complete', and 'collect' methods
+    group : string (or any hashable object), optional
+        identifier used by 'wait'
+    wait : boolean, optional
+        If True, wait for completion before processing any more messages.
+        False by default.
+    kwargs
+        passed through to ``obj.kickoff()``
+
+    Yields
+    ------
+    msg : Msg
+        Msg('kickoff', obj)
+
+    See Also
+    --------
+    :func:`bluesky.plans.complete`
+    :func:`bluesky.plans.collect`
+    :func:`bluesky.plans.wait`
+    """
+    ret = (yield Msg('kickoff', obj, group=group, **kwargs))
+    if wait:
+        yield from _wait(group=group)
+    return ret
+
+
+def complete(obj, *, group=None, wait=False, **kwargs):
+    """
+    Tell a flyer, 'stop collecting, whenver you are ready'.
+
+    The flyer returns a status object. Some flyers respond to this
+    command by stopping collection and returning a finished status
+    object immedately. Other flyers finish their given course and
+    finish whenever they finish, irrespective of when this command is
+    issued.
+
+    Parameters
+    ----------
+    obj : fly-able
+        Device with 'kickoff', 'complete', and 'collect' methods
+    group : string (or any hashable object), optional
+        identifier used by 'wait'
+    wait : boolean, optional
+        If True, wait for completion before processing any more messages.
+        False by default.
+    kwargs
+        passed through to ``obj.complete()``
+
+    Yields
+    ------
+    msg : Msg
+        a 'complete' Msg and maybe a 'wait' message
+
+    See Also
+    --------
+    :func:`bluesky.plans.kickoff`
+    :func:`bluesky.plans.collect`
+    :func:`bluesky.plans.wait`
+    """
+    ret = yield Msg('complete', obj, group=group, **kwargs)
+    if wait:
+        yield from _wait(group=group)
+    return ret
+
+
+def collect(obj, *, stream=False):
+    """
+    Collect data cached by a fly-scanning device and emit documents.
+
+    Parameters
+    ----------
+    obj : fly-able
+        Device with 'kickoff', 'complete', and 'collect' methods
+    stream : boolean
+        If False (default), emit events documents in one bulk dump. If True,
+        emit events one at time.
+
+    Yields
+    ------
+    msg : Msg
+        Msg('collect', obj)
+
+    See Also
+    --------
+    :func:`bluesky.plans.kickoff`
+    :func:`bluesky.plans.complete`
+    :func:`bluesky.plans.wait`
+    """
+    return (yield Msg('collect', obj, stream=stream))
+
+
+def configure(obj, *args, **kwargs):
+    """
+    Change Device configuration and emit an updated Event Descriptor document.
+
+    Parameters
+    ----------
+    obj : Device
+    args
+        passed through to ``obj.configure()``
+    kwargs
+        passed through to ``obj.configure()``
+
+    Yields
+    ------
+    msg : Msg
+        ``Msg('configure', obj, *args, **kwargs)``
+    """
+    return (yield Msg('configure', obj, *args, **kwargs))
+
+
+def stage(obj):
+    """
+    'Stage' a device (i.e., prepare it for use, 'arm' it).
+
+    Parameters
+    ----------
+    obj : Device
+
+    Yields
+    ------
+    msg : Msg
+        Msg('stage', obj)
+
+    See Also
+    --------
+    :func:`bluesky.plans.unstage`
+    """
+    return (yield Msg('stage', obj))
+
+
+def unstage(obj):
+    """
+    'Unstage' a device (i.e., put it in standby, 'disarm' it).
+
+    Parameters
+    ----------
+    obj : Device
+
+    Yields
+    ------
+    msg : Msg
+        Msg('unstage', obj)
+
+    See Also
+    --------
+    :func:`bluesky.plans.stage`
+    """
+    return (yield Msg('unstage', obj))
+
+
+def subscribe(name, func):
+    """
+    Subscribe the stream of emitted documents.
+
+    Parameters
+    ----------
+    name : {'all', 'start', 'descriptor', 'event', 'stop'}
+    func : callable
+        Expected signature: ``f(name, doc)`` where ``name`` is one of the
+        strings above ('all, 'start', ...) and ``doc`` is a dict
+
+    Yields
+    ------
+    msg : Msg
+        Msg('subscribe', None, func, name)
+
+    See Also
+    --------
+    :func:`bluesky.plans.unsubscribe`
+    """
+    return (yield Msg('subscribe', None, func, name))
+
+
+def unsubscribe(token):
+    """
+    Remove a subscription.
+
+    Parameters
+    ----------
+    token : int
+        token returned by processing a 'subscribe' message
+
+    Yields
+    ------
+    msg : Msg
+        Msg('unsubscribe', token=token)
+
+    See Also
+    --------
+    :func:`bluesky.plans.subscribe`
+    """
+    return (yield Msg('unsubscribe', token=token))
+
+
+def open_run(md=None):
+    """
+    Mark the beginning of a new 'run'. Emit a RunStart document.
+
+    Parameters
+    ----------
+    md : dict, optional
+        metadata
+
+    Yields
+    ------
+    msg : Msg
+        ``Msg('open_run', **md)``
+
+    See Also
+    --------
+    :func:`bluesky.plans.close_run`
+    """
+    return (yield Msg('open_run', **(md or {})))
+
+
+def close_run(exit_status=None, reason=None):
+    """
+    Mark the end of the current 'run'. Emit a RunStop document.
+
+    Yields
+    ------
+    msg : Msg
+        Msg('close_run')
+    exit_status : {None, 'success', 'abort', 'fail'}
+        The exit status to report in the Stop document
+    reason : str, optional
+        Long-form description of why the run ended
+
+    See Also
+    --------
+    :func:`bluesky.plans.open_run`
+    """
+    return (yield Msg('close_run', exit_status=exit_status, reason=reason))
+
+
+def wait_for(futures, **kwargs):
+    """
+    Low-level: wait for a list of ``asyncio.Future`` objects to set (complete).
+
+    Parameters
+    ----------
+    futures : collection
+        collection of asyncio.Future objects
+    kwargs
+        passed through to ``asyncio.wait()``
+
+    Yields
+    ------
+    msg : Msg
+        ``Msg('wait_for', None, futures, **kwargs)``
+
+    See Also
+    --------
+    :func:`bluesky.plans.wait`
+    """
+    return (yield Msg('wait_for', None, futures, **kwargs))
+
+
+def fly(flyers, *, md=None):
+    """
+    Perform a fly scan with one or more 'flyers'.
+
+    Parameters
+    ----------
+    flyers : collection
+        objects that support the flyer interface
+    md : dict, optional
+        metadata
+
+    Yields
+    ------
+    msg : Msg
+        'kickoff', 'wait', 'complete, 'wait', 'collect' messages
+
+    See Also
+    --------
+    :func:`bluesky.plans.fly_during`
+    """
+    yield from open_run(md)
+    for flyer in flyers:
+        yield from kickoff(flyer, wait=True)
+    for flyer in flyers:
+        yield from complete(flyer, wait=True)
+    for flyer in flyers:
+        yield from collect(flyer)
+    yield from close_run()
+
+
+def trigger_and_read(devices, name='primary'):
+    """
+    Trigger and read a list of detectors and bundle readings into one Event.
+
+    Parameters
+    ----------
+    devices : iterable
+        devices to trigger (if they have a trigger method) and then read
+    name : string, optional
+        event stream name, a convenient human-friendly identifier; default
+        name is 'primary'
+
+    Yields
+    ------
+    msg : Msg
+        messages to 'trigger', 'wait' and 'read'
+    """
+    # If devices is empty, don't emit 'create'/'save' messages.
+    if not devices:
+        yield from null()
+    devices = separate_devices(devices)  # remove redundant entries
+    rewindable = all_safe_rewind(devices)  # if devices can be re-triggered
+
+    def inner_trigger_and_read():
+        grp = _short_uid('trigger')
+        no_wait = True
+        for obj in devices:
+            if hasattr(obj, 'trigger'):
+                no_wait = False
+                yield from trigger(obj, group=grp)
+        # Skip 'wait' if none of the devices implemented a trigger method.
+        if not no_wait:
+            yield from wait(group=grp)
+        yield from create(name)
+        ret = {}  # collect and return readings to give plan access to them
+        for obj in devices:
+            reading = (yield from read(obj))
+            if reading is not None:
+                ret.update(reading)
+        yield from save()
+        return ret
+    from .preprocessors import rewindable_wrapper
+    return (yield from rewindable_wrapper(inner_trigger_and_read(),
+                                          rewindable))
+
+
+def broadcast_msg(command, objs, *args, **kwargs):
+    """
+    Generate many copies of a mesasge, applying it to a list of devices.
+
+    Parameters
+    ----------
+    command : string
+    devices : iterable
+    ``*args``
+        args for message
+    ``**kwargs``
+        kwargs for message
+
+    Yields
+    ------
+    msg : Msg
+    """
+    return_vals = []
+    for o in objs:
+        ret = yield Msg(command, o, *args, **kwargs)
+        return_vals.append(ret)
+
+    return return_vals
+
+
+def repeater(n, gen_func, *args, **kwargs):
+    """
+    Generate n chained copies of the messages from gen_func
+
+    Parameters
+    ----------
+    n : int or None
+        total number of repetitions; if None, infinite
+    gen_func : callable
+        returns generator instance
+    ``*args``
+        args for gen_func
+    ``**kwargs``
+        kwargs for gen_func
+
+    Yields
+    ------
+    msg : Msg
+
+    See Also
+    --------
+    :func:`bluesky.plans.caching_repeater`
+    """
+    it = range
+    if n is None:
+        n = 0
+        it = itertools.count
+
+    for j in it(n):
+        yield from gen_func(*args, **kwargs)
+
+
+def caching_repeater(n, plan):
+    """
+    Generate n chained copies of the messages in a plan.
+
+    This is different from ``repeater`` above because it takes in a
+    generator or iterator, not a function that returns one.
+
+    Parameters
+    ----------
+    n : int or None
+        total number of repetitions; if None, infinite
+    plan : iterable
+
+    Yields
+    ------
+    msg : Msg
+
+    See Also
+    --------
+    :func:`bluesky.plans.repeater`
+    """
+    it = range
+    if n is None:
+        n = 0
+        it = itertools.count
+
+    lst_plan = list(plan)
+    for j in it(n):
+        yield from (m for m in lst_plan)
+
+
+def one_1d_step(detectors, motor, step):
+    """
+    Inner loop of a 1D step scan
+
+    This is the default function for ``per_step`` param in 1D plans.
+    """
+    def move():
+        grp = _short_uid('set')
+        yield Msg('checkpoint')
+        yield Msg('set', motor, step, group=grp)
+        yield Msg('wait', None, group=grp)
+
+    yield from move()
+    return (yield from trigger_and_read(list(detectors) + [motor]))
+
+
+def one_nd_step(detectors, step, pos_cache):
+    """
+    Inner loop of an N-dimensional step scan
+
+    This is the default function for ``per_step`` param`` in ND plans.
+
+    Parameters
+    ----------
+    detectors : iterable
+        devices to read
+    step : dict
+        mapping motors to positions in this step
+    pos_cache : dict
+        mapping motors to their last-set positions
+    """
+    def move():
+        yield Msg('checkpoint')
+        grp = _short_uid('set')
+        for motor, pos in step.items():
+            if pos == pos_cache[motor]:
+                # This step does not move this motor.
+                continue
+            yield Msg('set', motor, pos, group=grp)
+            pos_cache[motor] = pos
+        yield Msg('wait', None, group=grp)
+
+    motors = step.keys()
+    yield from move()
+    yield from trigger_and_read(list(detectors) + list(motors))

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1,12 +1,9 @@
-import uuid
 import sys
-from functools import wraps
 import itertools
 from itertools import chain
-from contextlib import contextmanager
-from collections import OrderedDict, Iterable, defaultdict, deque, ChainMap
+
+from collections import (Iterable, defaultdict)
 import time
-from warnings import warn
 
 import numpy as np
 try:
@@ -17,2187 +14,11 @@ except ImportError:
 
 from . import plan_patterns
 
-from .utils import (Struct, Subs, normalize_subs_input, root_ancestor,
-                    separate_devices, apply_sub_factories, update_sub_lists,
-                    all_safe_rewind, Msg, ensure_generator, single_gen,
-                    short_uid as _short_uid, RampFail, make_decorator,
-                    RunEngineControlException, merge_cycler, merge_axis)
-
-
-def planify(func):
-    """Turn a function that returns a list of generators into a coroutine.
-
-    Parameters
-    ----------
-    func : callable
-        expected to return a list of generators that yield messages (`Msg`
-        objects) the function may have an arbitrary signature
-
-    Returns
-    -------
-    gen : generator
-        a single generator that yields messages. The return value from
-        the generator is the return of the last plan in the plan
-        stack.
-
-    """
-    @wraps(func)
-    def wrapped(*args, **kwargs):
-        gen_stack = func(*args, **kwargs)
-        ret = None
-        for g in gen_stack:
-            ret = yield from g
-        return ret
-
-    return wrapped
-
-
-def plan_mutator(plan, msg_proc):
-    """
-    Alter the contents of a plan on the fly by changing or inserting messages.
-
-    Parameters
-    ----------
-    plan : generator
-        a generator that yields messages (`Msg` objects)
-    msg_proc : callable
-        This function takes in a message and specifies messages(s) to replace
-        it with. The function must account for what type of response the
-        message would prompt. For example, an 'open_run' message causes the
-        RunEngine to send a uid string back to the plan, while a 'set' message
-        causes the RunEngine to send a status object back to the plan. The
-        function should return a pair of generators ``(head, tail)`` that yield
-        messages. The last message out of the ``head`` generator is the one
-        whose response will be sent back to the host plan. Therefore, that
-        message should prompt a response compatible with the message that it is
-        replacing. Any responses to all other messages will be swallowed. As
-        shorthand, either ``head`` or ``tail`` can be replaced by ``None``.
-        This means:
-
-        * ``(None, None)`` No-op. Let the original message pass through.
-        * ``(head, None)`` Mutate and/or insert messages before the original
-        message.
-        * ``(head, tail)`` As above, and additionally insert messages after.
-        * ``(None, tail)`` Let the original message pass through and then
-        insert messages after.
-
-        The reason for returning a pair of generators instead of just one is to
-        provide a way to specify which message's response should be sent out to
-        the host plan. Again, it's the last message yielded by the first
-        generator (``head``).
-
-    Yields
-    ------
-    msg : Msg
-        messages from `plan`, altered by `msg_proc`
-
-    See Also
-    --------
-    :func:`bluesky.plans.msg_mutator`
-    """
-    # internal stacks
-    msgs_seen = dict()
-    plan_stack = deque()
-    result_stack = deque()
-    tail_cache = dict()
-    tail_result_cache = dict()
-    exception = None
-
-    parent_plan = plan
-    ret_value = None
-    # seed initial conditions
-    plan_stack.append(plan)
-    result_stack.append(None)
-
-    while True:
-        # get last result
-        if exception is not None:
-            # if we have a stashed exception, pass it along
-            try:
-                msg = plan_stack[-1].throw(exception)
-            except Exception as e:
-                # if we catch an exception,
-                # the current top plan is dead so pop it
-                plan_stack.pop()
-                if plan_stack:
-                    # stash the exception and go to the top
-                    exception = e
-                    continue
-                else:
-                    raise
-            else:
-                exception = None
-        else:
-            ret = result_stack.pop()
-            try:
-                msg = plan_stack[-1].send(ret)
-            except StopIteration as e:
-                # discard the exhausted generator
-                exhausted_gen = plan_stack.pop()
-                # if this is the parent plan, capture it's return value
-                if exhausted_gen is parent_plan:
-                    ret_value = e.value
-
-                # if we just came out of a 'tail' generator,
-                # discard its return value and replace it with the
-                # cached one (from the last message in its paired
-                # 'new_gen')
-                if id(exhausted_gen) in tail_result_cache:
-                    ret = tail_result_cache.pop(id(exhausted_gen))
-
-                result_stack.append(ret)
-
-                if id(exhausted_gen) in tail_cache:
-                    gen = tail_cache.pop(id(exhausted_gen))
-                    if gen is not None:
-                        plan_stack.append(gen)
-                        saved_result = result_stack.pop()
-                        tail_result_cache[id(gen)] = saved_result
-                        # must use None to prime generator
-                        result_stack.append(None)
-
-                if plan_stack:
-                    continue
-                else:
-                    return ret_value
-            except Exception as ex:
-                # we are here because an exception came out of the send
-                # this may be due to
-                # a) the plan really raising or
-                # b) an exception that came out of the run engine via ophyd
-
-                # in either case the current plan is dead so pop it
-                failed_gen = plan_stack.pop()
-                if id(failed_gen) in tail_cache:
-                    gen = tail_cache.pop(id(failed_gen))
-                    if gen is not None:
-                        plan_stack.append(gen)
-                # if there is at least
-                if plan_stack:
-                    exception = ex
-                    continue
-                else:
-                    raise ex
-        # if inserting / mutating, put new generator on the stack
-        # and replace the current msg with the first element from the
-        # new generator
-        if id(msg) not in msgs_seen:
-            # Use the id as a hash, and hold a reference to the msg so that
-            # it cannot be garbage collected until the plan is complete.
-            msgs_seen[id(msg)] = msg
-
-            new_gen, tail_gen = msg_proc(msg)
-            # mild correctness check
-            if tail_gen is not None and new_gen is None:
-                new_gen = single_gen(msg)
-            if new_gen is not None:
-                # stash the new generator
-                plan_stack.append(new_gen)
-                # put in a result value to prime it
-                result_stack.append(None)
-                # stash the tail generator
-                tail_cache[id(new_gen)] = tail_gen
-                # go to the top of the loop
-                continue
-
-        try:
-            # yield out the 'current message' and collect the return
-            inner_ret = yield msg
-        except GeneratorExit:
-            # special case GeneratorExit.  We must clean up all of our plans
-            # and exit with out yielding anything else.
-            for p in plan_stack:
-                p.close()
-            raise
-        except Exception as ex:
-            if plan_stack:
-                exception = ex
-                continue
-            else:
-                raise
-        else:
-            result_stack.append(inner_ret)
-
-
-def msg_mutator(plan, msg_proc):
-    """
-    A simple preprocessor that mutates or deletes single messages in a plan
-
-    To *insert* messages, use ``plan_mutator`` instead.
-
-    Parameters
-    ----------
-    plan : generator
-        a generator that yields messages (`Msg` objects)
-    msg_proc : callable
-        Expected signature `f(msg) -> new_msg or None`
-
-    Yields
-    ------
-    msg : Msg
-        messages from `plan`, altered by `msg_proc`
-
-    See Also
-    --------
-    :func:`bluesky.plans.plan_mutator`
-    """
-    ret = None
-    while True:
-        try:
-            msg = plan.send(ret)
-            msg = msg_proc(msg)
-            # if None, just skip message
-            # feed 'None' back down into the base plan,
-            # this may break some plans
-            if msg is None:
-                ret = None
-                continue
-            ret = yield msg
-        except StopIteration as e:
-            return e.value
-
-
-def pchain(*args):
-    '''Like `itertools.chain` but using `yield from`
-
-    This ensures than `.send` works as expected and the underlying
-    plans get the return values
-
-    Parameters
-    ----------
-    args :
-        generators (plans)
-
-    Yields
-    ------
-    msg : Msg
-        The messages from each plan in turn
-    '''
-    rets = deque()
-    for p in args:
-        rets.append((yield from p))
-    return tuple(rets)
-
-
-def create(name='primary'):
-    """
-    Bundle future readings into a new Event document.
-
-    Parameters
-    ----------
-    name : string, optional
-        name given to event stream, used to convenient identification
-        default is 'primary'
-
-    Yields
-    ------
-    msg : Msg
-        Msg('create', name=name)
-
-    See Also
-    --------
-    :func:`bluesky.plans.save`
-    """
-    return (yield Msg('create', name=name))
-
-
-def save():
-    """
-    Close a bundle of readings and emit a completed Event document.
-
-    Yields
-    -------
-    msg : Msg
-        Msg('save')
-
-    See Also
-    --------
-    :func:`bluesky.plans.create`
-    """
-    return (yield Msg('save'))
-
-
-def read(obj):
-    """
-    Take a reading and add it to the current bundle of readings.
-
-    Parameters
-    ----------
-    obj : Device or Signal
-
-    Yields
-    ------
-    msg : Msg
-        Msg('read', obj)
-    """
-    return (yield Msg('read', obj))
-
-
-def monitor(obj, *, name=None, **kwargs):
-    """
-    Asynchronously monitor for new values and emit Event documents.
-
-    Parameters
-    ----------
-    obj : Signal
-    args :
-        passed through to ``obj.subscribe()``
-    name : string, optional
-        name of event stream; default is None
-    kwargs :
-        passed through to ``obj.subscribe()``
-
-    Yields
-    ------
-    msg : Msg
-        ``Msg('monitor', obj, *args, **kwargs)``
-
-    See Also
-    --------
-    :func:`bluesky.plans.unmonitor`
-    """
-    return (yield Msg('monitor', obj, name=name, **kwargs))
-
-
-def unmonitor(obj):
-    """
-    Stop monitoring.
-
-    Parameters
-    ----------
-    obj : Signal
-
-    Yields
-    ------
-    msg : Msg
-        Msg('unmonitor', obj)
-
-    See Also
-    --------
-    :func:`bluesky.plans.monitor`
-    """
-    return (yield Msg('unmonitor', obj))
-
-
-def null():
-    """
-    Yield a no-op Message. (Primarily for debugging and testing.)
-
-    Yields
-    ------
-    msg : Msg
-        Msg('null')
-    """
-    return (yield Msg('null'))
-
-
-def abs_set(obj, *args, group=None, wait=False, **kwargs):
-    """
-    Set a value. Optionally, wait for it to complete before continuing.
-
-    Parameters
-    ----------
-    obj : Device
-    group : string (or any hashable object), optional
-        identifier used by 'wait'
-    wait : boolean, optional
-        If True, wait for completion before processing any more messages.
-        False by default.
-    args :
-        passed to obj.set()
-    kwargs :
-        passed to obj.set()
-
-    Yields
-    ------
-    msg : Msg
-
-    See Also
-    --------
-    :func:`bluesky.plans.rel_set`
-    :func:`bluesky.plans.wait`
-    :func:`bluesky.plans.mv`
-    """
-    if wait and group is None:
-        group = str(uuid.uuid4())
-    ret = yield Msg('set', obj, *args, group=group, **kwargs)
-    if wait:
-        yield Msg('wait', None, group=group)
-    return ret
-
-
-def rel_set(obj, *args, group=None, wait=False, **kwargs):
-    """
-    Set a value relative to current value. Optionally, wait before continuing.
-
-    Parameters
-    ----------
-    obj : Device
-    group : string (or any hashable object), optional
-        identifier used by 'wait'; None by default
-    wait : boolean, optional
-        If True, wait for completion before processing any more messages.
-        False by default.
-    args :
-        passed to obj.set()
-    kwargs :
-        passed to obj.set()
-
-    Yields
-    ------
-    msg : Msg
-
-    See Also
-    --------
-    :func:`bluesky.plans.abs_set`
-    :func:`bluesky.plans.wait`
-    """
-    return (yield from relative_set_wrapper(
-        abs_set(obj, *args, group=group, wait=wait, **kwargs)))
-
-
-def mv(*args):
-    """
-    Move one or more devices to a setpoint. Wait for all to complete.
-
-    If more than one device is specifed, the movements are done in parallel.
-
-    Parameters
-    ----------
-    args :
-        device1, value1, device2, value2, ...
-
-    Yields
-    ------
-    msg : Msg
-
-    See Also
-    --------
-    :func:`bluesky.plans.abs_set`
-    :func:`bluesky.plans.mvr`
-    """
-    group = str(uuid.uuid4())
-    status_objects = []
-    for obj, val in partition(2, args):
-        ret = yield Msg('set', obj, val, group=group)
-        status_objects.append(ret)
-    yield Msg('wait', None, group=group)
-    return tuple(status_objects)
-
-
-mov = mv  # synonym
-
-
-def mvr(*args):
-    """
-    Move one or more devices to a relative setpoint. Wait for all to complete.
-
-    If more than one device is specifed, the movements are done in parallel.
-
-    Parameters
-    ----------
-    args :
-        device1, value1, device2, value2, ...
-
-    Yields
-    ------
-    msg : Msg
-
-    See Also
-    --------
-    :func:`bluesky.plans.rel_set`
-    :func:`bluesky.plans.mv`
-    """
-    objs = []
-    for obj, val in partition(2, args):
-        objs.append(obj)
-
-    @relative_set_decorator(objs)
-    def inner_mvr():
-        return (yield from mv(*args))
-
-    return (yield from inner_mvr())
-
-
-movr = mvr  # synonym
-
-
-def stop(obj):
-    """
-    Stop a device.
-
-    Parameters
-    ----------
-    obj : Device
-
-    Yields
-    ------
-    msg : Msg
-    """
-    return (yield Msg('stop', obj))
-
-
-def trigger(obj, *, group=None, wait=False):
-    """
-    Trigger and acquisition. Optionally, wait for it to complete.
-
-    Parameters
-    ----------
-    obj : Device
-    group : string (or any hashable object), optional
-        identifier used by 'wait'; None by default
-    wait : boolean, optional
-        If True, wait for completion before processing any more messages.
-        False by default.
-
-    Yields
-    ------
-    msg : Msg
-    """
-    ret = yield Msg('trigger', obj, group=group)
-    if wait:
-        yield Msg('wait', None, group=group)
-    return ret
-
-
-def sleep(time):
-    """
-    Tell the RunEngine to sleep, while asynchronously doing other processing.
-
-    This is not the same as ``import time; time.sleep()`` because it allows
-    other actions, like interruptions, to be processed during the sleep.
-
-    Parameters
-    ----------
-    time : float
-        seconds
-
-    Yields
-    ------
-    msg : Msg
-        Msg('sleep', None, time)
-    """
-    return (yield Msg('sleep', None, time))
-
-
-def wait(group=None):
-    """
-    Wait for all statuses in a group to report being finished.
-
-    Parameters
-    ----------
-    group : string (or any hashable object), optional
-        idenified given to `abs_set`, `rel_set`, `trigger`; None by default
-
-    Yields
-    ------
-    msg : Msg
-        Msg('wait', None, group=group)
-    """
-    return (yield Msg('wait', None, group=group))
-
-
-_wait = wait  # for internal references to avoid collision with 'wait' kwarg
-
-
-def checkpoint():
-    """
-    If interrupted, rewind to this point.
-
-    Yields
-    ------
-    msg : Msg
-        Msg('checkpoint')
-
-    See Also
-    --------
-    :func:`bluesky.plans.clear_checkpoint`
-    """
-    return (yield Msg('checkpoint'))
-
-
-def clear_checkpoint():
-    """
-    Designate that it is not safe to resume. If interrupted or paused, abort.
-
-    Yields
-    ------
-    msg : Msg
-        Msg('clear_checkpoint')
-
-    See Also
-    --------
-    :func:`bluesky.plans.checkpoint`
-    """
-    return (yield Msg('clear_checkpoint'))
-
-
-def pause():
-    """
-    Pause and wait for the user to resume.
-
-    Yields
-    ------
-    msg : Msg
-        Msg('pause')
-
-    See Also
-    --------
-    :func:`bluesky.plans.deferred_pause`
-    :func:`bluesky.plans.sleep`
-    """
-    return (yield Msg('pause', None, defer=False))
-
-
-def deferred_pause():
-    """
-    Pause at the next checkpoint.
-
-    Yields
-    ------
-    msg : Msg
-        Msg('pause', defer=True)
-
-    See Also
-    --------
-    :func:`bluesky.plans.pause`
-    :func:`bluesky.plans.sleep`
-    """
-    return (yield Msg('pause', None, defer=True))
-
-
-def input_plan(prompt=''):
-    """
-    Prompt the user for text input.
-
-    Parameters
-    ----------
-    prompt : str
-        prompt string, e.g., 'enter user name' or 'enter next position'
-
-    Yields
-    ------
-    msg : Msg
-        Msg('input', prompt=prompt)
-    """
-    return (yield Msg('input', prompt=prompt))
-
-
-def kickoff(obj, *, group=None, wait=False, **kwargs):
-    """
-    Kickoff a fly-scanning device.
-
-    Parameters
-    ----------
-    obj : fly-able
-        Device with 'kickoff', 'complete', and 'collect' methods
-    group : string (or any hashable object), optional
-        identifier used by 'wait'
-    wait : boolean, optional
-        If True, wait for completion before processing any more messages.
-        False by default.
-    kwargs
-        passed through to ``obj.kickoff()``
-
-    Yields
-    ------
-    msg : Msg
-        Msg('kickoff', obj)
-
-    See Also
-    --------
-    :func:`bluesky.plans.complete`
-    :func:`bluesky.plans.collect`
-    :func:`bluesky.plans.wait`
-    """
-    ret = (yield Msg('kickoff', obj, group=group, **kwargs))
-    if wait:
-        yield from _wait(group=group)
-    return ret
-
-
-def complete(obj, *, group=None, wait=False, **kwargs):
-    """
-    Tell a flyer, 'stop collecting, whenver you are ready'.
-
-    The flyer returns a status object. Some flyers respond to this
-    command by stopping collection and returning a finished status
-    object immedately. Other flyers finish their given course and
-    finish whenever they finish, irrespective of when this command is
-    issued.
-
-    Parameters
-    ----------
-    obj : fly-able
-        Device with 'kickoff', 'complete', and 'collect' methods
-    group : string (or any hashable object), optional
-        identifier used by 'wait'
-    wait : boolean, optional
-        If True, wait for completion before processing any more messages.
-        False by default.
-    kwargs
-        passed through to ``obj.complete()``
-
-    Yields
-    ------
-    msg : Msg
-        a 'complete' Msg and maybe a 'wait' message
-
-    See Also
-    --------
-    :func:`bluesky.plans.kickoff`
-    :func:`bluesky.plans.collect`
-    :func:`bluesky.plans.wait`
-    """
-    ret = yield Msg('complete', obj, group=group, **kwargs)
-    if wait:
-        yield from _wait(group=group)
-    return ret
-
-
-def collect(obj, *, stream=False):
-    """
-    Collect data cached by a fly-scanning device and emit documents.
-
-    Parameters
-    ----------
-    obj : fly-able
-        Device with 'kickoff', 'complete', and 'collect' methods
-    stream : boolean
-        If False (default), emit events documents in one bulk dump. If True,
-        emit events one at time.
-
-    Yields
-    ------
-    msg : Msg
-        Msg('collect', obj)
-
-    See Also
-    --------
-    :func:`bluesky.plans.kickoff`
-    :func:`bluesky.plans.complete`
-    :func:`bluesky.plans.wait`
-    """
-    return (yield Msg('collect', obj, stream=stream))
-
-
-def configure(obj, *args, **kwargs):
-    """
-    Change Device configuration and emit an updated Event Descriptor document.
-
-    Parameters
-    ----------
-    obj : Device
-    args
-        passed through to ``obj.configure()``
-    kwargs
-        passed through to ``obj.configure()``
-
-    Yields
-    ------
-    msg : Msg
-        ``Msg('configure', obj, *args, **kwargs)``
-    """
-    return (yield Msg('configure', obj, *args, **kwargs))
-
-
-def stage(obj):
-    """
-    'Stage' a device (i.e., prepare it for use, 'arm' it).
-
-    Parameters
-    ----------
-    obj : Device
-
-    Yields
-    ------
-    msg : Msg
-        Msg('stage', obj)
-
-    See Also
-    --------
-    :func:`bluesky.plans.unstage`
-    """
-    return (yield Msg('stage', obj))
-
-
-def unstage(obj):
-    """
-    'Unstage' a device (i.e., put it in standby, 'disarm' it).
-
-    Parameters
-    ----------
-    obj : Device
-
-    Yields
-    ------
-    msg : Msg
-        Msg('unstage', obj)
-
-    See Also
-    --------
-    :func:`bluesky.plans.stage`
-    """
-    return (yield Msg('unstage', obj))
-
-
-def subscribe(name, func):
-    """
-    Subscribe the stream of emitted documents.
-
-    Parameters
-    ----------
-    name : {'all', 'start', 'descriptor', 'event', 'stop'}
-    func : callable
-        Expected signature: ``f(name, doc)`` where ``name`` is one of the
-        strings above ('all, 'start', ...) and ``doc`` is a dict
-
-    Yields
-    ------
-    msg : Msg
-        Msg('subscribe', None, func, name)
-
-    See Also
-    --------
-    :func:`bluesky.plans.unsubscribe`
-    """
-    return (yield Msg('subscribe', None, func, name))
-
-
-def unsubscribe(token):
-    """
-    Remove a subscription.
-
-    Parameters
-    ----------
-    token : int
-        token returned by processing a 'subscribe' message
-
-    Yields
-    ------
-    msg : Msg
-        Msg('unsubscribe', token=token)
-
-    See Also
-    --------
-    :func:`bluesky.plans.subscribe`
-    """
-    return (yield Msg('unsubscribe', token=token))
-
-
-def print_summary_wrapper(plan):
-    """Print summary of plan as it goes by
-
-    Prints a minimal version of the plan, showing only moves and
-    where events are created.  Yields the `Msg` unchanged.
-
-    Parameters
-    ----------
-    plan : iterable
-        Must yield `Msg` objects
-
-    Yields
-    ------
-    msg : `Msg`
-    """
-
-    read_cache = []
-    for msg in plan:
-        cmd = msg.command
-        if cmd == 'open_run':
-            print('{:=^80}'.format(' Open Run '))
-        elif cmd == 'close_run':
-            print('{:=^80}'.format(' Close Run '))
-        elif cmd == 'set':
-            print('{motor.name} -> {args[0]}'.format(motor=msg.obj,
-                                                     args=msg.args))
-        elif cmd == 'create':
-            pass
-        elif cmd == 'read':
-            read_cache.append(msg.obj.name)
-        elif cmd == 'save':
-            print('  Read {}'.format(read_cache))
-            read_cache = []
-        yield msg
-
-
-def run_wrapper(plan, *, md=None):
-    """Enclose in 'open_run' and 'close_run' messages.
-
-    Parameters
-    ----------
-    plan : iterable or iterator
-        a generator, list, or similar containing `Msg` objects
-    md : dict, optional
-        metadata to be passed into the 'open_run' message
-    """
-    rs_uid = yield from open_run(md)
-
-    def except_plan(e):
-        if isinstance(e, RunEngineControlException):
-            yield from close_run()
-        else:
-            yield from close_run(exit_status='fail', reason=str(e))
-
-    yield from contingency_wrapper(plan,
-                            except_plan=except_plan,
-                            else_plan=close_run
-                            )
-    return rs_uid
-
-
-def subs_wrapper(plan, subs):
-    """
-    Subscribe callbacks to the document stream; finally, unsubscribe.
-
-    Parameters
-    ----------
-    plan : iterable or iterator
-        a generator, list, or similar containing `Msg` objects
-    subs : callable, list of callables, or dict of lists of callables
-         Documents of each type are routed to a list of functions.
-         Input is normalized to a dict of lists of functions, like so:
-
-         None -> {'all': [], 'start': [], 'stop': [], 'event': [],
-                  'descriptor': []}
-
-         func -> {'all': [func], 'start': [], 'stop': [], 'event': [],
-                  'descriptor': []}
-
-         [f1, f2] -> {'all': [f1, f2], 'start': [], 'stop': [], 'event': [],
-                      'descriptor': []}
-
-         {'event': [func]} ->  {'all': [], 'start': [], 'stop': [],
-                                'event': [func], 'descriptor': []}
-
-         Signature of functions must confirm to `f(name, doc)` where
-         name is one of {'all', 'start', 'stop', 'event', 'descriptor'} and
-         doc is a dictionary.
-
-    Yields
-    ------
-    msg : Msg
-        messages from plan, with 'subscribe' and 'unsubscribe' messages
-        inserted and appended
-    """
-    subs = normalize_subs_input(subs)
-    tokens = set()
-
-    def _subscribe():
-        for name, funcs in subs.items():
-            for func in funcs:
-                token = yield Msg('subscribe', None, func, name)
-                tokens.add(token)
-
-    def _unsubscribe():
-        for token in tokens:
-            yield Msg('unsubscribe', None, token=token)
-
-    def _inner_plan():
-        yield from _subscribe()
-        return (yield from plan)
-
-    return (yield from finalize_wrapper(_inner_plan(),
-                                        _unsubscribe()))
-
-
-def configure_count_time_wrapper(plan, time):
-    """
-    Preprocessor that sets all devices with a `count_time` to the same time.
-
-    The original setting is stashed and restored at the end.
-
-    Parameters
-    ----------
-    plan : iterable or iterator
-        a generator, list, or similar containing `Msg` objects
-    time : float or None
-        If None, the plan passes through unchanged.
-
-    Yields
-    ------
-    msg : Msg
-        messages from plan, with 'set' messages inserted
-    """
-    devices_seen = set()
-    original_times = {}
-
-    def insert_set(msg):
-        obj = msg.obj
-        if obj is not None and obj not in devices_seen:
-            devices_seen.add(obj)
-            if hasattr(obj, 'count_time'):
-                # TODO Do this with a 'read' Msg once reads can be
-                # marked as belonging to a different event stream (or no
-                # event stream.
-                original_times[obj] = obj.count_time.get()
-                # TODO do this with configure
-                return pchain(mv(obj.count_time, time),
-                              single_gen(msg)), None
-        return None, None
-
-    def reset():
-        for obj, time in original_times.items():
-            yield from mv(obj.count_time, time)
-
-    if time is None:
-        # no-op
-        return (yield from plan)
-    else:
-        return (yield from finalize_wrapper(plan_mutator(plan, insert_set),
-                                            reset()))
-
-
-def open_run(md=None):
-    """
-    Mark the beginning of a new 'run'. Emit a RunStart document.
-
-    Parameters
-    ----------
-    md : dict, optional
-        metadata
-
-    Yields
-    ------
-    msg : Msg
-        ``Msg('open_run', **md)``
-
-    See Also
-    --------
-    :func:`bluesky.plans.close_run`
-    """
-    return (yield Msg('open_run', **(md or {})))
-
-
-def close_run(exit_status=None, reason=None):
-    """
-    Mark the end of the current 'run'. Emit a RunStop document.
-
-    Yields
-    ------
-    msg : Msg
-        Msg('close_run')
-    exit_status : {None, 'success', 'abort', 'fail'}
-        The exit status to report in the Stop document
-    reason : str, optional
-        Long-form description of why the run ended
-
-    See Also
-    --------
-    :func:`bluesky.plans.open_run`
-    """
-    return (yield Msg('close_run', exit_status=exit_status, reason=reason))
-
-
-def wait_for(futures, **kwargs):
-    """
-    Low-level: wait for a list of ``asyncio.Future`` objects to set (complete).
-
-    Parameters
-    ----------
-    futures : collection
-        collection of asyncio.Future objects
-    kwargs
-        passed through to ``asyncio.wait()``
-
-    Yields
-    ------
-    msg : Msg
-        ``Msg('wait_for', None, futures, **kwargs)``
-
-    See Also
-    --------
-    :func:`bluesky.plans.wait`
-    """
-    return (yield Msg('wait_for', None, futures, **kwargs))
-
-
-def finalize_wrapper(plan, final_plan, *, pause_for_debug=False):
-    '''try...finally helper
-
-    Run the first plan and then the second.  If any of the messages
-    raise an error in the RunEngine (or otherwise), the second plan
-    will attempted to be run anyway.
-
-    Parameters
-    ----------
-    plan : iterable or iterator
-        a generator, list, or similar containing `Msg` objects
-    final_plan : callable, iterable or iterator
-        a generator, list, or similar containing `Msg` objects or a callable
-        that reurns one; attempted to be run no matter what happens in the
-        first plan
-    pause_for_debug : bool, optional
-        If the plan should pause before running the clean final_plan in
-        the case of an Exception.  This is intended as a debugging tool only.
-    Yields
-    ------
-    msg : Msg
-        messages from `plan` until it terminates or an error is raised, then
-        messages from `final_plan`
-    '''
-    # If final_plan is a generator *function* (as opposed to a generator
-    # *instance*), call it.
-    if callable(final_plan):
-        final_plan_instance = final_plan()
-    else:
-        final_plan_instance = final_plan
-    cleanup = True
-    try:
-        ret = yield from plan
-    except GeneratorExit:
-        cleanup = False
-        raise
-    except:
-        if pause_for_debug:
-            yield from pause()
-        raise
-    finally:
-        # if the exception raised in `GeneratorExit` that means
-        # someone called `gen.close()` on this generator.  In those
-        # cases generators must either re-raise the GeneratorExit or
-        # raise a different exception.  Trying to yield any values
-        # results in a RuntimeError being raised where `close` is
-        # called.  Thus, we catch, the GeneratorExit, disable cleanup
-        # and then re-raise
-
-        # https://docs.python.org/3/reference/expressions.html?#generator.close
-        if cleanup:
-            yield from ensure_generator(final_plan_instance)
-    return ret
-
-
-def contingency_wrapper(plan, *,
-                        except_plan=None,
-                        else_plan=None,
-                        final_plan=None,
-                        pause_for_debug=False):
-    '''try...except...else...finally helper
-
-    Run the first plan and then the second.  If any of the messages
-    raise an error in the RunEngine (or otherwise), the second plan
-    will attempted to be run anyway.
-
-    Parameters
-    ----------
-    plan : iterable or iterator
-        a generator, list, or similar containing `Msg` objects
-    except_plan : generator function, optional
-        this will be called with the exception as the only input.  The
-        plan does not need to re-raise, but may if you want to change the
-        exception.
-
-        Only subclasses of `Exception` will be passed in, will not see
-        `GeneratorExit`, `SystemExit`, or `KeyboardInterrupt`
-    else_plan : generator function, optional
-        well be called with no arguments if plan completes without raising
-    final_plan : generator function, optional
-        a generator, list, or similar containing `Msg` objects or a callable
-        that reurns one; attempted to be run no matter what happens in the
-        first plan
-    pause_for_debug : bool, optional
-        If the plan should pause before running the clean final_plan in
-        the case of an Exception.  This is intended as a debugging tool only.
-    Yields
-    ------
-    msg : Msg
-        messages from `plan` until it terminates or an error is raised, then
-        messages from `final_plan`
-    '''
-    cleanup = True
-    try:
-        ret = yield from plan
-    except GeneratorExit:
-        cleanup = False
-        raise
-    except Exception as e:
-        if pause_for_debug:
-            yield from pause()
-        if except_plan:
-            # it might be better to throw this in, but this is simpler
-            # to implement for now
-            yield from except_plan(e)
-        raise
-    else:
-        if else_plan:
-            yield from else_plan()
-    finally:
-        # if the exception raised in `GeneratorExit` that means
-        # someone called `gen.close()` on this generator.  In those
-        # cases generators must either re-raise the GeneratorExit or
-        # raise a different exception.  Trying to yield any values
-        # results in a RuntimeError being raised where `close` is
-        # called.  Thus, we catch, the GeneratorExit, disable cleanup
-        # and then re-raise
-
-        # https://docs.python.org/3/reference/expressions.html?#generator.close
-        if cleanup and final_plan:
-            yield from final_plan()
-    return ret
-
-
-def finalize_decorator(final_plan):
-    '''try...finally helper
-
-    Run the first plan and then the second.  If any of the messages
-    raise an error in the RunEngine (or otherwise), the second plan
-    will attempted to be run anyway.
-
-    Notice that, this decorator requires a generator *function* so that it can
-    be used multiple times, whereas :func:`bluesky.plans.finalize_wrapper`
-    accepts either a generator function or a generator instance.
-
-    Parameters
-    ----------
-    final_plan : callable
-        a callable that returns a generator, list, or similar containing `Msg`
-        objects; attempted to be run no matter what happens in the first plan
-
-    Yields
-    ------
-    msg : Msg
-        messages from `plan` until it terminates or an error is raised, then
-        messages from `final_plan`
-    '''
-    def dec(gen_func):
-        @wraps(gen_func)
-        def dec_inner(*inner_args, **inner_kwargs):
-            if not callable(final_plan):
-                raise TypeError("final_plan must be a callable (e.g., a "
-                                "generator function) not an iterable (e.g., a "
-                                "generator instance).")
-            final_plan_instance = final_plan()
-            plan = gen_func(*inner_args, **inner_kwargs)
-            cleanup = True
-            try:
-                ret = yield from plan
-            except GeneratorExit:
-                cleanup = False
-                raise
-            finally:
-                # if the exception raised in `GeneratorExit` that means
-                # someone called `gen.close()` on this generator.  In those
-                # cases generators must either re-raise the GeneratorExit or
-                # raise a different exception.  Trying to yield any values
-                # results in a RuntimeError being raised where `close` is
-                # called.  Thus, we catch, the GeneratorExit, disable cleanup
-                # and then re-raise
-
-                # https://docs.python.org/3/reference/expressions.html?#generator.close
-                if cleanup:
-                    yield from ensure_generator(final_plan_instance)
-            return ret
-        return dec_inner
-    return dec
-
-
-@contextmanager
-def subs_context(plan_stack, subs):
-    """
-    Subscribe callbacks to the document stream; then unsubscribe on exit.
-
-    .. deprecated:: 0.10.0
-        Use :func:`subs_wrapper` or :func:`subs_decorator` instead.
-
-    Parameters
-    ----------
-    plan_stack : list-like
-        appendable collection of generators that yield messages (`Msg` objects)
-    subs : callable, list of callables, or dict of lists of callables
-         Documents of each type are routed to a list of functions.
-         Input is normalized to a dict of lists of functions, like so:
-
-         None -> {'all': [], 'start': [], 'stop': [], 'event': [],
-                  'descriptor': []}
-
-         func -> {'all': [func], 'start': [], 'stop': [], 'event': [],
-                  'descriptor': []}
-
-         [f1, f2] -> {'all': [f1, f2], 'start': [], 'stop': [], 'event': [],
-                      'descriptor': []}
-
-         {'event': [func]} ->  {'all': [], 'start': [], 'stop': [],
-                                'event': [func], 'descriptor': []}
-
-         Signature of functions must confirm to `f(name, doc)` where
-         name is one of {'all', 'start', 'stop', 'event', 'descriptor'} and
-         doc is a dictionary.
-    """
-    warn("subs_context is deprecated. Use subs_wrapper or subs_decorator.")
-    subs = normalize_subs_input(subs)
-    tokens = set()
-
-    def _subscribe():
-        for name, funcs in subs.items():
-            for func in funcs:
-                token = yield Msg('subscribe', None, func, name)
-                tokens.add(token)
-
-    def _unsubscribe():
-        for token in tokens:
-            yield Msg('unsubscribe', None, token=token)
-
-    plan_stack.append(_subscribe())
-    try:
-        yield plan_stack
-    finally:
-        # The RunEngine might never process these if the execution fails,
-        # but it keeps its own cache of tokens and will try to remove them
-        # itself if this plan fails to do so.
-        plan_stack.append(_unsubscribe())
-
-
-@contextmanager
-def run_context(plan_stack, *, md=None):
-    """Enclose in 'open_run' and 'close_run' messages.
-
-    .. deprecated:: 0.10.0
-        Use :func:`run_wrapper` or :func:`run_decorator` instead.
-
-    Parameters
-    ----------
-    plan_stack : list-like
-        appendable collection of generators that yield messages (`Msg` objects)
-    md : dict, optional
-        metadata to be passed into the 'open_run' message
-    """
-    warn("run_context is deprecated. Use run_wrapper or run_decorator.")
-    plan_stack.append(single_gen(Msg('open_run', None, **dict(md or {}))))
-    yield plan_stack
-    plan_stack.append(single_gen(Msg('close_run')))
-
-
-@contextmanager
-def event_context(plan_stack, name='primary'):
-    """Bundle readings into an 'event' (a datapoint).
-
-    This encloses the contents in 'create' and 'save' messages.
-
-    .. deprecated:: 0.10.0
-        Use the :func:`create` and :func:`save` plans directly. Also,
-        :func:`trigger_and_read` addresses the common case of reading one or
-        more devices into one Event.
-
-    Parameters
-    ----------
-    plan_stack : list-like
-        appendable collection of generators that yield messages (`Msg` objects)
-    name : string, optional
-        name of event stream; default is 'primary'
-    """
-    warn("event_context is deprecated. Use create, save, or trigger_and_read.")
-    plan_stack.append(single_gen(Msg('create', None, name=name)))
-    yield plan_stack
-    plan_stack.append(single_gen(Msg('save')))
-
-
-def rewindable_wrapper(plan, rewindable):
-    '''Toggle the 'rewindable' state of the RE
-
-    Allow or disallow rewinding during the processing of the wrapped messages.
-    Then restore the initial state (rewindable or not rewindable).
-
-    Parameters
-    ----------
-    plan : generator
-        The plan to wrap in a 'rewindable' or 'not rewindable' context
-    rewindable : bool
-
-    '''
-    initial_rewindable = True
-
-    def capture_rewindable_state():
-        nonlocal initial_rewindable
-        initial_rewindable = yield Msg('rewindable', None, None)
-
-    def set_rewindable(rewindable):
-        if initial_rewindable != rewindable:
-            return (yield Msg('rewindable', None, rewindable))
-
-    def restore_rewindable():
-        if initial_rewindable != rewindable:
-            return (yield Msg('rewindable', None, initial_rewindable))
-
-    if not rewindable:
-        yield from capture_rewindable_state()
-        yield from set_rewindable(rewindable)
-        return (yield from finalize_wrapper(plan,
-                                            restore_rewindable()))
-    else:
-        return (yield from plan)
-
-
-def fly(flyers, *, md=None):
-    """
-    Perform a fly scan with one or more 'flyers'.
-
-    Parameters
-    ----------
-    flyers : collection
-        objects that support the flyer interface
-    md : dict, optional
-        metadata
-
-    Yields
-    ------
-    msg : Msg
-        'kickoff', 'wait', 'complete, 'wait', 'collect' messages
-
-    See Also
-    --------
-    :func:`bluesky.plans.fly_during`
-    """
-    yield from open_run(md)
-    for flyer in flyers:
-        yield from kickoff(flyer, wait=True)
-    for flyer in flyers:
-        yield from complete(flyer, wait=True)
-    for flyer in flyers:
-        yield from collect(flyer)
-    yield from close_run()
-
-
-def inject_md_wrapper(plan, md):
-    """
-    Inject additional metadata into a run.
-
-    This takes precedences over the original metadata dict in the event of
-    overlapping keys, but it does not mutate the original metadata dict.
-    (It uses ChainMap.)
-
-    Parameters
-    ----------
-    plan : iterable or iterator
-        a generator, list, or similar containing `Msg` objects
-    md : dict
-        metadata
-    """
-    def _inject_md(msg):
-        if msg.command == 'open_run':
-            msg = msg._replace(kwargs=ChainMap(md, msg.kwargs))
-        return msg
-
-    return (yield from msg_mutator(plan, _inject_md))
-
-
-def stub_wrapper(plan):
-    """
-    Remove Msg object in order to use plan as a stub
-
-    This will remove any `open_run`, `close_run`, `stage` and `unstage` `Msg`
-    objects present in the plan in order for it to be run as part of a larger
-    scan. Note, that any metadata from the provided plan will not be sent to
-    the RunEngine automatically.
-
-    Parameters
-    ----------
-    plan : iterable or iterator
-        A generator list or similar containing `Msg` objects
-
-    Returns
-    -------
-    md : dict
-        Metadata discovered from `open_run` Msg
-    """
-    md = {}
-
-    def _block_run_control(msg):
-        """
-        Block open and close run messages
-        """
-        #Capture the metadata from open_run
-        if msg.command == 'open_run':
-            md.update(msg.kwargs)
-            return None
-        elif msg.command in ('close_run', 'stage', 'unstage'):
-            return None
-        return msg
-
-    yield from msg_mutator(plan, _block_run_control)
-    return md
-
-
-def monitor_during_wrapper(plan, signals):
-    """
-    Monitor (asynchronously read) devices during runs.
-
-    This is a preprocessor that insert messages immediately after a run is
-    opened and before it is closed.
-
-    Parameters
-    ----------
-    plan : iterable or iterator
-        a generator, list, or similar containing `Msg` objects
-    signals : collection
-        objects that support the Signal interface
-
-    Yields
-    ------
-    msg : Msg
-        messages from plan with 'monitor', and 'unmontior' messages inserted
-
-    See Also
-    --------
-    :func:`bluesky.plans.fly_during_wrapper`
-    """
-    monitor_msgs = [Msg('monitor', sig, name=sig.name + '_monitor')
-                    for sig in signals]
-    unmonitor_msgs = [Msg('unmonitor', sig) for sig in signals]
-
-    def insert_after_open(msg):
-        if msg.command == 'open_run':
-            def new_gen():
-                yield from ensure_generator(monitor_msgs)
-            return single_gen(msg), new_gen()
-        else:
-            return None, None
-
-    def insert_before_close(msg):
-        if msg.command == 'close_run':
-            def new_gen():
-                yield from ensure_generator(unmonitor_msgs)
-                yield msg
-            return new_gen(), None
-        else:
-            return None, None
-
-    # Apply nested mutations.
-    plan1 = plan_mutator(plan, insert_after_open)
-    plan2 = plan_mutator(plan1, insert_before_close)
-    return (yield from plan2)
-
-
-def fly_during_wrapper(plan, flyers):
-    """
-    Kickoff and collect "flyer" (asynchronously collect) objects during runs.
-
-    This is a preprocessor that insert messages immediately after a run is
-    opened and before it is closed.
-
-    Parameters
-    ----------
-    plan : iterable or iterator
-        a generator, list, or similar containing `Msg` objects
-    flyers : collection
-        objects that support the flyer interface
-
-    Yields
-    ------
-    msg : Msg
-        messages from plan with 'kickoff', 'wait' and 'collect' messages
-        inserted
-
-    See Also
-    --------
-    :func:`bluesky.plans.fly`
-    """
-    grp1 = _short_uid('flyers-kickoff')
-    grp2 = _short_uid('flyers-complete')
-    kickoff_msgs = [Msg('kickoff', flyer, group=grp1) for flyer in flyers]
-    complete_msgs = [Msg('complete', flyer, group=grp2) for flyer in flyers]
-    collect_msgs = [Msg('collect', flyer) for flyer in flyers]
-    if flyers:
-        # If there are any flyers, insert a 'wait' Msg after kickoff, complete
-        kickoff_msgs += [Msg('wait', None, group=grp1)]
-        complete_msgs += [Msg('wait', None, group=grp2)]
-
-    def insert_after_open(msg):
-        if msg.command == 'open_run':
-            def new_gen():
-                yield from ensure_generator(kickoff_msgs)
-            return single_gen(msg), new_gen()
-        else:
-            return None, None
-
-    def insert_before_close(msg):
-        if msg.command == 'close_run':
-            def new_gen():
-                yield from ensure_generator(complete_msgs)
-                yield from ensure_generator(collect_msgs)
-                yield msg
-            return new_gen(), None
-        else:
-            return None, None
-
-    # Apply nested mutations.
-    plan1 = plan_mutator(plan, insert_after_open)
-    plan2 = plan_mutator(plan1, insert_before_close)
-    return (yield from plan2)
-
-
-def lazily_stage_wrapper(plan):
-    """
-    This is a preprocessor that inserts 'stage' messages and appends 'unstage'.
-
-    The first time an object is seen in `plan`, it is staged. To avoid
-    redundant staging we actually stage the object's ultimate parent.
-
-    At the end, in a `finally` block, an 'unstage' Message issued for every
-    'stage' Message.
-
-    Parameters
-    ----------
-    plan : iterable or iterator
-        a generator, list, or similar containing `Msg` objects
-
-    Yields
-    ------
-    msg : Msg
-        messages from plan with 'stage' messages inserted and 'unstage'
-        messages appended
-    """
-    COMMANDS = set(['read', 'set', 'trigger', 'kickoff'])
-    # Cache devices in the order they are staged; then unstage in reverse.
-    devices_staged = []
-
-    def inner(msg):
-        if msg.command in COMMANDS and msg.obj not in devices_staged:
-            root = root_ancestor(msg.obj)
-
-            def new_gen():
-                # Here we insert a 'stage' message
-                ret = yield Msg('stage', root)
-                # and cache the result
-                if ret is None:
-                    # The generator may be being list-ified.
-                    # This is a hack to make that possible.
-                    ret = [root]
-                devices_staged.extend(ret)
-                # and then proceed with our regularly scheduled programming
-                yield msg
-            return new_gen(), None
-        else:
-            return None, None
-
-    def unstage_all():
-        for device in reversed(devices_staged):
-            yield Msg('unstage', device)
-
-    return (yield from finalize_wrapper(plan_mutator(plan, inner),
-                                        unstage_all()))
-
-
-@contextmanager
-def stage_context(plan_stack, devices):
-    """
-    Stage devices upon entering context and unstage upon exiting.
-
-    .. deprecated:: 0.10.0
-        Use :func:`stage_wrapper` or :func:`stage_decorator`.
-
-    Parameters
-    ----------
-    plan_stack : list-like
-        appendable collection of generators that yield messages (`Msg` objects)
-    devices : collection
-        list of devices to stage immediately on entrance and unstage on exit
-
-    See Also
-    --------
-    :func:`bluesky.plans.lazily_stage`
-    """
-    warn("stage_context is deprecated. Use stage_wrapper or stage_decorator.")
-    # Resolve unique devices, avoiding redundant staging.
-    devices = separate_devices(root_ancestor(device) for device in devices)
-
-    def stage():
-        # stage devices explicitly passed to 'devices' argument
-        yield from broadcast_msg('stage', devices)
-
-    def unstage():
-        # unstage devices explicitly passed to 'devices' argument
-        yield from broadcast_msg('unstage', reversed(devices))
-
-    plan_stack.append(stage())
-    yield plan_stack
-    plan_stack.append(unstage())
-
-
-def stage_wrapper(plan, devices):
-    """
-    'Stage' devices (i.e., prepare them for use, 'arm' them) and then unstage.
-
-    Parameters
-    ----------
-    plan : iterable or iterator
-        a generator, list, or similar containing `Msg` objects
-    devices : collection
-        list of devices to stage immediately on entrance and unstage on exit
-
-    Yields
-    ------
-    msg : Msg
-        messages from plan with 'stage' and finally 'unstage' messages inserted
-
-    See Also
-    --------
-    :func:`bluesky.plans.lazily_stage_wrapper`
-    :func:`bluesky.plans.stage`
-    :func:`bluesky.plans.unstage`
-    """
-    devices = separate_devices(root_ancestor(device) for device in devices)
-
-    def stage_devices():
-        for d in devices:
-            yield Msg('stage', d)
-
-    def unstage_devices():
-        for d in reversed(devices):
-            yield Msg('unstage', d)
-
-    def inner():
-        yield from stage_devices()
-        return (yield from plan)
-
-    return (yield from finalize_wrapper(inner(), unstage_devices()))
-
-
-def _normalize_devices(devices):
-    coupled_parents = set()
-    # if we have any pseudo devices then setting any part of it
-    # needs to trigger the relative behavior.
-    io, co, go = merge_axis(devices)
-    devices = set(devices) | set(io) | set(co) | set(go)
-    # if a device with coupled children is directly in the
-    # list, include all the coupled children as well
-    for obj in co:
-        devices |= set(obj.pseudo_positioners)
-        coupled_parents.add(obj)
-
-    # if at least one child of a device with coupled children
-    # only include the coupled children if at least of the children
-    # directly included is one of the coupled ones.
-    for obj, type_map in go.items():
-        if len(type_map['pseudo']) > 0:
-            devices |= set(obj.pseudo_positioners)
-            coupled_parents.add(obj)
-    return devices, coupled_parents
-
-
-def __read_and_stash_a_motor(obj, initial_positions, coupled_parents):
-    """Internal plan for relative set and reset wrappers
-
-
-    .. warning ::
-
-       Do not use this plan directly for any reason.
-
-    """
-    # obj should have a `position` attribution
-    try:
-        cur_pos = obj.position
-    except AttributeError:
-        # ... but as a fallback we can read obj and grab the value of the
-        # first key
-        reading = yield Msg('read', obj)
-        if reading is None:
-            # this plan may be being list-ified
-            cur_pos = 0
-        else:
-            fields = getattr(obj, 'hints', {}).get('fields', [])
-            if len(fields) == 1:
-                k, = fields
-                cur_pos = reading[k]['value']
-            elif len(fields) == 0:
-                k = list(reading.keys())[0]
-                cur_pos = reading[k]['value']
-            else:
-                raise Exception("do not yet know how to deal with "
-                                "non pseudopositioner multi-axis.  Please "
-                                "contact DAMA to justify why you need "
-                                "this.")
-
-    initial_positions[obj] = cur_pos
-
-    # if we move a pseudo positioner also stash it's children
-    if obj in coupled_parents:
-        for c, p in zip(obj.pseudo_positioners, cur_pos):
-            initial_positions[c] = p
-
-    # if we move a pseudo single, also stash it's parent and siblings
-    parent = obj.parent
-    if parent in coupled_parents and obj in parent.pseudo_positioners:
-        parent_pos = parent.position
-        initial_positions[parent] = parent_pos
-        for c, p in zip(parent.pseudo_positioners, parent_pos):
-            initial_positions[c] = p
-
-    # TODO forbid mixed pseudo / real motion
-
-
-def relative_set_wrapper(plan, devices=None):
-    """
-    Interpret 'set' messages on devices as relative to initial position.
-
-    Parameters
-    ----------
-    plan : iterable or iterator
-        a generator, list, or similar containing `Msg` objects
-    devices : collection or None, optional
-        if default (None), apply to all devices that are moved by the plan
-
-    Yields
-    ------
-    msg : Msg
-        messages from plan, with 'read' messages inserted and 'set' messages
-        mutated
-    """
-    initial_positions = {}
-    if devices is not None:
-        devices, coupled_parents = _normalize_devices(devices)
-    else:
-        coupled_parents = set()
-
-    def rewrite_pos(msg):
-        if (msg.command == 'set') and (msg.obj in initial_positions):
-            rel_pos, = msg.args
-            abs_pos = initial_positions[msg.obj] + rel_pos
-            new_msg = msg._replace(args=(abs_pos,))
-            return new_msg
-        else:
-            return msg
-
-    def insert_reads(msg):
-        eligible = (devices is None) or (msg.obj in devices)
-        seen = msg.obj in initial_positions
-        if (msg.command == 'set') and eligible and not seen:
-                return (pchain(
-                    __read_and_stash_a_motor(
-                        msg.obj, initial_positions, coupled_parents),
-                    single_gen(msg)), None)
-        else:
-            return None, None
-
-    plan = plan_mutator(plan, insert_reads)
-    plan = msg_mutator(plan, rewrite_pos)
-    return (yield from plan)
-
-
-def reset_positions_wrapper(plan, devices=None):
-    """
-    Return movable devices to their initial positions at the end.
-
-    Parameters
-    ----------
-    plan : iterable or iterator
-        a generator, list, or similar containing `Msg` objects
-    devices : collection or None, optional
-        If default (None), apply to all devices that are moved by the plan.
-
-    Yields
-    ------
-    msg : Msg
-        messages from plan with 'read' and finally 'set' messages inserted
-    """
-    initial_positions = OrderedDict()
-    if devices is not None:
-        devices, coupled_parents = _normalize_devices(devices)
-    else:
-        coupled_parents = set()
-
-    def read_and_stash_a_motor(obj):
-        try:
-            cur_pos = obj.position
-        except AttributeError:
-            reading = yield Msg('read', obj)
-            if reading is None:
-                # this plan may be being list-ified
-                cur_pos = 0
-            else:
-                k = list(reading.keys())[0]
-                cur_pos = reading[k]['value']
-        initial_positions[obj] = cur_pos
-
-    def insert_reads(msg):
-        eligible = devices is None or msg.obj in devices
-        seen = msg.obj in initial_positions
-        if (msg.command == 'set') and eligible and not seen:
-            return (pchain(
-                    __read_and_stash_a_motor(
-                        msg.obj, initial_positions, coupled_parents),
-                    single_gen(msg)), None)
-        else:
-            return None, None
-
-    def reset():
-        blk_grp = 'reset-{}'.format(str(uuid.uuid4())[:6])
-        for k, v in initial_positions.items():
-            yield Msg('set', k, v, group=blk_grp)
-        yield Msg('wait', None, group=blk_grp)
-
-    return (yield from finalize_wrapper(plan_mutator(plan, insert_reads),
-                                        reset()))
-
-
-def baseline_wrapper(plan, devices, name='baseline'):
-    """
-    Preprocessor that records a baseline of all `devices` after `open_run`
-
-    The readings are designated for a separate event stream named 'baseline' by
-    default.
-
-    Parameters
-    ----------
-    plan : iterable or iterator
-        a generator, list, or similar containing `Msg` objects
-    devices : collection
-        collection of Devices to read
-        If None, the plan passes through unchanged.
-    name : string, optional
-        name for event stream; by default, 'baseline'
-
-    Yields
-    ------
-    msg : Msg
-        messages from plan, with 'set' messages inserted
-    """
-    def insert_baseline(msg):
-        if msg.command == 'open_run':
-            return None, trigger_and_read(devices, name=name)
-
-        elif msg.command == 'close_run':
-            def post_baseline():
-                yield from trigger_and_read(devices, name=name)
-                return (yield msg)
-
-            return post_baseline(), None
-
-        return None, None
-
-    if not devices:
-        # no-op
-        return (yield from plan)
-    else:
-        return (yield from plan_mutator(plan, insert_baseline))
-
-
-@contextmanager
-def baseline_context(plan_stack, devices, name='baseline'):
-    """
-    Read every device once upon entering and exiting the context.
-
-    .. deprecated:: 0.10.0
-        Use :func:`baseline_wrapper` or :func:`baseline_decorator`.
-
-    The readings are designated for a separate event stream named 'baseline'
-    by default.
-
-    Parameters
-    ----------
-    plan_stack : list-like
-        appendable collection of generators that yield messages (`Msg` objects)
-    devices : collection
-        collection of Devices to read
-    name : string, optional
-        name for event stream; by default, 'baseline'
-    """
-    warn("baseline_context is deprecated. Use baseline_wrapper or "
-         "baselin_decorator.")
-    plan_stack.append(trigger_and_read(devices, name=name))
-    yield
-    plan_stack.append(trigger_and_read(devices, name=name))
-
-
-@contextmanager
-def monitor_context(plan_stack, signals):
-    """
-    Asynchronously monitor signals, generating separate event streams.
-
-    .. deprecated:: 0.10.0
-        Use :func:`monitor_wrapper` or :func:`monitor_decorator`.
-
-    Upon exiting the context, stop monitoring.
-
-    Parameters
-    ----------
-    plan_stack : list-like
-        appendable collection of generators that yield messages (`Msg` objects)
-    signals : dict or list
-        either a dict mapping Signals to event stream names or simply a list
-        of Signals, in which case the event stream names default to None
-    name : string, optional
-        name for event stream; by default, None
-
-    Examples
-    --------
-    >>> plan_stack = deque()
-
-    With custom event stream names
-
-    >>> with monitor_context(plan_stack, {sig1: 'sig1', sig2: 'sig2'}):
-            ...
-
-    With no event stream names
-
-    >>> with monitor_context(plan_stack, [sig1, sig2]):
-            ...
-    """
-    warn("monitor_context is deprecated. Use monitor_wrapper or "
-         "monitor_decorator.")
-    if hasattr(signals, 'items'):
-        # interpret input as dict of signals mapped to event stream names
-        pass
-    else:
-        # interpet input as list of signals
-        signals = {sig: None for sig in signals}
-
-    for sig, name in signals.items():
-        plan_stack.append(single_gen(Msg('monitor', sig, name=name)))
-    yield
-    for sig, name in signals.items():
-        plan_stack.append(single_gen(Msg('unmonitor', sig)))
-
-
-def trigger_and_read(devices, name='primary'):
-    """
-    Trigger and read a list of detectors and bundle readings into one Event.
-
-    Parameters
-    ----------
-    devices : iterable
-        devices to trigger (if they have a trigger method) and then read
-    name : string, optional
-        event stream name, a convenient human-friendly identifier; default
-        name is 'primary'
-
-    Yields
-    ------
-    msg : Msg
-        messages to 'trigger', 'wait' and 'read'
-    """
-    # If devices is empty, don't emit 'create'/'save' messages.
-    if not devices:
-        yield from null()
-    devices = separate_devices(devices)  # remove redundant entries
-    rewindable = all_safe_rewind(devices)  # if devices can be re-triggered
-
-    def inner_trigger_and_read():
-        grp = _short_uid('trigger')
-        no_wait = True
-        for obj in devices:
-            if hasattr(obj, 'trigger'):
-                no_wait = False
-                yield from trigger(obj, group=grp)
-        # Skip 'wait' if none of the devices implemented a trigger method.
-        if not no_wait:
-            yield from wait(group=grp)
-        yield from create(name)
-        ret = {}  # collect and return readings to give plan access to them
-        for obj in devices:
-            reading = (yield from read(obj))
-            if reading is not None:
-                ret.update(reading)
-        yield from save()
-        return ret
-
-    return (yield from rewindable_wrapper(inner_trigger_and_read(),
-                                          rewindable))
-
-
-def broadcast_msg(command, objs, *args, **kwargs):
-    """
-    Generate many copies of a mesasge, applying it to a list of devices.
-
-    Parameters
-    ----------
-    command : string
-    devices : iterable
-    ``*args``
-        args for message
-    ``**kwargs``
-        kwargs for message
-
-    Yields
-    ------
-    msg : Msg
-    """
-    return_vals = []
-    for o in objs:
-        ret = yield Msg(command, o, *args, **kwargs)
-        return_vals.append(ret)
-
-    return return_vals
-
-
-def repeater(n, gen_func, *args, **kwargs):
-    """
-    Generate n chained copies of the messages from gen_func
-
-    Parameters
-    ----------
-    n : int or None
-        total number of repetitions; if None, infinite
-    gen_func : callable
-        returns generator instance
-    ``*args``
-        args for gen_func
-    ``**kwargs``
-        kwargs for gen_func
-
-    Yields
-    ------
-    msg : Msg
-
-    See Also
-    --------
-    :func:`bluesky.plans.caching_repeater`
-    """
-    it = range
-    if n is None:
-        n = 0
-        it = itertools.count
-
-    for j in it(n):
-        yield from gen_func(*args, **kwargs)
-
-
-def caching_repeater(n, plan):
-    """
-    Generate n chained copies of the messages in a plan.
-
-    This is different from ``repeater`` above because it takes in a
-    generator or iterator, not a function that returns one.
-
-    Parameters
-    ----------
-    n : int or None
-        total number of repetitions; if None, infinite
-    plan : iterable
-
-    Yields
-    ------
-    msg : Msg
-
-    See Also
-    --------
-    :func:`bluesky.plans.repeater`
-    """
-    it = range
-    if n is None:
-        n = 0
-        it = itertools.count
-
-    lst_plan = list(plan)
-    for j in it(n):
-        yield from (m for m in lst_plan)
-
-
-# Make generator function decorator for each generator instance wrapper.
-baseline_decorator = make_decorator(baseline_wrapper)
-subs_decorator = make_decorator(subs_wrapper)
-relative_set_decorator = make_decorator(relative_set_wrapper)
-reset_positions_decorator = make_decorator(reset_positions_wrapper)
-# finalize_decorator is custom-made since it takes a plan as its
-# argument. See its docstring for details why.
-lazily_stage_decorator = make_decorator(lazily_stage_wrapper)
-stage_decorator = make_decorator(stage_wrapper)
-fly_during_decorator = make_decorator(fly_during_wrapper)
-monitor_during_decorator = make_decorator(monitor_during_wrapper)
-inject_md_decorator = make_decorator(inject_md_wrapper)
-run_decorator = make_decorator(run_wrapper)
-contingency_decorator = make_decorator(contingency_wrapper)
-stub_decorator = make_decorator(stub_wrapper)
-configure_count_time_decorator = make_decorator(configure_count_time_wrapper)
+from . import utils
+from .utils import Msg
+
+from . import preprocessors as bpp
+from . import plan_stubs as bps
 
 
 def count(detectors, num=1, delay=None, *, md=None):
@@ -2251,13 +72,13 @@ def count(detectors, num=1, delay=None, *, md=None):
                                  "entries" % (num, num_delays))
         delay = iter(delay)
 
-    @stage_decorator(detectors)
-    @run_decorator(md=_md)
+    @bpp.stage_decorator(detectors)
+    @bpp.run_decorator(md=_md)
     def finite_plan():
         for i in range(num):
             now = time.time()  # Intercept the flow in its earliest moment.
             yield Msg('checkpoint')
-            yield from trigger_and_read(detectors)
+            yield from bps.trigger_and_read(detectors)
             try:
                 d = next(delay)
             except StopIteration:
@@ -2272,12 +93,12 @@ def count(detectors, num=1, delay=None, *, md=None):
                 if d > 0:  # Sleep if and only if time is left to do it.
                     yield Msg('sleep', None, d)
 
-    @stage_decorator(detectors)
-    @run_decorator(md=_md)
+    @bpp.stage_decorator(detectors)
+    @bpp.run_decorator(md=_md)
     def infinite_plan():
         while True:
             yield Msg('checkpoint')
-            yield from trigger_and_read(detectors)
+            yield from bps.trigger_and_read(detectors)
             try:
                 d = next(delay)
             except StopIteration:
@@ -2289,22 +110,6 @@ def count(detectors, num=1, delay=None, *, md=None):
         return (yield from infinite_plan())
     else:
         return (yield from finite_plan())
-
-
-def one_1d_step(detectors, motor, step):
-    """
-    Inner loop of a 1D step scan
-
-    This is the default function for ``per_step`` param in 1D plans.
-    """
-    def move():
-        grp = _short_uid('set')
-        yield Msg('checkpoint')
-        yield Msg('set', motor, step, group=grp)
-        yield Msg('wait', None, group=grp)
-
-    yield from move()
-    return (yield from trigger_and_read(list(detectors) + [motor]))
 
 
 def list_scan(detectors, motor, steps, *, per_step=None, md=None):
@@ -2351,10 +156,10 @@ def list_scan(detectors, motor, steps, *, per_step=None, md=None):
     else:
         _md['hints'].setdefault('dimensions', dimensions)
     if per_step is None:
-        per_step = one_1d_step
+        per_step = bps.one_1d_step
 
-    @stage_decorator(list(detectors) + [motor])
-    @run_decorator(md=_md)
+    @bpp.stage_decorator(list(detectors) + [motor])
+    @bpp.run_decorator(md=_md)
     def inner_list_scan():
         for step in steps:
             yield from per_step(detectors, motor, step)
@@ -2388,14 +193,13 @@ def rel_list_scan(detectors, motor, steps, *, per_step=None, md=None):
     _md = {'plan_name': 'rel_list_scan'}
     _md.update(md or {})
 
-    @reset_positions_decorator([motor])
-    @relative_set_decorator([motor])
+    @bpp.reset_positions_decorator([motor])
+    @bpp.relative_set_decorator([motor])
     def inner_relative_list_scan():
         return (yield from list_scan(detectors, motor, steps,
                                      per_step=per_step, md=_md))
     return (yield from inner_relative_list_scan())
 
-relative_list_scan = rel_list_scan  # back-compat
 
 def scan(detectors, motor, start, stop, num, *, per_step=None, md=None):
     """
@@ -2446,12 +250,12 @@ def scan(detectors, motor, start, stop, num, *, per_step=None, md=None):
         _md['hints'].setdefault('dimensions', dimensions)
 
     if per_step is None:
-        per_step = one_1d_step
+        per_step = bps.one_1d_step
 
     steps = np.linspace(**_md['plan_pattern_args'])
 
-    @stage_decorator(list(detectors) + [motor])
-    @run_decorator(md=_md)
+    @bpp.stage_decorator(list(detectors) + [motor])
+    @bpp.run_decorator(md=_md)
     def inner_scan():
         for step in steps:
             yield from per_step(detectors, motor, step)
@@ -2460,7 +264,7 @@ def scan(detectors, motor, start, stop, num, *, per_step=None, md=None):
 
 
 def rel_scan(detectors, motor, start, stop, num, *, per_step=None,
-                  md=None):
+             md=None):
     """
     Scan over one variable in equally spaced steps relative to current positon.
 
@@ -2490,15 +294,14 @@ def rel_scan(detectors, motor, start, stop, num, *, per_step=None,
     _md.update(md or {})
     # TODO read initial positions (redundantly) so they can be put in md here
 
-    @reset_positions_decorator([motor])
-    @relative_set_decorator([motor])
+    @bpp.reset_positions_decorator([motor])
+    @bpp.relative_set_decorator([motor])
     def inner_relative_scan():
         return (yield from scan(detectors, motor, start, stop,
                                 num, per_step=per_step, md=_md))
 
     return (yield from inner_relative_scan())
 
-relative_scan = rel_scan  # back-compat
 
 def log_scan(detectors, motor, start, stop, num, *, per_step=None, md=None):
     """
@@ -2549,12 +352,12 @@ def log_scan(detectors, motor, start, stop, num, *, per_step=None, md=None):
         _md['hints'].setdefault('dimensions', dimensions)
 
     if per_step is None:
-        per_step = one_1d_step
+        per_step = bps.one_1d_step
 
     steps = np.logspace(**_md['plan_pattern_args'])
 
-    @stage_decorator(list(detectors) + [motor])
-    @run_decorator(md=_md)
+    @bpp.stage_decorator(list(detectors) + [motor])
+    @bpp.run_decorator(md=_md)
     def inner_log_scan():
         for step in steps:
             yield from per_step(detectors, motor, step)
@@ -2563,7 +366,7 @@ def log_scan(detectors, motor, start, stop, num, *, per_step=None, md=None):
 
 
 def rel_log_scan(detectors, motor, start, stop, num, *, per_step=None,
-                      md=None):
+                 md=None):
     """
     Scan over one variable in log-spaced steps relative to current position.
 
@@ -2593,15 +396,14 @@ def rel_log_scan(detectors, motor, start, stop, num, *, per_step=None,
     _md = {'plan_name': 'rel_log_scan'}
     _md.update(md or {})
 
-    @reset_positions_decorator([motor])
-    @relative_set_decorator([motor])
+    @bpp.reset_positions_decorator([motor])
+    @bpp.relative_set_decorator([motor])
     def inner_relative_log_scan():
         return (yield from log_scan(detectors, motor, start, stop, num,
                                     per_step=per_step, md=_md))
 
     return (yield from inner_relative_log_scan())
 
-relative_log_scan = rel_log_scan  # back-compat
 
 def adaptive_scan(detectors, target_field, motor, start, stop,
                   min_step, max_step, target_delta, backstep,
@@ -2664,8 +466,8 @@ def adaptive_scan(detectors, target_field, motor, start, stop,
     else:
         _md['hints'].setdefault('dimensions', dimensions)
 
-    @stage_decorator(list(detectors) + [motor])
-    @run_decorator(md=_md)
+    @bpp.stage_decorator(list(detectors) + [motor])
+    @bpp.run_decorator(md=_md)
     def adaptive_core():
         next_pos = start
         step = (max_step - min_step) / 2
@@ -2678,12 +480,12 @@ def adaptive_scan(detectors, target_field, motor, start, stop,
             direction_sign = -1
         while next_pos * direction_sign < stop * direction_sign:
             yield Msg('checkpoint')
-            yield from mv(motor, next_pos)
+            yield from bps.mv(motor, next_pos)
             yield Msg('create', None, name='primary')
             for det in detectors:
                 yield Msg('trigger', det, group='B')
             yield Msg('wait', None, 'B')
-            for det in separate_devices(detectors + [motor]):
+            for det in utils.separate_devices(detectors + [motor]):
                 cur_det = yield Msg('read', det)
                 if target_field in cur_det:
                     cur_I = cur_det[target_field]['value']
@@ -2716,8 +518,8 @@ def adaptive_scan(detectors, target_field, motor, start, stop,
 
 
 def rel_adaptive_scan(detectors, target_field, motor, start, stop,
-                           min_step, max_step, target_delta, backstep,
-                           threshold=0.8, *, md=None):
+                      min_step, max_step, target_delta, backstep,
+                      threshold=0.8, *, md=None):
     """
     Relative scan over one variable with adaptively tuned step size.
 
@@ -2753,8 +555,8 @@ def rel_adaptive_scan(detectors, target_field, motor, start, stop,
     _md = {'plan_name': 'rel_adaptive_scan'}
     _md.update(md or {})
 
-    @reset_positions_decorator([motor])
-    @relative_set_decorator([motor])
+    @bpp.reset_positions_decorator([motor])
+    @bpp.relative_set_decorator([motor])
     def inner_relative_adaptive_scan():
         return (yield from adaptive_scan(detectors, target_field,
                                          motor, start, stop, min_step,
@@ -2763,7 +565,6 @@ def rel_adaptive_scan(detectors, target_field, motor, start, stop,
 
     return (yield from inner_relative_adaptive_scan())
 
-relative_adaptive_scan = rel_adaptive_scan  # back-compat
 
 def tune_centroid(
         detectors, signal, motor,
@@ -2845,10 +646,10 @@ def tune_centroid(
                          'start': start,
                          'stop': stop,
                          'num': num,
-                         'min_step': min_step,},
+                         'min_step': min_step, },
            'plan_name': 'tune_centroid',
            'hints': {},
-          }
+           }
     _md.update(md or {})
     try:
         dimensions = [(motor.hints['fields'], 'primary')]
@@ -2860,21 +661,20 @@ def tune_centroid(
     low_limit = min(start, stop)
     high_limit = max(start, stop)
 
-    @stage_decorator(list(detectors) + [motor])
-    @run_decorator(md=_md)
+    @bpp.stage_decorator(list(detectors) + [motor])
+    @bpp.run_decorator(md=_md)
     def _tune_core(start, stop, num, signal):
         next_pos = start
         step = (stop - start) / (num - 1)
         peak_position = None
         cur_I = None
-        cur_det = {}
         sum_I = 0       # for peak centroid calculation, I(x)
         sum_xI = 0
 
         while abs(step) >= min_step:
             yield Msg('checkpoint')
-            yield from mv(motor, next_pos)
-            ret = (yield from trigger_and_read(detectors + [motor]))
+            yield from bps.mv(motor, next_pos)
+            ret = (yield from bps.trigger_and_read(detectors + [motor]))
             cur_I = ret[signal]['value']
             sum_I += cur_I
             position = ret[motor_name]['value']
@@ -2892,8 +692,10 @@ def tune_centroid(
                     return
                 peak_position = sum_xI / sum_I  # centroid
                 # improvement: report current peak_position somehow
-                start = np.clip(peak_position - step_factor*step, low_limit, high_limit)
-                stop = np.clip(peak_position + step_factor*step, low_limit, high_limit)
+                start = np.clip(peak_position - step_factor*step,
+                                low_limit, high_limit)
+                stop = np.clip(peak_position + step_factor*step,
+                               low_limit, high_limit)
                 if snake:
                     start, stop = stop, start
                 step = (stop - start) / (num - 1)
@@ -2902,40 +704,9 @@ def tune_centroid(
         # finally, move to peak position
         if peak_position is not None:
             # improvement: report final peak_position
-            yield from mv(motor, peak_position)
+            yield from bps.mv(motor, peak_position)
 
     return (yield from _tune_core(start, stop, num, signal))
-
-
-def one_nd_step(detectors, step, pos_cache):
-    """
-    Inner loop of an N-dimensional step scan
-
-    This is the default function for ``per_step`` param`` in ND plans.
-
-    Parameters
-    ----------
-    detectors : iterable
-        devices to read
-    step : dict
-        mapping motors to positions in this step
-    pos_cache : dict
-        mapping motors to their last-set positions
-    """
-    def move():
-        yield Msg('checkpoint')
-        grp = _short_uid('set')
-        for motor, pos in step.items():
-            if pos == pos_cache[motor]:
-                # This step does not move this motor.
-                continue
-            yield Msg('set', motor, pos, group=grp)
-            pos_cache[motor] = pos
-        yield Msg('wait', None, group=grp)
-
-    motors = step.keys()
-    yield from move()
-    yield from trigger_and_read(list(detectors) + list(motors))
 
 
 def scan_nd(detectors, cycler, *, per_step=None, md=None):
@@ -2949,7 +720,7 @@ def scan_nd(detectors, cycler, *, per_step=None, md=None):
         list of dictionaries mapping motors to positions
     per_step : callable, optional
         hook for cutomizing action of inner loop (messages per step)
-        See docstring of bluesky.plans.one_nd_step (the default) for
+        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
         details.
     md : dict, optional
         metadata
@@ -2985,13 +756,13 @@ def scan_nd(detectors, cycler, *, per_step=None, md=None):
         _md['hints'].setdefault('dimensions', dimensions)
 
     if per_step is None:
-        per_step = one_nd_step
+        per_step = bps.one_nd_step
     pos_cache = defaultdict(lambda: None)  # where last position is stashed
-    cycler = merge_cycler(cycler)
+    cycler = utils.merge_cycler(cycler)
     motors = list(cycler.keys)
 
-    @stage_decorator(list(detectors) + motors)
-    @run_decorator(md=_md)
+    @bpp.stage_decorator(list(detectors) + motors)
+    @bpp.run_decorator(md=_md)
     def inner_scan_nd():
         for step in list(cycler):
             yield from per_step(detectors, step, pos_cache)
@@ -3014,7 +785,7 @@ def inner_product_scan(detectors, num, *args, per_step=None, md=None):
         Motors can be any 'setable' object (motor, temp controller, etc.)
     per_step : callable, optional
         hook for cutomizing action of inner loop (messages per step)
-        See docstring of bluesky.plans.one_nd_step (the default) for
+        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
         details.
     md : dict, optional
         metadata
@@ -3066,7 +837,7 @@ def grid_scan(detectors, *args, per_step=None, md=None):
         simple left-to-right trajectory.
     per_step : callable, optional
         hook for cutomizing action of inner loop (messages per step)
-        See docstring of bluesky.plans.one_nd_step (the default) for
+        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
         details.
     md : dict, optional
         metadata
@@ -3119,7 +890,6 @@ def grid_scan(detectors, *args, per_step=None, md=None):
     return (yield from scan_nd(detectors, full_cycler,
                                per_step=per_step, md=_md))
 
-outer_product_scan = grid_scan  # back-compat
 
 def rel_grid_scan(detectors, *args, per_step=None, md=None):
     """
@@ -3139,7 +909,7 @@ def rel_grid_scan(detectors, *args, per_step=None, md=None):
         trajectory or a simple left-to-right trajectory.
     per_step : callable, optional
         hook for cutomizing action of inner loop (messages per step)
-        See docstring of bluesky.plans.one_nd_step (the default) for
+        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
         details.
     md : dict, optional
         metadata
@@ -3155,15 +925,14 @@ def rel_grid_scan(detectors, *args, per_step=None, md=None):
     motors = [m[0] for m in
               plan_patterns.chunk_outer_product_args(args)]
 
-    @reset_positions_decorator(motors)
-    @relative_set_decorator(motors)
+    @bpp.reset_positions_decorator(motors)
+    @bpp.relative_set_decorator(motors)
     def inner_rel_grid_scan():
         return (yield from grid_scan(detectors, *args,
-                                              per_step=per_step, md=_md))
+                                     per_step=per_step, md=_md))
 
     return (yield from inner_rel_grid_scan())
 
-relative_outer_product_scan = rel_grid_scan  # back-compat
 
 def relative_inner_product_scan(detectors, num, *args, per_step=None, md=None):
     """
@@ -3180,7 +949,7 @@ def relative_inner_product_scan(detectors, num, *args, per_step=None, md=None):
         Motors can be any 'setable' object (motor, temp controller, etc.)
     per_step : callable, optional
         hook for cutomizing action of inner loop (messages per step)
-        See docstring of bluesky.plans.one_nd_step (the default) for
+        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
         details.
     md : dict, optional
         metadata
@@ -3195,8 +964,8 @@ def relative_inner_product_scan(detectors, num, *args, per_step=None, md=None):
     _md.update(md or {})
     motors = [motor for motor, start, stop in partition(3, args)]
 
-    @reset_positions_decorator(motors)
-    @relative_set_decorator(motors)
+    @bpp.reset_positions_decorator(motors)
+    @bpp.relative_set_decorator(motors)
     def inner_relative_inner_product_scan():
         return (yield from inner_product_scan(detectors, num, *args,
                                               per_step=per_step, md=_md))
@@ -3245,8 +1014,8 @@ def tweak(detector, target_field, motor, step, *, md=None):
         def clear_output(wait=False):
             pass
 
-    @stage_decorator([detector, motor])
-    @run_decorator(md=_md)
+    @bpp.stage_decorator([detector, motor])
+    @bpp.run_decorator(md=_md)
     def tweak_core():
         nonlocal step
 
@@ -3309,7 +1078,7 @@ def spiral_fermat(detectors, x_motor, y_motor, x_start, y_start, x_range,
         Tilt angle in radians, default 0.0
     per_step : callable, optional
         hook for cutomizing action of inner loop (messages per step)
-        See docstring of bluesky.plans.one_nd_step (the default) for
+        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
         details.
     md : dict, optional
         metadata
@@ -3355,7 +1124,7 @@ def spiral_fermat(detectors, x_motor, y_motor, x_start, y_start, x_range,
 
 
 def rel_spiral_fermat(detectors, x_motor, y_motor, x_range, y_range, dr,
-                           factor, *, tilt=0.0, per_step=None, md=None):
+                      factor, *, tilt=0.0, per_step=None, md=None):
     '''Relative fermat spiral scan
 
     Parameters
@@ -3378,7 +1147,7 @@ def rel_spiral_fermat(detectors, x_motor, y_motor, x_range, y_range, dr,
         Tilt angle in radians, default 0.0
     per_step : callable, optional
         hook for cutomizing action of inner loop (messages per step)
-        See docstring of bluesky.plans.one_nd_step (the default) for
+        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
         details.
     md : dict, optional
         metadata
@@ -3397,7 +1166,6 @@ def rel_spiral_fermat(detectors, x_motor, y_motor, x_range, y_range, dr,
                                      y_range, dr, factor, tilt=tilt,
                                      per_step=per_step, md=_md))
 
-rel_spiral_fermat = rel_spiral_fermat  # back-compat
 
 def spiral(detectors, x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
            nth, *, tilt=0.0, per_step=None, md=None):
@@ -3425,7 +1193,7 @@ def spiral(detectors, x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
         Tilt angle in radians, default 0.0
     per_step : callable, optional
         hook for cutomizing action of inner loop (messages per step)
-        See docstring of bluesky.plans.one_nd_step (the default) for
+        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
         details.
     md : dict, optional
         metadata
@@ -3471,7 +1239,7 @@ def spiral(detectors, x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
 
 
 def rel_spiral(detectors, x_motor, y_motor, x_range, y_range, dr, nth,
-                    *, tilt=0.0, per_step=None, md=None):
+               *, tilt=0.0, per_step=None, md=None):
     '''Relative spiral scan
 
     Parameters
@@ -3496,7 +1264,7 @@ def rel_spiral(detectors, x_motor, y_motor, x_range, y_range, dr, nth,
         Tilt angle in radians, default 0.0
     per_step : callable, optional
         hook for cutomizing action of inner loop (messages per step)
-        See docstring of bluesky.plans.one_nd_step (the default) for
+        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
         details.
     md : dict, optional
         metadata
@@ -3513,7 +1281,6 @@ def rel_spiral(detectors, x_motor, y_motor, x_range, y_range, dr, nth,
                               x_range, y_range, dr, nth, tilt=tilt,
                               per_step=per_step, md=_md))
 
-relative_spiral = rel_spiral  # back-compat
 
 def ramp_plan(go_plan,
               monitor_sig,
@@ -3565,8 +1332,8 @@ def ramp_plan(go_plan,
     _md = {'plan_name': 'ramp_plan'}
     _md.update(md or {})
 
-    @monitor_during_decorator((monitor_sig,))
-    @run_decorator(md=_md)
+    @bpp.monitor_during_decorator((monitor_sig,))
+    @bpp.run_decorator(md=_md)
     def polling_plan():
         fail_time = None
         if timeout is not None:
@@ -3583,441 +1350,23 @@ def ramp_plan(go_plan,
             yield from inner_plan_func()
             if fail_time is not None:
                 if time.time() > fail_time:
-                    raise RampFail()
+                    raise utils.RampFail()
             if period is not None:
                 cur_time = time.time()
                 wait_time = (start_time + period) - cur_time
                 if wait_time > 0:
-                    yield from sleep(wait_time)
+                    yield from bps.sleep(wait_time)
             # take a 'post' data point
         yield from inner_plan_func()
 
     return (yield from polling_plan())
 
 
-class SupplementalData:
-    """
-    A configurable preprocessor for supplemental measurements
-
-    This is a plan preprocessor. It inserts messages into plans to:
-
-    * take "baseline" readings at the beginning and end of each run for the
-      devices listed in its ``baseline`` atrribute
-    * kick off "flyable" devices listed in its ``flyers`` attribute at the
-      beginning of each run and collect their data at the end
-    * monitor signals in its ``monitors`` attribute for asynchronous
-      updates during each run.
-
-    Internally, it uses the plan preprocessors:
-
-    * :func:`baseline_wrapper`
-    * :func:`monitor_during_wrapper`
-    * :func:`flyer_during_wrapper`
-
-    Parameters
-    ----------
-    baseline : list
-        Devices to be read at the beginning and end of each run
-    monitors : list
-        Signals (not multi-signal Devices) to be monitored during each run,
-        generating readings asynchronously
-    flyers : list
-        "Flyable" Devices to be kicked off before each run and collected
-        at the end of each run
-
-    Examples
-    --------
-    Create an instance of SupplementalData and apply it to a RunEngine.
-
-    >>> sd = SupplementalData(baseline=[some_motor, some_detector]),
-    ...                       monitors=[some_signal],
-    ...                       flyers=[some_flyer])
-    >>> RE = RunEngine({})
-    >>> RE.preprocessors.append(sd)
-
-    Now all plans executed by RE will be modified to add baseline readings
-    (before and after each run), monitors (during each run), and flyers
-    (kicked off before each run and collected afterward).
-
-    Inspect or update the lists of devices interactively.
-
-    >>> sd.baseline
-    [some_motor, some_detector]
-
-    >>> sd.baseline.remove(some_motor)
-
-    >>> sd.baseline
-    [some_detector]
-
-    >>> sd.baseline.append(another_detector)
-
-    >>> sd.baseline
-    [some_detector, another_detector]
-
-    Each attribute (``baseline``, ``monitors``, ``flyers``) is an ordinary
-    Python list, support all the standard list methods, such as:
-
-    >>> sd.baseline.clear()
-
-    The arguments to SupplementalData are optional. All the lists
-    will empty by default.  As shown above, they can be populated
-    interactively.
-
-    >>> sd = SupplementalData()
-    >>> RE = RunEngine({})
-    >>> RE.preprocessors.append(sd)
-    >>> sd.baseline.append(some_detector)
-    """
-    def __init__(self, *, baseline=None, monitors=None, flyers=None):
-        if baseline is None:
-            baseline = []
-        if monitors is None:
-            monitors = []
-        if flyers is None:
-            flyers = []
-        self.baseline = list(baseline)
-        self.monitors = list(monitors)
-        self.flyers = list(flyers)
-
-    def __repr__(self):
-        return ("{cls}(baseline={baseline}, monitors={monitors}, "
-                "flyers={flyers})"
-                "").format(cls=type(self).__name__, **vars(self))
-
-    # I'm not sure why anyone would want to pickle this but it's good manners
-    # to avoid breaking pickling.
-
-    def __setstate__(self, state):
-        baseline, monitors, flyers = state
-        self.baseline = baseline
-        self.monitors = monitors
-        self.flyers = flyers
-
-    def __getstate__(self):
-        return (self.baseline, self.monitors, self.flyers)
-
-    def __call__(self, plan):
-        """
-        Insert messages into a plan.
-
-        Parameters
-        ----------
-        plan : iterable or iterator
-            a generator, list, or similar containing `Msg` objects
-        """
-        plan = baseline_wrapper(plan, self.baseline)
-        plan = monitor_during_wrapper(plan, self.monitors)
-        plan = fly_during_wrapper(plan, self.flyers)
-        return (yield from plan)
-
-
-# The code below adds no new logic, but it wraps the generators above in
-# classes for an alternative interface that is more stateful.
-
-
-class Plan(Struct):
-    """
-    This is a base class for wrapping plan generators in a stateful class.
-
-    To create a new sub-class you need to over-ride two things:
-
-    - an ``__init__`` method *or* a class level ``_fields`` attribute which is
-      used to construct the init signature via meta-class magic
-    - a ``_gen`` method, which should return a generator of Msg objects
-
-    The class provides:
-
-    - state stored in attributes that are used to re-generate a plan generator
-      with the same parameters
-    - a hook for adding "flyable" objects to a plan
-    - attributes for adding subscriptions and subscription factory functions
-    """
-    subs = Subs({})
-    sub_factories = Subs({})
-
-    def __iter__(self):
-        """
-        Return an iterable of messages.
-        """
-        return self()
-
-    def __call__(self, **kwargs):
-        """
-        Return an iterable of messages.
-
-        Any keyword arguments override present settings.
-        """
-        warn("This plan and all object-oriented plans have been deprecated "
-             "and will be removed in a future release of bluesky. Instead of "
-             "Count or Scan use count or scan, etc.", stacklevel=2)
-        subs = defaultdict(list)
-        update_sub_lists(subs, self.subs)
-        update_sub_lists(subs, apply_sub_factories(self.sub_factories, self))
-        flyers = getattr(self, 'flyers', [])
-
-        def cls_plan():
-            current_settings = {}
-            for key, val in kwargs.items():
-                current_settings[key] = getattr(self, key)
-                setattr(self, key, val)
-            try:
-                plan = self._gen()
-                plan = subs_wrapper(plan, subs)
-                plan = stage_wrapper(plan, flyers)
-                plan = fly_during_wrapper(plan, flyers)
-                return (yield from plan)
-            finally:
-                for key, val in current_settings.items():
-                    setattr(self, key, val)
-
-        cls_plan.__name__ = self.__class__.__name__
-        return cls_plan()
-
-    def _gen(self):
-        "Subclasses override this to provide the main plan content."
-        yield from ensure_generator([])
-
-
-PlanBase = Plan  # back-compat
-
-
-class Count(Plan):
-    _fields = ['detectors', 'num', 'delay']
-    __doc__ = count.__doc__
-
-    def __init__(self, detectors, num=1, delay=0, *, md=None):
-        self.detectors = detectors
-        self.num = num
-        self.delay = delay
-        self.flyers = []
-        self.md = md
-
-    def _gen(self):
-        return count(self.detectors, self.num, self.delay, md=self.md)
-
-
-class ListScan(Plan):
-    _fields = ['detectors', 'motor', 'steps']
-    __doc__ = list_scan.__doc__
-
-    def _gen(self):
-        return list_scan(self.detectors, self.motor, self.steps,
-                         md=self.md)
-
-AbsListScanPlan = ListScan  # back-compat
-
-
-class RelativeListScan(Plan):
-    _fields = ['detectors', 'motor', 'steps']
-    __doc__ = rel_list_scan.__doc__
-
-    def _gen(self):
-        return rel_list_scan(self.detectors, self.motor, self.steps,
-                                  md=self.md)
-
-DeltaListScanPlan = RelativeListScan  # back-compat
-
-
-class Scan(Plan):
-    _fields = ['detectors', 'motor', 'start', 'stop', 'num']
-    __doc__ = scan.__doc__
-
-    def _gen(self):
-        return scan(self.detectors, self.motor, self.start, self.stop,
-                    self.num, md=self.md)
-
-AbsScanPlan = Scan  # back-compat
-
-
-class LogScan(Plan):
-    _fields = ['detectors', 'motor', 'start', 'stop', 'num']
-    __doc__ = log_scan.__doc__
-
-    def _gen(self):
-        return log_scan(self.detectors, self.motor, self.start, self.stop,
-                        self.num, md=self.md)
-
-LogAbsScanPlan = LogScan  # back-compat
-
-
-class RelativeScan(Plan):
-    _fields = ['detectors', 'motor', 'start', 'stop', 'num']
-    __doc__ = rel_scan.__doc__
-
-    def _gen(self):
-        return rel_scan(self.detectors, self.motor, self.start, self.stop,
-                             self.num, md=self.md)
-
-DeltaScanPlan = RelativeScan  # back-compat
-
-
-class RelativeLogScan(Plan):
-    _fields = ['detectors', 'motor', 'start', 'stop', 'num']
-    __doc__ = rel_log_scan.__doc__
-
-    def _gen(self):
-        return rel_log_scan(self.detectors, self.motor, self.start,
-                                 self.stop, self.num, md=self.md)
-
-LogDeltaScanPlan = RelativeLogScan  # back-compat
-
-
-class AdaptiveScan(Plan):
-    _fields = ['detectors', 'target_field', 'motor', 'start', 'stop',
-               'min_step', 'max_step', 'target_delta', 'backstep',
-               'threshold']
-    __doc__ = adaptive_scan.__doc__
-
-    def __init__(self, detectors, target_field, motor, start, stop,
-                 min_step, max_step, target_delta, backstep,
-                 threshold=0.8, *, md=None):
-        self.detectors = detectors
-        self.target_field = target_field
-        self.motor = motor
-        self.start = start
-        self.stop = stop
-        self.min_step = min_step
-        self.max_step = max_step
-        self.target_delta = target_delta
-        self.backstep = backstep
-        self.threshold = threshold
-        self.flyers = []
-        self.md = md
-
-    def _gen(self):
-        return adaptive_scan(self.detectors, self.target_field, self.motor,
-                             self.start, self.stop, self.min_step,
-                             self.max_step, self.target_delta,
-                             self.backstep, self.threshold, md=self.md)
-
-AdaptiveAbsScanPlan = AdaptiveScan  # back-compat
-
-
-class RelativeAdaptiveScan(AdaptiveAbsScanPlan):
-    __doc__ = rel_adaptive_scan.__doc__
-
-    def _gen(self):
-        return rel_adaptive_scan(self.detectors, self.target_field,
-                                      self.motor, self.start, self.stop,
-                                      self.min_step, self.max_step,
-                                      self.target_delta, self.backstep,
-                                      self.threshold, md=self.md)
-
-AdaptiveDeltaScanPlan = RelativeAdaptiveScan  # back-compat
-
-
-class ScanND(PlanBase):
-    _fields = ['detectors', 'cycler']
-    __doc__ = scan_nd.__doc__
-
-    def _gen(self):
-        return scan_nd(self.detectors, self.cycler, md=self.md)
-
-PlanND = ScanND  # back-compat
-
-
-class InnerProductScan(Plan):
-    __doc__ = inner_product_scan.__doc__
-
-    def __init__(self, detectors, num, *args, md=None):
-        self.detectors = detectors
-        self.num = num
-        self.args = args
-        self.flyers = []
-        self.md = md
-
-    def _gen(self):
-        return inner_product_scan(self.detectors, self.num, *self.args,
-                                  md=self.md)
-
-InnerProductAbsScanPlan = InnerProductScan  # back-compat
-
-
-class RelativeInnerProductScan(InnerProductScan):
-    __doc__ = relative_inner_product_scan.__doc__
-
-    def _gen(self):
-        return relative_inner_product_scan(self.detectors, self.num,
-                                           *self.args, md=self.md)
-
-InnerProductDeltaScanPlan = RelativeInnerProductScan  # back-compat
-
-
-class OuterProductScan(Plan):
-    __doc__ = grid_scan.__doc__
-
-    def __init__(self, detectors, *args, md=None):
-        self.detectors = detectors
-        self.args = args
-        self.flyers = []
-        self.md = md
-
-    def _gen(self):
-        return grid_scan(self.detectors, *self.args, md=self.md)
-
-OuterProductAbsScanPlan = OuterProductScan  # back-compat
-
-
-class RelativeOuterProductScan(OuterProductScan):
-    __doc__ = rel_grid_scan.__doc__
-
-    def _gen(self):
-        return rel_grid_scan(self.detectors, *self.args,
-                                           md=self.md)
-
-OuterProductDeltaScanPlan = RelativeOuterProductScan  # back-compat
-
-
-class Tweak(Plan):
-    _fields = ['detector', 'target_field', 'motor', 'step']
-    __doc__ = tweak.__doc__
-
-    def _gen(self):
-        return tweak(self.detector, self.target_field, self.motor, self.step,
-                     md=self.md)
-
-
-class SpiralScan(Plan):
-    _fields = ['detectors', 'x_motor', 'y_motor', 'x_start', 'y_start',
-               'x_range', 'y_range', 'dr', 'nth', 'tilt']
-    __doc__ = spiral.__doc__
-
-    def _gen(self):
-        return spiral(self.detectors, self.x_motor, self.y_motor, self.x_start,
-                      self.y_start, self.x_range, self.y_range, self.dr,
-                      self.nth, tilt=self.tilt, md=self.md)
-
-
-class SpiralFermatScan(Plan):
-    _fields = ['detectors', 'x_motor', 'y_motor', 'x_start', 'y_start',
-               'x_range', 'y_range', 'dr', 'factor', 'tilt']
-    __doc__ = spiral_fermat.__doc__
-
-    def _gen(self):
-        return spiral_fermat(self.detectors, self.x_motor, self.y_motor,
-                             self.x_start, self.y_start, self.x_range,
-                             self.y_range, self.dr, self.factor,
-                             tilt=self.tilt, md=self.md)
-
-
-class RelativeSpiralScan(Plan):
-    _fields = ['detectors', 'x_motor', 'y_motor', 'x_range', 'y_range', 'dr',
-               'nth', 'tilt']
-    __doc__ = rel_spiral.__doc__
-
-    def _gen(self):
-        return rel_spiral(self.detectors, self.x_motor, self.y_motor,
-                               self.x_range, self.y_range, self.dr, self.nth,
-                               tilt=self.tilt, md=self.md)
-
-
-class RelativeSpiralFermatScan(Plan):
-    _fields = ['detectors', 'x_motor', 'y_motor', 'x_range', 'y_range', 'dr',
-               'factor', 'tilt']
-    __doc__ = rel_spiral_fermat.__doc__
-
-    def _gen(self):
-        return rel_spiral_fermat(self.detectors, self.x_motor,
-                                      self.y_motor, self.x_range, self.y_range,
-                                      self.dr, self.factor, tilt=self.tilt,
-                                      md=self.md)
+relative_list_scan = rel_list_scan  # back-compat
+relative_scan = rel_scan  # back-compat
+relative_log_scan = rel_log_scan  # back-compat
+relative_adaptive_scan = rel_adaptive_scan  # back-compat
+outer_product_scan = grid_scan  # back-compat
+relative_outer_product_scan = rel_grid_scan  # back-compat
+relative_spiral_fermat = rel_spiral_fermat  # back-compat
+relative_spiral = rel_spiral  # back-compat

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -1,0 +1,1225 @@
+from collections import OrderedDict, deque, ChainMap
+import uuid
+from .utils import (normalize_subs_input, root_ancestor,
+                    separate_devices,
+                    Msg, ensure_generator, single_gen,
+                    short_uid as _short_uid, make_decorator,
+                    RunEngineControlException, merge_axis)
+from functools import wraps
+from .plan_stubs import (open_run, close_run, mv, pause, trigger_and_read)
+
+
+def plan_mutator(plan, msg_proc):
+    """
+    Alter the contents of a plan on the fly by changing or inserting messages.
+
+    Parameters
+    ----------
+    plan : generator
+        a generator that yields messages (`Msg` objects)
+    msg_proc : callable
+        This function takes in a message and specifies messages(s) to replace
+        it with. The function must account for what type of response the
+        message would prompt. For example, an 'open_run' message causes the
+        RunEngine to send a uid string back to the plan, while a 'set' message
+        causes the RunEngine to send a status object back to the plan. The
+        function should return a pair of generators ``(head, tail)`` that yield
+        messages. The last message out of the ``head`` generator is the one
+        whose response will be sent back to the host plan. Therefore, that
+        message should prompt a response compatible with the message that it is
+        replacing. Any responses to all other messages will be swallowed. As
+        shorthand, either ``head`` or ``tail`` can be replaced by ``None``.
+        This means:
+
+        * ``(None, None)`` No-op. Let the original message pass through.
+        * ``(head, None)`` Mutate and/or insert messages before the original
+        message.
+        * ``(head, tail)`` As above, and additionally insert messages after.
+        * ``(None, tail)`` Let the original message pass through and then
+        insert messages after.
+
+        The reason for returning a pair of generators instead of just one is to
+        provide a way to specify which message's response should be sent out to
+        the host plan. Again, it's the last message yielded by the first
+        generator (``head``).
+
+    Yields
+    ------
+    msg : Msg
+        messages from `plan`, altered by `msg_proc`
+
+    See Also
+    --------
+    :func:`bluesky.plans.msg_mutator`
+    """
+    # internal stacks
+    msgs_seen = dict()
+    plan_stack = deque()
+    result_stack = deque()
+    tail_cache = dict()
+    tail_result_cache = dict()
+    exception = None
+
+    parent_plan = plan
+    ret_value = None
+    # seed initial conditions
+    plan_stack.append(plan)
+    result_stack.append(None)
+
+    while True:
+        # get last result
+        if exception is not None:
+            # if we have a stashed exception, pass it along
+            try:
+                msg = plan_stack[-1].throw(exception)
+            except Exception as e:
+                # if we catch an exception,
+                # the current top plan is dead so pop it
+                plan_stack.pop()
+                if plan_stack:
+                    # stash the exception and go to the top
+                    exception = e
+                    continue
+                else:
+                    raise
+            else:
+                exception = None
+        else:
+            ret = result_stack.pop()
+            try:
+                msg = plan_stack[-1].send(ret)
+            except StopIteration as e:
+                # discard the exhausted generator
+                exhausted_gen = plan_stack.pop()
+                # if this is the parent plan, capture it's return value
+                if exhausted_gen is parent_plan:
+                    ret_value = e.value
+
+                # if we just came out of a 'tail' generator,
+                # discard its return value and replace it with the
+                # cached one (from the last message in its paired
+                # 'new_gen')
+                if id(exhausted_gen) in tail_result_cache:
+                    ret = tail_result_cache.pop(id(exhausted_gen))
+
+                result_stack.append(ret)
+
+                if id(exhausted_gen) in tail_cache:
+                    gen = tail_cache.pop(id(exhausted_gen))
+                    if gen is not None:
+                        plan_stack.append(gen)
+                        saved_result = result_stack.pop()
+                        tail_result_cache[id(gen)] = saved_result
+                        # must use None to prime generator
+                        result_stack.append(None)
+
+                if plan_stack:
+                    continue
+                else:
+                    return ret_value
+            except Exception as ex:
+                # we are here because an exception came out of the send
+                # this may be due to
+                # a) the plan really raising or
+                # b) an exception that came out of the run engine via ophyd
+
+                # in either case the current plan is dead so pop it
+                failed_gen = plan_stack.pop()
+                if id(failed_gen) in tail_cache:
+                    gen = tail_cache.pop(id(failed_gen))
+                    if gen is not None:
+                        plan_stack.append(gen)
+                # if there is at least
+                if plan_stack:
+                    exception = ex
+                    continue
+                else:
+                    raise ex
+        # if inserting / mutating, put new generator on the stack
+        # and replace the current msg with the first element from the
+        # new generator
+        if id(msg) not in msgs_seen:
+            # Use the id as a hash, and hold a reference to the msg so that
+            # it cannot be garbage collected until the plan is complete.
+            msgs_seen[id(msg)] = msg
+
+            new_gen, tail_gen = msg_proc(msg)
+            # mild correctness check
+            if tail_gen is not None and new_gen is None:
+                new_gen = single_gen(msg)
+            if new_gen is not None:
+                # stash the new generator
+                plan_stack.append(new_gen)
+                # put in a result value to prime it
+                result_stack.append(None)
+                # stash the tail generator
+                tail_cache[id(new_gen)] = tail_gen
+                # go to the top of the loop
+                continue
+
+        try:
+            # yield out the 'current message' and collect the return
+            inner_ret = yield msg
+        except GeneratorExit:
+            # special case GeneratorExit.  We must clean up all of our plans
+            # and exit with out yielding anything else.
+            for p in plan_stack:
+                p.close()
+            raise
+        except Exception as ex:
+            if plan_stack:
+                exception = ex
+                continue
+            else:
+                raise
+        else:
+            result_stack.append(inner_ret)
+
+
+def msg_mutator(plan, msg_proc):
+    """
+    A simple preprocessor that mutates or deletes single messages in a plan
+
+    To *insert* messages, use ``plan_mutator`` instead.
+
+    Parameters
+    ----------
+    plan : generator
+        a generator that yields messages (`Msg` objects)
+    msg_proc : callable
+        Expected signature `f(msg) -> new_msg or None`
+
+    Yields
+    ------
+    msg : Msg
+        messages from `plan`, altered by `msg_proc`
+
+    See Also
+    --------
+    :func:`bluesky.plans.plan_mutator`
+    """
+    ret = None
+    while True:
+        try:
+            msg = plan.send(ret)
+            msg = msg_proc(msg)
+            # if None, just skip message
+            # feed 'None' back down into the base plan,
+            # this may break some plans
+            if msg is None:
+                ret = None
+                continue
+            ret = yield msg
+        except StopIteration as e:
+            return e.value
+
+
+def pchain(*args):
+    '''Like `itertools.chain` but using `yield from`
+
+    This ensures than `.send` works as expected and the underlying
+    plans get the return values
+
+    Parameters
+    ----------
+    args :
+        generators (plans)
+
+    Yields
+    ------
+    msg : Msg
+        The messages from each plan in turn
+    '''
+    rets = deque()
+    for p in args:
+        rets.append((yield from p))
+    return tuple(rets)
+
+
+def print_summary_wrapper(plan):
+    """Print summary of plan as it goes by
+
+    Prints a minimal version of the plan, showing only moves and
+    where events are created.  Yields the `Msg` unchanged.
+
+    Parameters
+    ----------
+    plan : iterable
+        Must yield `Msg` objects
+
+    Yields
+    ------
+    msg : `Msg`
+    """
+
+    read_cache = []
+    for msg in plan:
+        cmd = msg.command
+        if cmd == 'open_run':
+            print('{:=^80}'.format(' Open Run '))
+        elif cmd == 'close_run':
+            print('{:=^80}'.format(' Close Run '))
+        elif cmd == 'set':
+            print('{motor.name} -> {args[0]}'.format(motor=msg.obj,
+                                                     args=msg.args))
+        elif cmd == 'create':
+            pass
+        elif cmd == 'read':
+            read_cache.append(msg.obj.name)
+        elif cmd == 'save':
+            print('  Read {}'.format(read_cache))
+            read_cache = []
+        yield msg
+
+
+def run_wrapper(plan, *, md=None):
+    """Enclose in 'open_run' and 'close_run' messages.
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        a generator, list, or similar containing `Msg` objects
+    md : dict, optional
+        metadata to be passed into the 'open_run' message
+    """
+    rs_uid = yield from open_run(md)
+
+    def except_plan(e):
+        if isinstance(e, RunEngineControlException):
+            yield from close_run()
+        else:
+            yield from close_run(exit_status='fail', reason=str(e))
+
+    yield from contingency_wrapper(plan,
+                                   except_plan=except_plan,
+                                   else_plan=close_run)
+    return rs_uid
+
+
+def subs_wrapper(plan, subs):
+    """
+    Subscribe callbacks to the document stream; finally, unsubscribe.
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        a generator, list, or similar containing `Msg` objects
+    subs : callable, list of callables, or dict of lists of callables
+         Documents of each type are routed to a list of functions.
+         Input is normalized to a dict of lists of functions, like so:
+
+         None -> {'all': [], 'start': [], 'stop': [], 'event': [],
+                  'descriptor': []}
+
+         func -> {'all': [func], 'start': [], 'stop': [], 'event': [],
+                  'descriptor': []}
+
+         [f1, f2] -> {'all': [f1, f2], 'start': [], 'stop': [], 'event': [],
+                      'descriptor': []}
+
+         {'event': [func]} ->  {'all': [], 'start': [], 'stop': [],
+                                'event': [func], 'descriptor': []}
+
+         Signature of functions must confirm to `f(name, doc)` where
+         name is one of {'all', 'start', 'stop', 'event', 'descriptor'} and
+         doc is a dictionary.
+
+    Yields
+    ------
+    msg : Msg
+        messages from plan, with 'subscribe' and 'unsubscribe' messages
+        inserted and appended
+    """
+    subs = normalize_subs_input(subs)
+    tokens = set()
+
+    def _subscribe():
+        for name, funcs in subs.items():
+            for func in funcs:
+                token = yield Msg('subscribe', None, func, name)
+                tokens.add(token)
+
+    def _unsubscribe():
+        for token in tokens:
+            yield Msg('unsubscribe', None, token=token)
+
+    def _inner_plan():
+        yield from _subscribe()
+        return (yield from plan)
+
+    return (yield from finalize_wrapper(_inner_plan(),
+                                        _unsubscribe()))
+
+
+def configure_count_time_wrapper(plan, time):
+    """
+    Preprocessor that sets all devices with a `count_time` to the same time.
+
+    The original setting is stashed and restored at the end.
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        a generator, list, or similar containing `Msg` objects
+    time : float or None
+        If None, the plan passes through unchanged.
+
+    Yields
+    ------
+    msg : Msg
+        messages from plan, with 'set' messages inserted
+    """
+    devices_seen = set()
+    original_times = {}
+
+    def insert_set(msg):
+        obj = msg.obj
+        if obj is not None and obj not in devices_seen:
+            devices_seen.add(obj)
+            if hasattr(obj, 'count_time'):
+                # TODO Do this with a 'read' Msg once reads can be
+                # marked as belonging to a different event stream (or no
+                # event stream.
+                original_times[obj] = obj.count_time.get()
+                # TODO do this with configure
+                return pchain(mv(obj.count_time, time),
+                              single_gen(msg)), None
+        return None, None
+
+    def reset():
+        for obj, time in original_times.items():
+            yield from mv(obj.count_time, time)
+
+    if time is None:
+        # no-op
+        return (yield from plan)
+    else:
+        return (yield from finalize_wrapper(plan_mutator(plan, insert_set),
+                                            reset()))
+
+
+def finalize_wrapper(plan, final_plan, *, pause_for_debug=False):
+    '''try...finally helper
+
+    Run the first plan and then the second.  If any of the messages
+    raise an error in the RunEngine (or otherwise), the second plan
+    will attempted to be run anyway.
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        a generator, list, or similar containing `Msg` objects
+    final_plan : callable, iterable or iterator
+        a generator, list, or similar containing `Msg` objects or a callable
+        that reurns one; attempted to be run no matter what happens in the
+        first plan
+    pause_for_debug : bool, optional
+        If the plan should pause before running the clean final_plan in
+        the case of an Exception.  This is intended as a debugging tool only.
+    Yields
+    ------
+    msg : Msg
+        messages from `plan` until it terminates or an error is raised, then
+        messages from `final_plan`
+    '''
+    # If final_plan is a generator *function* (as opposed to a generator
+    # *instance*), call it.
+    if callable(final_plan):
+        final_plan_instance = final_plan()
+    else:
+        final_plan_instance = final_plan
+    cleanup = True
+    try:
+        ret = yield from plan
+    except GeneratorExit:
+        cleanup = False
+        raise
+    except:
+        if pause_for_debug:
+            yield from pause()
+        raise
+    finally:
+        # if the exception raised in `GeneratorExit` that means
+        # someone called `gen.close()` on this generator.  In those
+        # cases generators must either re-raise the GeneratorExit or
+        # raise a different exception.  Trying to yield any values
+        # results in a RuntimeError being raised where `close` is
+        # called.  Thus, we catch, the GeneratorExit, disable cleanup
+        # and then re-raise
+
+        # https://docs.python.org/3/reference/expressions.html?#generator.close
+        if cleanup:
+            yield from ensure_generator(final_plan_instance)
+    return ret
+
+
+def contingency_wrapper(plan, *,
+                        except_plan=None,
+                        else_plan=None,
+                        final_plan=None,
+                        pause_for_debug=False):
+    '''try...except...else...finally helper
+
+    Run the first plan and then the second.  If any of the messages
+    raise an error in the RunEngine (or otherwise), the second plan
+    will attempted to be run anyway.
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        a generator, list, or similar containing `Msg` objects
+    except_plan : generator function, optional
+        this will be called with the exception as the only input.  The
+        plan does not need to re-raise, but may if you want to change the
+        exception.
+
+        Only subclasses of `Exception` will be passed in, will not see
+        `GeneratorExit`, `SystemExit`, or `KeyboardInterrupt`
+    else_plan : generator function, optional
+        well be called with no arguments if plan completes without raising
+    final_plan : generator function, optional
+        a generator, list, or similar containing `Msg` objects or a callable
+        that reurns one; attempted to be run no matter what happens in the
+        first plan
+    pause_for_debug : bool, optional
+        If the plan should pause before running the clean final_plan in
+        the case of an Exception.  This is intended as a debugging tool only.
+    Yields
+    ------
+    msg : Msg
+        messages from `plan` until it terminates or an error is raised, then
+        messages from `final_plan`
+    '''
+    cleanup = True
+    try:
+        ret = yield from plan
+    except GeneratorExit:
+        cleanup = False
+        raise
+    except Exception as e:
+        if pause_for_debug:
+            yield from pause()
+        if except_plan:
+            # it might be better to throw this in, but this is simpler
+            # to implement for now
+            yield from except_plan(e)
+        raise
+    else:
+        if else_plan:
+            yield from else_plan()
+    finally:
+        # if the exception raised in `GeneratorExit` that means
+        # someone called `gen.close()` on this generator.  In those
+        # cases generators must either re-raise the GeneratorExit or
+        # raise a different exception.  Trying to yield any values
+        # results in a RuntimeError being raised where `close` is
+        # called.  Thus, we catch, the GeneratorExit, disable cleanup
+        # and then re-raise
+
+        # https://docs.python.org/3/reference/expressions.html?#generator.close
+        if cleanup and final_plan:
+            yield from final_plan()
+    return ret
+
+
+def finalize_decorator(final_plan):
+    '''try...finally helper
+
+    Run the first plan and then the second.  If any of the messages
+    raise an error in the RunEngine (or otherwise), the second plan
+    will attempted to be run anyway.
+
+    Notice that, this decorator requires a generator *function* so that it can
+    be used multiple times, whereas :func:`bluesky.plans.finalize_wrapper`
+    accepts either a generator function or a generator instance.
+
+    Parameters
+    ----------
+    final_plan : callable
+        a callable that returns a generator, list, or similar containing `Msg`
+        objects; attempted to be run no matter what happens in the first plan
+
+    Yields
+    ------
+    msg : Msg
+        messages from `plan` until it terminates or an error is raised, then
+        messages from `final_plan`
+    '''
+    def dec(gen_func):
+        @wraps(gen_func)
+        def dec_inner(*inner_args, **inner_kwargs):
+            if not callable(final_plan):
+                raise TypeError("final_plan must be a callable (e.g., a "
+                                "generator function) not an iterable (e.g., a "
+                                "generator instance).")
+            final_plan_instance = final_plan()
+            plan = gen_func(*inner_args, **inner_kwargs)
+            cleanup = True
+            try:
+                ret = yield from plan
+            except GeneratorExit:
+                cleanup = False
+                raise
+            finally:
+                # if the exception raised in `GeneratorExit` that means
+                # someone called `gen.close()` on this generator.  In those
+                # cases generators must either re-raise the GeneratorExit or
+                # raise a different exception.  Trying to yield any values
+                # results in a RuntimeError being raised where `close` is
+                # called.  Thus, we catch, the GeneratorExit, disable cleanup
+                # and then re-raise
+
+                # https://docs.python.org/3/reference/expressions.html?#generator.close
+                if cleanup:
+                    yield from ensure_generator(final_plan_instance)
+            return ret
+        return dec_inner
+    return dec
+
+
+def rewindable_wrapper(plan, rewindable):
+    '''Toggle the 'rewindable' state of the RE
+
+    Allow or disallow rewinding during the processing of the wrapped messages.
+    Then restore the initial state (rewindable or not rewindable).
+
+    Parameters
+    ----------
+    plan : generator
+        The plan to wrap in a 'rewindable' or 'not rewindable' context
+    rewindable : bool
+
+    '''
+    initial_rewindable = True
+
+    def capture_rewindable_state():
+        nonlocal initial_rewindable
+        initial_rewindable = yield Msg('rewindable', None, None)
+
+    def set_rewindable(rewindable):
+        if initial_rewindable != rewindable:
+            return (yield Msg('rewindable', None, rewindable))
+
+    def restore_rewindable():
+        if initial_rewindable != rewindable:
+            return (yield Msg('rewindable', None, initial_rewindable))
+
+    if not rewindable:
+        yield from capture_rewindable_state()
+        yield from set_rewindable(rewindable)
+        return (yield from finalize_wrapper(plan,
+                                            restore_rewindable()))
+    else:
+        return (yield from plan)
+
+
+def inject_md_wrapper(plan, md):
+    """
+    Inject additional metadata into a run.
+
+    This takes precedences over the original metadata dict in the event of
+    overlapping keys, but it does not mutate the original metadata dict.
+    (It uses ChainMap.)
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        a generator, list, or similar containing `Msg` objects
+    md : dict
+        metadata
+    """
+    def _inject_md(msg):
+        if msg.command == 'open_run':
+            msg = msg._replace(kwargs=ChainMap(md, msg.kwargs))
+        return msg
+
+    return (yield from msg_mutator(plan, _inject_md))
+
+
+def stub_wrapper(plan):
+    """
+    Remove Msg object in order to use plan as a stub
+
+    This will remove any `open_run`, `close_run`, `stage` and `unstage` `Msg`
+    objects present in the plan in order for it to be run as part of a larger
+    scan. Note, that any metadata from the provided plan will not be sent to
+    the RunEngine automatically.
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        A generator list or similar containing `Msg` objects
+
+    Returns
+    -------
+    md : dict
+        Metadata discovered from `open_run` Msg
+    """
+    md = {}
+
+    def _block_run_control(msg):
+        """
+        Block open and close run messages
+        """
+        # Capture the metadata from open_run
+        if msg.command == 'open_run':
+            md.update(msg.kwargs)
+            return None
+        elif msg.command in ('close_run', 'stage', 'unstage'):
+            return None
+        return msg
+
+    yield from msg_mutator(plan, _block_run_control)
+    return md
+
+
+def monitor_during_wrapper(plan, signals):
+    """
+    Monitor (asynchronously read) devices during runs.
+
+    This is a preprocessor that insert messages immediately after a run is
+    opened and before it is closed.
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        a generator, list, or similar containing `Msg` objects
+    signals : collection
+        objects that support the Signal interface
+
+    Yields
+    ------
+    msg : Msg
+        messages from plan with 'monitor', and 'unmontior' messages inserted
+
+    See Also
+    --------
+    :func:`bluesky.plans.fly_during_wrapper`
+    """
+    monitor_msgs = [Msg('monitor', sig, name=sig.name + '_monitor')
+                    for sig in signals]
+    unmonitor_msgs = [Msg('unmonitor', sig) for sig in signals]
+
+    def insert_after_open(msg):
+        if msg.command == 'open_run':
+            def new_gen():
+                yield from ensure_generator(monitor_msgs)
+            return single_gen(msg), new_gen()
+        else:
+            return None, None
+
+    def insert_before_close(msg):
+        if msg.command == 'close_run':
+            def new_gen():
+                yield from ensure_generator(unmonitor_msgs)
+                yield msg
+            return new_gen(), None
+        else:
+            return None, None
+
+    # Apply nested mutations.
+    plan1 = plan_mutator(plan, insert_after_open)
+    plan2 = plan_mutator(plan1, insert_before_close)
+    return (yield from plan2)
+
+
+def fly_during_wrapper(plan, flyers):
+    """
+    Kickoff and collect "flyer" (asynchronously collect) objects during runs.
+
+    This is a preprocessor that insert messages immediately after a run is
+    opened and before it is closed.
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        a generator, list, or similar containing `Msg` objects
+    flyers : collection
+        objects that support the flyer interface
+
+    Yields
+    ------
+    msg : Msg
+        messages from plan with 'kickoff', 'wait' and 'collect' messages
+        inserted
+
+    See Also
+    --------
+    :func:`bluesky.plans.fly`
+    """
+    grp1 = _short_uid('flyers-kickoff')
+    grp2 = _short_uid('flyers-complete')
+    kickoff_msgs = [Msg('kickoff', flyer, group=grp1) for flyer in flyers]
+    complete_msgs = [Msg('complete', flyer, group=grp2) for flyer in flyers]
+    collect_msgs = [Msg('collect', flyer) for flyer in flyers]
+    if flyers:
+        # If there are any flyers, insert a 'wait' Msg after kickoff, complete
+        kickoff_msgs += [Msg('wait', None, group=grp1)]
+        complete_msgs += [Msg('wait', None, group=grp2)]
+
+    def insert_after_open(msg):
+        if msg.command == 'open_run':
+            def new_gen():
+                yield from ensure_generator(kickoff_msgs)
+            return single_gen(msg), new_gen()
+        else:
+            return None, None
+
+    def insert_before_close(msg):
+        if msg.command == 'close_run':
+            def new_gen():
+                yield from ensure_generator(complete_msgs)
+                yield from ensure_generator(collect_msgs)
+                yield msg
+            return new_gen(), None
+        else:
+            return None, None
+
+    # Apply nested mutations.
+    plan1 = plan_mutator(plan, insert_after_open)
+    plan2 = plan_mutator(plan1, insert_before_close)
+    return (yield from plan2)
+
+
+def lazily_stage_wrapper(plan):
+    """
+    This is a preprocessor that inserts 'stage' messages and appends 'unstage'.
+
+    The first time an object is seen in `plan`, it is staged. To avoid
+    redundant staging we actually stage the object's ultimate parent.
+
+    At the end, in a `finally` block, an 'unstage' Message issued for every
+    'stage' Message.
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        a generator, list, or similar containing `Msg` objects
+
+    Yields
+    ------
+    msg : Msg
+        messages from plan with 'stage' messages inserted and 'unstage'
+        messages appended
+    """
+    COMMANDS = set(['read', 'set', 'trigger', 'kickoff'])
+    # Cache devices in the order they are staged; then unstage in reverse.
+    devices_staged = []
+
+    def inner(msg):
+        if msg.command in COMMANDS and msg.obj not in devices_staged:
+            root = root_ancestor(msg.obj)
+
+            def new_gen():
+                # Here we insert a 'stage' message
+                ret = yield Msg('stage', root)
+                # and cache the result
+                if ret is None:
+                    # The generator may be being list-ified.
+                    # This is a hack to make that possible.
+                    ret = [root]
+                devices_staged.extend(ret)
+                # and then proceed with our regularly scheduled programming
+                yield msg
+            return new_gen(), None
+        else:
+            return None, None
+
+    def unstage_all():
+        for device in reversed(devices_staged):
+            yield Msg('unstage', device)
+
+    return (yield from finalize_wrapper(plan_mutator(plan, inner),
+                                        unstage_all()))
+
+
+def stage_wrapper(plan, devices):
+    """
+    'Stage' devices (i.e., prepare them for use, 'arm' them) and then unstage.
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        a generator, list, or similar containing `Msg` objects
+    devices : collection
+        list of devices to stage immediately on entrance and unstage on exit
+
+    Yields
+    ------
+    msg : Msg
+        messages from plan with 'stage' and finally 'unstage' messages inserted
+
+    See Also
+    --------
+    :func:`bluesky.plans.lazily_stage_wrapper`
+    :func:`bluesky.plans.stage`
+    :func:`bluesky.plans.unstage`
+    """
+    devices = separate_devices(root_ancestor(device) for device in devices)
+
+    def stage_devices():
+        for d in devices:
+            yield Msg('stage', d)
+
+    def unstage_devices():
+        for d in reversed(devices):
+            yield Msg('unstage', d)
+
+    def inner():
+        yield from stage_devices()
+        return (yield from plan)
+
+    return (yield from finalize_wrapper(inner(), unstage_devices()))
+
+
+def _normalize_devices(devices):
+    coupled_parents = set()
+    # if we have any pseudo devices then setting any part of it
+    # needs to trigger the relative behavior.
+    io, co, go = merge_axis(devices)
+    devices = set(devices) | set(io) | set(co) | set(go)
+    # if a device with coupled children is directly in the
+    # list, include all the coupled children as well
+    for obj in co:
+        devices |= set(obj.pseudo_positioners)
+        coupled_parents.add(obj)
+
+    # if at least one child of a device with coupled children
+    # only include the coupled children if at least of the children
+    # directly included is one of the coupled ones.
+    for obj, type_map in go.items():
+        if len(type_map['pseudo']) > 0:
+            devices |= set(obj.pseudo_positioners)
+            coupled_parents.add(obj)
+    return devices, coupled_parents
+
+
+def __read_and_stash_a_motor(obj, initial_positions, coupled_parents):
+    """Internal plan for relative set and reset wrappers
+
+
+    .. warning ::
+
+       Do not use this plan directly for any reason.
+
+    """
+    # obj should have a `position` attribution
+    try:
+        cur_pos = obj.position
+    except AttributeError:
+        # ... but as a fallback we can read obj and grab the value of the
+        # first key
+        reading = yield Msg('read', obj)
+        if reading is None:
+            # this plan may be being list-ified
+            cur_pos = 0
+        else:
+            fields = getattr(obj, 'hints', {}).get('fields', [])
+            if len(fields) == 1:
+                k, = fields
+                cur_pos = reading[k]['value']
+            elif len(fields) == 0:
+                k = list(reading.keys())[0]
+                cur_pos = reading[k]['value']
+            else:
+                raise Exception("do not yet know how to deal with "
+                                "non pseudopositioner multi-axis.  Please "
+                                "contact DAMA to justify why you need "
+                                "this.")
+
+    initial_positions[obj] = cur_pos
+
+    # if we move a pseudo positioner also stash it's children
+    if obj in coupled_parents:
+        for c, p in zip(obj.pseudo_positioners, cur_pos):
+            initial_positions[c] = p
+
+    # if we move a pseudo single, also stash it's parent and siblings
+    parent = obj.parent
+    if parent in coupled_parents and obj in parent.pseudo_positioners:
+        parent_pos = parent.position
+        initial_positions[parent] = parent_pos
+        for c, p in zip(parent.pseudo_positioners, parent_pos):
+            initial_positions[c] = p
+
+    # TODO forbid mixed pseudo / real motion
+
+
+def relative_set_wrapper(plan, devices=None):
+    """
+    Interpret 'set' messages on devices as relative to initial position.
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        a generator, list, or similar containing `Msg` objects
+    devices : collection or None, optional
+        if default (None), apply to all devices that are moved by the plan
+
+    Yields
+    ------
+    msg : Msg
+        messages from plan, with 'read' messages inserted and 'set' messages
+        mutated
+    """
+    initial_positions = {}
+    if devices is not None:
+        devices, coupled_parents = _normalize_devices(devices)
+    else:
+        coupled_parents = set()
+
+    def rewrite_pos(msg):
+        if (msg.command == 'set') and (msg.obj in initial_positions):
+            rel_pos, = msg.args
+            abs_pos = initial_positions[msg.obj] + rel_pos
+            new_msg = msg._replace(args=(abs_pos,))
+            return new_msg
+        else:
+            return msg
+
+    def insert_reads(msg):
+        eligible = (devices is None) or (msg.obj in devices)
+        seen = msg.obj in initial_positions
+        if (msg.command == 'set') and eligible and not seen:
+                return (pchain(
+                    __read_and_stash_a_motor(
+                        msg.obj, initial_positions, coupled_parents),
+                    single_gen(msg)), None)
+        else:
+            return None, None
+
+    plan = plan_mutator(plan, insert_reads)
+    plan = msg_mutator(plan, rewrite_pos)
+    return (yield from plan)
+
+
+def reset_positions_wrapper(plan, devices=None):
+    """
+    Return movable devices to their initial positions at the end.
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        a generator, list, or similar containing `Msg` objects
+    devices : collection or None, optional
+        If default (None), apply to all devices that are moved by the plan.
+
+    Yields
+    ------
+    msg : Msg
+        messages from plan with 'read' and finally 'set' messages inserted
+    """
+    initial_positions = OrderedDict()
+    if devices is not None:
+        devices, coupled_parents = _normalize_devices(devices)
+    else:
+        coupled_parents = set()
+
+    def read_and_stash_a_motor(obj):
+        try:
+            cur_pos = obj.position
+        except AttributeError:
+            reading = yield Msg('read', obj)
+            if reading is None:
+                # this plan may be being list-ified
+                cur_pos = 0
+            else:
+                k = list(reading.keys())[0]
+                cur_pos = reading[k]['value']
+        initial_positions[obj] = cur_pos
+
+    def insert_reads(msg):
+        eligible = devices is None or msg.obj in devices
+        seen = msg.obj in initial_positions
+        if (msg.command == 'set') and eligible and not seen:
+            return (pchain(
+                    __read_and_stash_a_motor(
+                        msg.obj, initial_positions, coupled_parents),
+                    single_gen(msg)), None)
+        else:
+            return None, None
+
+    def reset():
+        blk_grp = 'reset-{}'.format(str(uuid.uuid4())[:6])
+        for k, v in initial_positions.items():
+            yield Msg('set', k, v, group=blk_grp)
+        yield Msg('wait', None, group=blk_grp)
+
+    return (yield from finalize_wrapper(plan_mutator(plan, insert_reads),
+                                        reset()))
+
+
+def baseline_wrapper(plan, devices, name='baseline'):
+    """
+    Preprocessor that records a baseline of all `devices` after `open_run`
+
+    The readings are designated for a separate event stream named 'baseline' by
+    default.
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        a generator, list, or similar containing `Msg` objects
+    devices : collection
+        collection of Devices to read
+        If None, the plan passes through unchanged.
+    name : string, optional
+        name for event stream; by default, 'baseline'
+
+    Yields
+    ------
+    msg : Msg
+        messages from plan, with 'set' messages inserted
+    """
+    def insert_baseline(msg):
+        if msg.command == 'open_run':
+            return None, trigger_and_read(devices, name=name)
+
+        elif msg.command == 'close_run':
+            def post_baseline():
+                yield from trigger_and_read(devices, name=name)
+                return (yield msg)
+
+            return post_baseline(), None
+
+        return None, None
+
+    if not devices:
+        # no-op
+        return (yield from plan)
+    else:
+        return (yield from plan_mutator(plan, insert_baseline))
+
+
+# Make generator function decorator for each generator instance wrapper.
+baseline_decorator = make_decorator(baseline_wrapper)
+subs_decorator = make_decorator(subs_wrapper)
+relative_set_decorator = make_decorator(relative_set_wrapper)
+reset_positions_decorator = make_decorator(reset_positions_wrapper)
+# finalize_decorator is custom-made since it takes a plan as its
+# argument. See its docstring for details why.
+lazily_stage_decorator = make_decorator(lazily_stage_wrapper)
+stage_decorator = make_decorator(stage_wrapper)
+fly_during_decorator = make_decorator(fly_during_wrapper)
+monitor_during_decorator = make_decorator(monitor_during_wrapper)
+inject_md_decorator = make_decorator(inject_md_wrapper)
+run_decorator = make_decorator(run_wrapper)
+contingency_decorator = make_decorator(contingency_wrapper)
+stub_decorator = make_decorator(stub_wrapper)
+configure_count_time_decorator = make_decorator(configure_count_time_wrapper)
+
+
+class SupplementalData:
+    """
+    A configurable preprocessor for supplemental measurements
+
+    This is a plan preprocessor. It inserts messages into plans to:
+
+    * take "baseline" readings at the beginning and end of each run for the
+      devices listed in its ``baseline`` atrribute
+    * kick off "flyable" devices listed in its ``flyers`` attribute at the
+      beginning of each run and collect their data at the end
+    * monitor signals in its ``monitors`` attribute for asynchronous
+      updates during each run.
+
+    Internally, it uses the plan preprocessors:
+
+    * :func:`baseline_wrapper`
+    * :func:`monitor_during_wrapper`
+    * :func:`flyer_during_wrapper`
+
+    Parameters
+    ----------
+    baseline : list
+        Devices to be read at the beginning and end of each run
+    monitors : list
+        Signals (not multi-signal Devices) to be monitored during each run,
+        generating readings asynchronously
+    flyers : list
+        "Flyable" Devices to be kicked off before each run and collected
+        at the end of each run
+
+    Examples
+    --------
+    Create an instance of SupplementalData and apply it to a RunEngine.
+
+    >>> sd = SupplementalData(baseline=[some_motor, some_detector]),
+    ...                       monitors=[some_signal],
+    ...                       flyers=[some_flyer])
+    >>> RE = RunEngine({})
+    >>> RE.preprocessors.append(sd)
+
+    Now all plans executed by RE will be modified to add baseline readings
+    (before and after each run), monitors (during each run), and flyers
+    (kicked off before each run and collected afterward).
+
+    Inspect or update the lists of devices interactively.
+
+    >>> sd.baseline
+    [some_motor, some_detector]
+
+    >>> sd.baseline.remove(some_motor)
+
+    >>> sd.baseline
+    [some_detector]
+
+    >>> sd.baseline.append(another_detector)
+
+    >>> sd.baseline
+    [some_detector, another_detector]
+
+    Each attribute (``baseline``, ``monitors``, ``flyers``) is an ordinary
+    Python list, support all the standard list methods, such as:
+
+    >>> sd.baseline.clear()
+
+    The arguments to SupplementalData are optional. All the lists
+    will empty by default.  As shown above, they can be populated
+    interactively.
+
+    >>> sd = SupplementalData()
+    >>> RE = RunEngine({})
+    >>> RE.preprocessors.append(sd)
+    >>> sd.baseline.append(some_detector)
+    """
+    def __init__(self, *, baseline=None, monitors=None, flyers=None):
+        if baseline is None:
+            baseline = []
+        if monitors is None:
+            monitors = []
+        if flyers is None:
+            flyers = []
+        self.baseline = list(baseline)
+        self.monitors = list(monitors)
+        self.flyers = list(flyers)
+
+    def __repr__(self):
+        return ("{cls}(baseline={baseline}, monitors={monitors}, "
+                "flyers={flyers})"
+                "").format(cls=type(self).__name__, **vars(self))
+
+    # I'm not sure why anyone would want to pickle this but it's good manners
+    # to avoid breaking pickling.
+
+    def __setstate__(self, state):
+        baseline, monitors, flyers = state
+        self.baseline = baseline
+        self.monitors = monitors
+        self.flyers = flyers
+
+    def __getstate__(self):
+        return (self.baseline, self.monitors, self.flyers)
+
+    def __call__(self, plan):
+        """
+        Insert messages into a plan.
+
+        Parameters
+        ----------
+        plan : iterable or iterator
+            a generator, list, or similar containing `Msg` objects
+        """
+        plan = baseline_wrapper(plan, self.baseline)
+        plan = monitor_during_wrapper(plan, self.monitors)
+        plan = fly_during_wrapper(plan, self.flyers)
+        return (yield from plan)

--- a/bluesky/simulators.py
+++ b/bluesky/simulators.py
@@ -1,5 +1,5 @@
 from warnings import warn
-from bluesky.plans import print_summary_wrapper
+from bluesky.preprocessors import print_summary_wrapper
 
 
 def plot_raster_path(plan, x_motor, y_motor, ax=None, probe_size=None, lw=2):

--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -1,5 +1,6 @@
 import ast
-from bluesky.plans import scan, SupplementalData
+from bluesky.plans import scan
+from bluesky.preprocessors import SupplementalData
 from bluesky.callbacks.best_effort import BestEffortCallback
 
 

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -7,14 +7,13 @@ from bluesky.examples import (simple_scan, sleepy, wait_one,
 from bluesky.callbacks import LivePlot
 from bluesky import (Msg, IllegalMessageSequence,
                      RunEngineInterrupted, FailedStatus)
-import bluesky.plans as bp
+import bluesky.plan_stubs as bps
 import os
 import signal
 import asyncio
 import time as ttime
 import numpy as np
 from numpy.testing import assert_array_equal
-import pytest
 
 
 def test_msgs(RE, hw):
@@ -658,8 +657,8 @@ def test_async_trigger_delay(RE, hw):
     hw.motor.delay = .5
     hw.det.exposure_time = .5
 
-    _time_test(bp.trigger, .5, hw.det, wait=True)
-    _time_test(bp.abs_set, .5, hw.motor, 1, wait=True)
+    _time_test(bps.trigger, .5, hw.det, wait=True)
+    _time_test(bps.abs_set, .5, hw.motor, 1, wait=True)
 
 
 def test_reg_reader(hw, db):

--- a/bluesky/tests/test_generators.py
+++ b/bluesky/tests/test_generators.py
@@ -5,10 +5,12 @@ from itertools import zip_longest
 
 from bluesky import Msg
 
-from bluesky.plans import (msg_mutator, stub_wrapper, plan_mutator, pchain,
-                           single_gen as single_message_gen, finalize_wrapper)
+from bluesky.preprocessors import (msg_mutator, stub_wrapper,
+                                   plan_mutator, pchain, single_gen as
+                                   single_message_gen,
+                                   finalize_wrapper)
 
-from bluesky.utils import ensure_generator, single_gen
+from bluesky.utils import ensure_generator
 
 
 class EchoException(Exception):

--- a/bluesky/tests/test_magics.py
+++ b/bluesky/tests/test_magics.py
@@ -1,6 +1,6 @@
 from bluesky.magics import BlueskyMagics
 import bluesky.plans as bp
-from collections import OrderedDict
+import bluesky.plan_stubs as bps
 import os
 import pytest
 import signal
@@ -21,12 +21,18 @@ def compare_msgs(actual, expected):
 
 
 @pytest.mark.parametrize('pln,plnargs,magic,line', [
-    (bp.mv, lambda hw: (hw.motor1, 2), 'mov', 'motor1 2'),
-    (bp.mv, lambda hw: (hw.motor1, 2, hw.motor2, 3), 'mov', 'motor1 2 motor2 3'),
-    (bp.mvr, lambda hw: (hw.motor1, 2), 'movr', 'motor1 2'),
-    (bp.mvr, lambda hw: (hw.motor1, 2, hw.motor2, 3), 'movr', 'motor1 2 motor2 3'),
-    (bp.count, lambda hw: ([hw.invariant1],), 'ct', 'dets'),
-    (bp.count, lambda hw: ([hw.invariant1, hw.invariant2],), 'ct', ''),
+    (bps.mv, lambda hw: (hw.motor1, 2),
+     'mov', 'motor1 2'),
+    (bps.mv, lambda hw: (hw.motor1, 2, hw.motor2, 3),
+     'mov', 'motor1 2 motor2 3'),
+    (bps.mvr, lambda hw: (hw.motor1, 2),
+     'movr', 'motor1 2'),
+    (bps.mvr, lambda hw: (hw.motor1, 2, hw.motor2, 3),
+     'movr', 'motor1 2 motor2 3'),
+    (bp.count, lambda hw: ([hw.invariant1],),
+     'ct', 'dets'),
+    (bp.count, lambda hw: ([hw.invariant1, hw.invariant2],),
+     'ct', ''),
     ])
 def test_bluesky_magics(pln, plnargs, line, magic, RE, hw):
     # Build a FakeIPython instance to use the magics with.
@@ -45,11 +51,11 @@ def test_bluesky_magics(pln, plnargs, line, magic, RE, hw):
     sm.RE.msg_hook = collect
 
     # Test magics cause the RunEngine to execute the messages we expect.
-    RE(bp.mv(hw.motor1, 10, hw.motor2, 10))  # ensure known initial state
+    RE(bps.mv(hw.motor1, 10, hw.motor2, 10))  # ensure known initial state
     RE(pln(*plnargs(hw)))
     expected = msgs.copy()
     msgs.clear()
-    RE(bp.mv(hw.motor1, 10, hw.motor2, 10))  # ensure known initial state
+    RE(bps.mv(hw.motor1, 10, hw.motor2, 10))  # ensure known initial state
     getattr(sm, magic)(line)
     actual = msgs.copy()
     msgs.clear()

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -1,53 +1,58 @@
-from collections import deque, defaultdict
+from collections import defaultdict
 import pytest
 from bluesky import Msg, RunEngineInterrupted
-from bluesky.plans import (create, save, read, monitor, unmonitor, null,
-                           abs_set, rel_set, trigger, sleep, wait, checkpoint,
-                           clear_checkpoint, pause, deferred_pause, kickoff,
-                           collect, configure, stage, unstage, subscribe,
-                           unsubscribe, open_run, close_run, wait_for, mv, mvr,
-                           subs_context, run_context, event_context,
-                           baseline_context, monitor_context,
-                           stage_context, planify, finalize_wrapper,
-                           fly_during_wrapper, reset_positions_wrapper,
-                           monitor_during_wrapper,
-                           lazily_stage_wrapper, relative_set_wrapper,
-                           subs_wrapper, trigger_and_read, stop,
-                           repeater, caching_repeater, count,
-                           fly_during_decorator, subs_decorator,
-                           monitor_during_decorator,
-                           inject_md_wrapper, finalize_decorator,
-                           configure_count_time_wrapper)
+from bluesky.plan_stubs import (
+    create,
+    save,
+    read,
+    monitor,
+    unmonitor,
+    null,
+    abs_set,
+    rel_set,
+    trigger,
+    sleep,
+    wait,
+    checkpoint,
+    clear_checkpoint,
+    pause,
+    deferred_pause,
+    kickoff,
+    collect,
+    configure,
+    stage,
+    unstage,
+    subscribe,
+    unsubscribe,
+    open_run,
+    close_run,
+    wait_for,
+    mv,
+    mvr,
+    trigger_and_read,
+    stop,
+    repeater,
+    caching_repeater,)
+from bluesky.preprocessors import (
+    finalize_wrapper,
+    fly_during_wrapper,
+    reset_positions_wrapper,
+    monitor_during_wrapper,
+    lazily_stage_wrapper,
+    relative_set_wrapper,
+    subs_wrapper,
+    fly_during_decorator,
+    subs_decorator,
+    monitor_during_decorator,
+    inject_md_wrapper,
+    finalize_decorator,
+    configure_count_time_wrapper)
+
+from bluesky.plans import count
+
 import bluesky.plans as bp
 
 from bluesky.utils import all_safe_rewind
-
-
-class DummyMover:
-    def __init__(self, name):
-        self._value = 0
-        self.name = name
-        self.parent = None
-
-    def describe(self):
-        return {self.name: {}}
-
-    def set(self, value):
-        self._value = value
-        return NullStatus()
-
-    def read_configuration(self):
-        return {}
-
-    def describe_configuration(self):
-        return {}
-
-    def read(self):
-        return {self.name: {'value': self._value, 'timestamp': 0}}
-
-
-def cb(name, doc):
-    pass
 
 
 @pytest.mark.parametrize(
@@ -222,6 +227,7 @@ def test_fly_during():
 
 def test_lazily_stage(hw):
     det1, det2 = hw.det1, hw.det2
+
     def plan():
         yield from [Msg('read', det1), Msg('read', det1), Msg('read', det2)]
 
@@ -312,7 +318,8 @@ def test_finalize(hw):
     assert processed_plan == expected
 
     # or func that returns list
-    processed_plan = list(finalize_decorator(lambda: [Msg('read', det)])(plan)())
+    processed_plan = list(finalize_decorator(
+        lambda: [Msg('read', det)])(plan)())
     expected = [Msg('null'), Msg('read', det)]
     assert processed_plan == expected
 
@@ -341,7 +348,7 @@ def test_finalize_runs_after_error(RE, hw):
     try:
         RE(finalize_wrapper(plan(), [Msg('read', det)]))
     except Exception:
-        pass # swallow the Exception; we are interested in msgs below
+        pass  # swallow the Exception; we are interested in msgs below
 
     expected = [Msg('null'), Msg('read', det)]
 

--- a/bluesky/tests/test_progress_bar.py
+++ b/bluesky/tests/test_progress_bar.py
@@ -1,5 +1,5 @@
 from bluesky.utils import ProgressBar, ProgressBarManager
-from bluesky.plans import mv
+from bluesky.plan_stubs import mv
 from bluesky.tests import requires_ophyd
 from bluesky import RunEngine
 from collections import OrderedDict

--- a/bluesky/tests/test_ramp_plan.py
+++ b/bluesky/tests/test_ramp_plan.py
@@ -1,6 +1,7 @@
 from bluesky.tests import requires_ophyd
 from bluesky.tests.utils import DocCollector
-from bluesky.plans import (ramp_plan, trigger_and_read)
+from bluesky.plans import ramp_plan
+from bluesky.plan_stubs import trigger_and_read
 from bluesky import Msg
 from bluesky.utils import RampFail
 import numpy as np

--- a/bluesky/tests/test_simulators.py
+++ b/bluesky/tests/test_simulators.py
@@ -14,6 +14,7 @@ def test_print_summary(hw):
     summarize_plan(scan([det], motor, -1, 1, 10))  # new name
     list(print_summary_wrapper(scan([det], motor, -1, 1, 10)))
 
+
 def test_old_module_name(hw):
     det = hw.det
     motor = hw.motor

--- a/bluesky/tests/test_supplemental_data.py
+++ b/bluesky/tests/test_supplemental_data.py
@@ -1,6 +1,7 @@
 import pickle
 from bluesky import SupplementalData
-from bluesky.plans import count, pchain
+from bluesky.plans import count
+from bluesky.preprocessors import pchain
 
 
 def test_monitors(hw):


### PR DESCRIPTION
This will be force-pushed to

The nominal goal is to get all of the local imports into plans.py namespaced so tab-complete only gives you fully boxed plans.

@teddyrendahl @ZLLentz I suspect this will cause you a lot of breakage.

cntx.py is likely to be deleted, all of it's contents were already deprecated.

closes #850 