### PR TITLE
Added hint to inner_prod scan

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -111,9 +111,10 @@ class BestEffortCallback(CallbackBase):
             dimensions = GUESS  # Fall back on our GUESS.
             warn("We are ignoring the dimensions hinted because we cannot "
                  "combine streams.")
-        self.dim_fields = [f
-                           for field, stream_name in dimensions
-                           for f in field]
+        # just select the first field
+        # TODO : Allow option for selecting other fields
+        self.dim_fields = [fields[0]
+                           for fields, stream_name in dimensions]
         _, self.dim_stream = dimensions[0]
 
         # Print heading.
@@ -143,6 +144,7 @@ class BestEffortCallback(CallbackBase):
             # look up the actual fields for.
             self._cleanup_motor_heuristic = False
             fixed_dim_fields = []
+            # dim fields is a list of tuples
             for obj_name in self.dim_fields:
                 try:
                     fields = doc.get('hints', {}).get(obj_name, {})['fields']
@@ -153,6 +155,10 @@ class BestEffortCallback(CallbackBase):
 
         # ## TABLE ## #
 
+        # TODO : Add option to select multiple dim_fields
+        # i.e. [['motor1', 'motor2'], 'primary'] assumes a 1D plot
+        # where 'motor1' is the x axis. There is current no option to allow for
+        # selecting 'motor2' (see relative_inner_product_scan for use case)
         if stream_name == self.dim_stream:
             # Ensure that no independent variables ('dimensions') are
             # duplicated here.

--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -111,8 +111,11 @@ class BestEffortCallback(CallbackBase):
             dimensions = GUESS  # Fall back on our GUESS.
             warn("We are ignoring the dimensions hinted because we cannot "
                  "combine streams.")
+        # TODO : Add option to select multiple dim_fields
+        # i.e. [['motor1', 'motor2'], 'primary'] assumes a 1D plot
+        # where 'motor1' is the x axis. There is current no option to allow for
+        # selecting 'motor2' (see relative_inner_product_scan for use case)
         # just select the first field
-        # TODO : Allow option for selecting other fields
         self.dim_fields = [fields[0]
                            for fields, stream_name in dimensions]
         _, self.dim_stream = dimensions[0]
@@ -155,10 +158,6 @@ class BestEffortCallback(CallbackBase):
 
         # ## TABLE ## #
 
-        # TODO : Add option to select multiple dim_fields
-        # i.e. [['motor1', 'motor2'], 'primary'] assumes a 1D plot
-        # where 'motor1' is the x axis. There is current no option to allow for
-        # selecting 'motor2' (see relative_inner_product_scan for use case)
         if stream_name == self.dim_stream:
             # Ensure that no independent variables ('dimensions') are
             # duplicated here.

--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -112,10 +112,6 @@ class BestEffortCallback(CallbackBase):
             warn("We are ignoring the dimensions hinted because we cannot "
                  "combine streams.")
         # TODO : Add option to select multiple dim_fields
-        # i.e. [['motor1', 'motor2'], 'primary'] assumes a 1D plot
-        # where 'motor1' is the x axis. There is current no option to allow for
-        # selecting 'motor2' (see relative_inner_product_scan for use case)
-        # just select the first field
         self.dim_fields = [fields[0]
                            for fields, stream_name in dimensions]
         _, self.dim_stream = dimensions[0]
@@ -147,7 +143,6 @@ class BestEffortCallback(CallbackBase):
             # look up the actual fields for.
             self._cleanup_motor_heuristic = False
             fixed_dim_fields = []
-            # dim fields is a list of tuples
             for obj_name in self.dim_fields:
                 try:
                     fields = doc.get('hints', {}).get(obj_name, {})['fields']

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -982,7 +982,7 @@ def relative_inner_product_scan(detectors, num, *args, per_step=None, md=None):
 
     _md['hints'] = default_hints
 
-    if 'hints' in md:
+    if md is not None and 'hints' in md:
         _md['hints'].update(md['hints'])
 
     @bpp.reset_positions_decorator(motors)

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -971,7 +971,7 @@ def relative_inner_product_scan(detectors, num, *args, per_step=None, md=None):
 
     # Default should assume the first motor is what to plot
     # If another motor is desired, override with separate hints
-    if 'fields' in motors[0].hints:
+    if hasatttr(motors[0], 'hints') and 'fields' in motors[0].hints:
         fields = list()
         for motor in motors:
             fields.extend(motor.hints['fields'])

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -972,7 +972,10 @@ def relative_inner_product_scan(detectors, num, *args, per_step=None, md=None):
     # Default should assume the first motor is what to plot
     # If another motor is desired, override with separate hints
     if 'fields' in motors[0].hints:
-        default_dimensions = [((motors[0].hints['fields'][0],), 'primary')]
+        fields = list()
+        for motor in motors:
+            fields.extend(motor.hints['fields'])
+        default_dimensions = [(fields, 'primary')]
         default_hints = {'dimensions': default_dimensions}
     else:
         default_hints = {}

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -969,10 +969,16 @@ def relative_inner_product_scan(detectors, num, *args, per_step=None, md=None):
     _md.update(md or {})
     motors = [motor for motor, start, stop in partition(3, args)]
 
-    # update the hints separately for the best effort callback
-    # TODO : consider non-primary?
-    default_hints = {'dimensions': [((motors[0].name,), 'primary')]}
+    # Default should assume the first motor is what to plot
+    # If another motor is desired, override with separate hints
+    if 'fields' in motors[0].hints:
+        default_dimensions = [((motors[0].hints['fields'][0],), 'primary')]
+        default_hints = {'dimensions': default_dimensions}
+    else:
+        default_hints = {}
+
     _md['hints'] = default_hints
+
     if 'hints' in md:
         _md['hints'].update(md['hints'])
 

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -964,9 +964,17 @@ def relative_inner_product_scan(detectors, num, *args, per_step=None, md=None):
     :func:`bluesky.plans.inner_product_scan`
     :func:`bluesky.plans.scan_nd`
     """
-    _md = {'plan_name': 'relative_inner_product_scan'}
+    _md = {'plan_name': 'relative_inner_product_scan',
+           }
     _md.update(md or {})
     motors = [motor for motor, start, stop in partition(3, args)]
+
+    # update the hints separately for the best effort callback
+    # TODO : consider non-primary?
+    default_hints = {'dimensions': [((motors[0].name,), 'primary')]}
+    _md['hints'] = default_hints
+    if 'hints' in md:
+        _md['hints'].update(md['hints'])
 
     @bpp.reset_positions_decorator(motors)
     @bpp.relative_set_decorator(motors)

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -971,7 +971,7 @@ def relative_inner_product_scan(detectors, num, *args, per_step=None, md=None):
 
     # Default should assume the first motor is what to plot
     # If another motor is desired, override with separate hints
-    if hasatttr(motors[0], 'hints') and 'fields' in motors[0].hints:
+    if hasattr(motors[0], 'hints') and 'fields' in motors[0].hints:
         fields = list()
         for motor in motors:
             fields.extend(motor.hints['fields'])


### PR DESCRIPTION
Some issues with best effort callback. Used a hint in the `relative_inner_product_scan` to help guide the best effort callback.

Sample code to run (toggle `False` to `True` to test between the outer and inner product scans):
(Note this is a copy and paste from documentation)
```python
from bluesky.plan_stubs import abs_set, wait

from bluesky.plans import (relative_outer_product_scan)
from bluesky.plans import relative_inner_product_scan

from bluesky.preprocessors import (run_decorator, stage_decorator,
                                    subs_decorator)
from bluesky.callbacks import LiveTable, LivePlot
from ophyd.sim import det4, motor1, motor2
from bluesky import RunEngine

from bluesky.callbacks.best_effort import BestEffortCallback

from bluesky.utils import ts_msg_hook


bec = BestEffortCallback()

def grid_in_grid(samples):
    """
    Scan a grid around the neighborhood of each sample.

    Parameters
    ----------
    sample : dict
        mapping each sample's name to its (x, y) position
    """

    # In this example we hard-code the hardware and other parameters. For more
    # flexibility, they could instead be parameters to the function.
    detector = det4
    x = motor1
    y = motor2
    x_range = y_range = 0.2
    x_num = y_num = 5

    hints = dict()

    @subs_decorator([
                     LiveTable([detector, x, y]),
                     #LivePlot('motor2'),
                     bec,
                    ])
    def plan():
        for name, position in samples.items():
            # Prepare metadata.
            md = {'sample': name}  #, 'hints': hints}

            # Move to the cetner of the sample position.
            x_pos, y_pos = position
            yield from abs_set(x, x_pos)
            yield from abs_set(y, y_pos)
            yield from wait()

            # Scan a grid around that position.
            if False:
                yield from relative_outer_product_scan([detector],
                                                       x, -x_range, x_range,
                                                       x_num,
                                                       y, -y_range, y_range,
                                                       y_num,
                                                       True, md=md)

            else:
                yield from relative_inner_product_scan([detector],
                                                       x_num,
                                                       x, -x_range, x_range,
                                                       y, -y_range, y_range,
                                                       md=md)

    yield from plan()


# Example usage:

RE = RunEngine({})
RE.msg_hook = ts_msg_hook
RE.subscribe(print)



#bec = BestEffortCallback()
#RE.subscribe(bec)

samples = {'A': (1, 1),
           'B': (1, 2),
           'C': (1, 3),
           'D': (2, 1),
           'E': (2, 2),
           'F': (2, 3)}

RE(grid_in_grid(samples))
```