### PR TITLE
ENH: clarify band suspenders

### DIFF
--- a/bluesky/suspenders.py
+++ b/bluesky/suspenders.py
@@ -4,6 +4,7 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 import operator
 from threading import Lock
 from functools import partial
+from warnings import warn
 
 
 class SuspenderBase(metaclass=ABCMeta):
@@ -425,7 +426,7 @@ class _SuspendBandBase(SuspenderBase):
         self._top = band_top
 
 
-class SuspendInBand(_SuspendBandBase):
+class SuspendWhenOutsideBand(_SuspendBandBase):
     """
     Suspend when a scalar signal leaves a given band of values.
 
@@ -494,6 +495,7 @@ class SuspendOutBand(_SuspendBandBase):
     post_plan : iterable or iterator, optional
             a generator, list, or similar containing `Msg` objects
     """
+    warn("bluesky.suspenders.SuspendOutBand is deprecated.")
     def _should_resume(self, value):
         return not (self._bot < value < self._top)
 

--- a/bluesky/tests/test_suspenders.py
+++ b/bluesky/tests/test_suspenders.py
@@ -5,7 +5,7 @@ from bluesky.suspenders import (SuspendBoolHigh,
                                 SuspendBoolLow,
                                 SuspendFloor,
                                 SuspendCeil,
-                                SuspendInBand,
+                                SuspendWhenOutsideBand,
                                 SuspendOutBand)
 from bluesky.tests.utils import MsgCollector
 from bluesky import Msg
@@ -19,7 +19,7 @@ import time
      (SuspendBoolLow, (), 1, 0, 1, .2),
      (SuspendFloor, (.5,), 1, 0, 1, .2),
      (SuspendCeil, (.5,), 0, 1, 0, .2),
-     (SuspendInBand, (.5, 1.5), 1, 0, 1, .2),
+     (SuspendWhenOutsideBand, (.5, 1.5), 1, 0, 1, .2),
      (SuspendOutBand, (.5, 1.5), 0, 1, 0, .2)])
 def test_suspender(klass, sc_args, start_val, fail_val,
                    resume_val, wait_time, RE, hw):

--- a/doc/source/state-machine.rst
+++ b/doc/source/state-machine.rst
@@ -259,8 +259,7 @@ Built-in Suspenders
    bluesky.suspenders.SuspendBoolLow
    bluesky.suspenders.SuspendFloor
    bluesky.suspenders.SuspendCeil
-   bluesky.suspenders.SuspendInBand
-   bluesky.suspenders.SuspendOutBand
+   bluesky.suspenders.SuspendWhenOutsideBand
 
 .. _checkpoints:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The "band" suspenders were counter-intuitive and confusing. This PR should resolve the confusion by deprecating `SuspendOutBand` and renaming `SuspendInBand` -> `SuspendWhenOutsideBand`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Better user experience.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The corresponding test was updated.

<!--
## Screenshots (if appropriate):
-->
