### PR TITLE
ENH: Add ‘drop’ Message

### DIFF
--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -54,6 +54,23 @@ def save():
     return (yield Msg('save'))
 
 
+def drop():
+    """
+    Drop a bundle of readings without emitting a completed Event document.
+
+    Yields
+    ------
+    msg : Msg
+        Msg('drop')
+
+    See Also
+    --------
+    :func:`bluesky.plans.save`
+    :func:`bluesky.plans.create`
+    """
+    return (yield Msg('drop'))
+
+
 def read(obj):
     """
     Take a reading and add it to the current bundle of readings.

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -475,7 +475,7 @@ def test_illegal_sequences(RE, hw):
         yield(Msg('close_run'))
 
     with pytest.raises(IllegalMessageSequence):
-        RE(gen1())
+        RE(gen2())
 
     def gen3():
         # 'configure' after 'create', before 'save'
@@ -485,6 +485,17 @@ def test_illegal_sequences(RE, hw):
 
     with pytest.raises(IllegalMessageSequence):
         RE(gen3())
+
+    def gen4():
+        # two 'drop' msgs in a row
+        yield(Msg('open_run'))
+        yield(Msg('create'))
+        yield(Msg('drop'))
+        yield(Msg('drop'))
+        yield(Msg('close_run'))
+
+    with pytest.raises(IllegalMessageSequence):
+        RE(gen4())
 
 
 def test_new_ev_desc(RE, hw):

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -4,6 +4,7 @@ from bluesky import Msg, RunEngineInterrupted
 from bluesky.plan_stubs import (
     create,
     save,
+    drop,
     read,
     monitor,
     unmonitor,
@@ -60,6 +61,7 @@ from bluesky.utils import all_safe_rewind
     [(create, (), {}, [Msg('create', name='primary')]),
      (create, ('custom_name',), {}, [Msg('create', name='custom_name')]),
      (save, (), {}, [Msg('save')]),
+     (drop, (), {}, [Msg('drop')]),
      (read, ('det',), {}, [Msg('read', 'det')]),
      (monitor, ('foo',), {}, [Msg('monitor', 'foo', name=None)]),
      (monitor, ('foo',), {'name': 'c'}, [Msg('monitor', 'foo', name='c')]),

--- a/doc/source/msg.rst
+++ b/doc/source/msg.rst
@@ -40,9 +40,10 @@ state of the `RunEnigne` instance.
 create
 ++++++
 
-This command tells the run engine that it should start to collect the results of
-``read`` to create an event.  If this is called twice without a ``save`` or ``drop`` between
-them it is an exception (as you can not have more than one open event going at a time).
+This command tells the run engine that it should start to collect the results
+of ``read`` to create an event.  If this is called twice without a ``save`` or
+``drop`` between them it is an exception (as you can not have more than one
+open event going at a time).
 
 This relies very heavily on the internal state of the run engine and should not
 be overridden by the user.
@@ -54,9 +55,9 @@ This ignores all parts of the `Msg` except the command.
 save
 ++++
 
-This is the pair to ``create`` which bundles and causes ``Event`` documents to be
-emitted.  This must be called after a ``create`` or a the scan will die and raise
-`IllegalMessageSequence`.
+This is the pair to ``create`` which bundles and causes ``Event`` documents to
+be emitted.  This must be called after a ``create`` or a the scan will die and
+raise `IllegalMessageSequence`.
 
 This relies very heavily on the internal state of the run engine and should not
 be messed with.
@@ -80,13 +81,15 @@ be messed with.
 
 Returns the dictionary returned by `read` to the co-routine.
 
-The ``args`` and ``kwargs`` parts of the message are passed to the `read` method.
+The ``args`` and ``kwargs`` parts of the message are passed to the `read`
+method.
 
 
 null
 ++++
 
-This is a null message and is ignored by the run engine.  This exists to make the algebra work.
+This is a null message and is ignored by the run engine.  This exists to make
+the algebra work.
 
 Returns `None` to the co-routine.
 
@@ -95,8 +98,8 @@ Ignores all values in the `Msg` except the command.
 set
 +++
 
-Tells a ``Mover`` object to move.  Currently this mimics the epics-like logic of immediate
-motion
+Tells a ``Mover`` object to move.  Currently this mimics the epics-like logic
+of immediate motion
 
 trigger
 +++++++

--- a/doc/source/msg.rst
+++ b/doc/source/msg.rst
@@ -41,7 +41,7 @@ create
 ++++++
 
 This command tells the run engine that it should start to collect the results of
-``read`` to create an event.  If this is called twice without a ``save`` between
+``read`` to create an event.  If this is called twice without a ``save`` or ``drop`` between
 them it is an exception (as you can not have more than one open event going at a time).
 
 This relies very heavily on the internal state of the run engine and should not
@@ -118,6 +118,21 @@ collect
 
 kickoff
 +++++++
+
+drop
+++++
+
+This is a command that abandons previous ``create`` and ``read`` commands
+without emitting an event. This can be used to drop known bad events
+(e.g. no beam) and keep the event document stream clean. It is safe to start
+another ``create``, ``read``, ``save`` sequence after a ``drop``.
+
+This must be called after a ``create`` or a the scan will die and raise
+`IllegalMessageSequence`.
+
+This call returns `None` back to the co-routine.
+
+This ignores all parts of the `Msg` except the command.
 
 Registering Custom Commands
 ---------------------------

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -486,6 +486,7 @@ Plans that control the RunEngine:
     close_run
     create
     save
+    drop
     pause
     deferred_pause
     checkpoint


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add and register a `drop` message to cancel bundled readings, allowing us to call `create` and try again.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are use cases for plans with live feedback where you want to take some number of “good” events. When the quality of a `read` command is known at runtime and is clear, calling for a `drop` is a convenient way to curate the stream of event documents so that only certain events make it to the subscribed callbacks. This allows us to avoid duplicating event filtering code in every single callback.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The `drop` message was added to any parametrized test that also had the `save` message. A new test was added that drops events and counts emitted event documents.
<!--
## Miscellaneous Thoughts
-->
- I’ve taken the same approach as in `save` to only allow a `drop` after a `create` message. This isn’t strictly needed because consecutive `drop` messages are not harmful, but I thought it would help identify when something has gone horribly wrong in the plan flow.
- I’ve noticed that some of the cleanup from previous `read` messages is actually done at the next `create`. I assume this is because it’s cheap to repeat and important to guarantee that it happens, but this is conceptually odd.
- I’ve shamelessly duplicated code here. Should some of this actually live in shared subroutines?
