### PR TITLE
FIX: pseudo reset wrapper

### DIFF
--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -1,5 +1,9 @@
 import itertools
 import uuid
+from cycler import cycler
+from . import utils
+import operator
+from functools import reduce
 
 try:
     # cytools is a drop-in replacement for toolz, implemented in Cython
@@ -212,7 +216,12 @@ def mv(*args):
     """
     group = str(uuid.uuid4())
     status_objects = []
-    for obj, val in partition(2, args):
+
+    cyl = reduce(operator.add,
+                 [cycler(obj, [val]) for
+                  obj, val in partition(2, args)])
+    step, = utils.merge_cycler(cyl)
+    for obj, val in step.items():
         ret = yield Msg('set', obj, val, group=group)
         status_objects.append(ret)
     yield Msg('wait', None, group=group)

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -1043,6 +1043,8 @@ def reset_positions_wrapper(plan, devices=None):
     def reset():
         blk_grp = 'reset-{}'.format(str(uuid.uuid4())[:6])
         for k, v in initial_positions.items():
+            if k.parent in coupled_parents:
+                continue
             yield Msg('set', k, v, group=blk_grp)
         yield Msg('wait', None, group=blk_grp)
 

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -178,3 +178,16 @@ def test_reset_wrapper(hw, RE):
                     p, None]
     assert len(m_col.msgs) == 14
     assert [m.obj for m in m_col.msgs] == expecte_objs
+
+
+@pytest.mark.parametrize('pln', [bps.mv, bps.mvr])
+def test_pseudo_mv(hw, RE, pln):
+    p = hw.pseudo3x3
+    m_col = MsgCollector()
+    RE.msg_hook = m_col
+
+    RE(pln(p.pseudo1, 1,
+           p.pseudo2, 1))
+    expecte_objs = [p, None]
+    assert len(m_col.msgs) == 2
+    assert [m.obj for m in m_col.msgs] == expecte_objs


### PR DESCRIPTION
If parent is in the set of things to be reset, do not reset the
children too.

closes #905

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
