### PR TITLE
ENH: LiveStream

### DIFF
--- a/bluesky/callbacks/stream.py
+++ b/bluesky/callbacks/stream.py
@@ -29,6 +29,7 @@ class LiveDispatcher(CallbackBase):
     RunEngine, effectively creating a small chain of callbacks
 
     .. code::
+
         # Create our dispatcher
         ld = LiveDispatcher()
         # Subscribe it to receive events from the RunEgine
@@ -69,8 +70,7 @@ class LiveDispatcher(CallbackBase):
         """
         Receive an event document from the original stream.
 
-        This should be reimplemented by a subclass, with ``super().event``
-        called as the last step in the method.
+        This should be reimplemented by a subclass.
 
         Parameters
         ----------

--- a/bluesky/callbacks/stream.py
+++ b/bluesky/callbacks/stream.py
@@ -2,7 +2,6 @@ import logging
 import time as ttime
 from collections import Iterable, ChainMap
 
-import streamz
 import jsonschema
 import numpy as np
 from event_model import DocumentNames, schemas
@@ -14,44 +13,39 @@ from ..utils import new_uid
 logger = logging.getLogger(__name__)
 
 
-class LiveStream(CallbackBase):
+class LiveDispatcher(CallbackBase):
     """Create a secondary event stream of processed data"""
-    def __init__(self, in_node, out_node=None):
-        self.in_node = in_node
-        # Use the same node as an output if None is given
-        self.out_node = out_node or self.in_node
-        # The output should propagate the modified Event document down the
-        # pipeline
-        self.event = self.in_node.emit
-        self.out_node.sink(self.send_event)
+    def __init__(self):
         # Public dispatcher for callbacks
         self.dispatcher = Dispatcher()
         # Local caches for internal use
         self.seq_count = 0  # Maintain our own sequence count for this stream
+        self.raw_descriptors = dict()  # Store raw descriptors for use later
         self._stream_start_uid = None  # Generated start doc uid
-        self._raw_descriptors = dict()  # List of past raw event descriptors
-        self._described = list()  # List of raw event desc. we have translated
-        self._last_descriptor = None  # List of sent descriptors
+        self._descriptors = dict()  # Dictionary of sent descriptors
 
-    def start(self, doc):
-        """Receive a stop document, re-emit it for this event stream"""
+    def start(self, doc, _md=None):
+        """Receive a start document, re-emit it for this event stream"""
         self._stream_start_uid = new_uid()
+        _md = _md or dict()
         # Create a new start document with a new uid, start time, and the uid
         # of the original start document. Preserve the rest of the metadata
         # that we retrieved from the start document
         md = ChainMap({'uid': self._stream_start_uid,
                        'original_run_uid': doc['uid'],
                        'time': ttime.time()},
-                      doc)
-        # Emit the start document for anyone subscribed to our Dispatcher
+                      _md, doc)
+        # Dispatch the start document for anyone subscribed to our Dispatcher
         self.emit(DocumentNames.start, dict(md))
+        super().start(doc)
 
     def descriptor(self, doc):
-        """Receive a descriptor and store for later reference"""
-        self._raw_descriptors[doc['uid']] = doc
+        """Store a descriptor"""
+        self.raw_descriptors[doc['uid']] = doc
         super().descriptor(doc)
 
-    def send_event(self, doc):
+    def process_event(self, doc, stream_name='primary',
+                      id_args=None, config=None):
         """
         Receive an event document
 
@@ -62,20 +56,26 @@ class LiveStream(CallbackBase):
         that it is not confused with the raw data stream being emitted from the
         RunEngine
         """
+        id_args = id_args or (doc['descriptor'],)
+        config = config or dict()
+        # Determine the descriptor id
+
+        desc_id = frozenset((tuple(doc['data'].keys()), stream_name, id_args))
         # If we haven't described this configuration
         # Send a new document to our subscribers
-        if doc['descriptor'] not in self._described:
-            prior_desc = self._raw_descriptors[doc['descriptor']]
+        if (stream_name not in self._descriptors or
+            desc_id not in self._descriptors[stream_name]):
             # Create a new description document for the output of the stream
             data_keys = dict()
             # Parse the event document creating a new description. If the key
             # existed in the original source description, just assume that it
             # is the same type, units and shape. Otherwise do some
             # investigation
+            raw_desc = self.raw_descriptors.get(doc['descriptor'], {})
             for key, val in doc['data'].items():
                 # Described priorly
-                if key in prior_desc['data_keys']:
-                    key_desc = prior_desc['data_keys'][key]
+                if key in raw_desc['data_keys']:
+                    key_desc = raw_desc['data_keys'][key]
                 # String key
                 elif isinstance(val, str):
                     key_desc = {'dtype': 'string',
@@ -89,29 +89,31 @@ class LiveStream(CallbackBase):
                     key_desc = {'dtype': 'number',
                                 'shape': []}
                 # Modify the source
-                key_desc['source'] = 'Stream: {}'.format(self.out_node.name
-                                                         or 'Unnamed Stream')
+                key_desc['source'] = 'Stream'
                 # Store in our new descriptor
                 data_keys[key] = key_desc
             # Create our complete description document
             desc = ChainMap({'uid': new_uid(), 'time': ttime.time(),
                              'run_start': self._stream_start_uid,
+                             'data_keys': data_keys, 'configuration': config,
                              'object_keys': {'stream':
                                              list(data_keys.keys())}},
-                            prior_desc)
+                            raw_desc)
             # Store information about our descriptors
-            self._last_descriptor = dict(desc)
-            self._described.append(doc['descriptor'])
+            desc = dict(desc)
+            if stream_name not in self._descriptors:
+                self._descriptors[stream_name] = dict()
+            self._descriptors[stream_name][desc_id] = desc
             # Emit the document to all subscribers
-            self.emit(DocumentNames.descriptor, self._last_descriptor)
+            self.emit(DocumentNames.descriptor, desc)
 
         # Clean the Event document produced by graph network. The data is left
         # untouched, but the relevant uids, timestamps, seq_num are modified so
         # that this event is not confused with the raw data stream
         self.seq_count += 1
+        desc_uid = self._descriptors[stream_name][desc_id]['uid']
         current_time = ttime.time()
-        evt = ChainMap({'uid': new_uid(),
-                        'descriptor': self._last_descriptor['uid'],
+        evt = ChainMap({'uid': new_uid(), 'descriptor': desc_uid,
                         'timestamps': dict((key, current_time)
                                            for key in doc['data'].keys()),
                         'seq_num': self.seq_count, 'time': current_time},
@@ -119,22 +121,25 @@ class LiveStream(CallbackBase):
         # Emit the event document
         self.emit(DocumentNames.event, dict(evt))
 
-    def stop(self, doc):
+    def stop(self, doc, _md=None):
         """Receive a stop document, re-emit it for this event stream"""
         # Create a new stop document with a new_uid, pointing to the correct
         # start document uid, and tally the number of events we have emitted.
         # The rest of the stop information is passed on to the next callback
+        _md = _md or dict()
+        num_events = dict((stream, len(self._descriptors[stream]))
+                          for stream in self._descriptors.keys())
         md = ChainMap(dict(run_start=self._stream_start_uid,
                            time=ttime.time(), uid=new_uid(),
-                           num_events={'primary': self.seq_count}),
+                           num_events=num_events),
                       doc)
         self.emit(DocumentNames.stop, dict(md))
         # Clear the local caches for the run
-        self._raw_descriptors.clear()
-        self._described.clear()
         self.seq_count = 0
-        self._last_descriptor = None
+        self.raw_descriptors.clear()
+        self._descriptors.clear()
         self._stream_start_uid = None
+        super().stop(doc)
 
     def emit(self, name, doc):
         """Emit a document, first checking the schema"""
@@ -148,34 +153,3 @@ class LiveStream(CallbackBase):
     def unsubscribe(self, token):
         """Convenience function for dispatcher un-subscription"""
         self.dispatcher.unsubscribe(token)
-
-
-class AverageStream(LiveStream):
-    """Stream that averages data points together"""
-    def __init__(self, n):
-        self.n = n
-        # Define our nodes
-        in_node = streamz.Source(stream_name='Input')
-        self._averager = in_node.partition(n)
-
-        def average_events(cache):
-            average_evt = dict()
-            desc_id = cache[0]['descriptor']
-            # Check that all of our events came from the same configuration
-            if not all([desc_id == evt['descriptor'] for evt in cache]):
-                raise Exception('The events in this bundle are from '
-                                'different configurations!')
-            # Use the last descriptor to avoid strings and objects
-            data_keys = self._raw_descriptors[desc_id]['data_keys']
-            for key, info in data_keys.items():
-                # Information from non-number fields is dropped
-                if info['dtype'] in ('number', 'array'):
-                    # Average together
-                    average_evt[key] = np.mean([evt['data'][key]
-                                                for evt in cache], axis=0)
-            return {'data': average_evt, 'descriptor': desc_id}
-
-        out_node = self._averager.map(average_events)
-        out_node.name = 'Average %s'.format(self.n)
-        # Initialize the Stream
-        super().__init__(in_node=in_node, out_node=out_node)

--- a/bluesky/callbacks/stream.py
+++ b/bluesky/callbacks/stream.py
@@ -1,0 +1,181 @@
+import logging
+import time as ttime
+from collections import Iterable, ChainMap
+
+import streamz
+import jsonschema
+import numpy as np
+from event_model import DocumentNames, schemas
+
+from .core import CallbackBase
+from ..run_engine import Dispatcher
+from ..utils import new_uid
+
+logger = logging.getLogger(__name__)
+
+
+class LiveStream(CallbackBase):
+    """Create a secondary event stream of processed data"""
+    def __init__(self, in_node, out_node=None):
+        self.in_node = in_node
+        # Use the same node as an output if None is given
+        self.out_node = out_node or self.in_node
+        # The output should propagate the modified Event document down the
+        # pipeline
+        self.event = self.in_node.emit
+        self.out_node.sink(self.send_event)
+        # Public dispatcher for callbacks
+        self.dispatcher = Dispatcher()
+        # Local caches for internal use
+        self.seq_count = 0  # Maintain our own sequence count for this stream
+        self._stream_start_uid = None  # Generated start doc uid
+        self._raw_descriptors = dict()  # List of past raw event descriptors
+        self._described = list()  # List of raw event desc. we have translated
+        self._last_descriptor = None  # List of sent descriptors
+
+    def start(self, doc):
+        """Receive a stop document, re-emit it for this event stream"""
+        self._stream_start_uid = new_uid()
+        # Create a new start document with a new uid, start time, and the uid
+        # of the original start document. Preserve the rest of the metadata
+        # that we retrieved from the start document
+        md = ChainMap({'uid': self._stream_start_uid,
+                       'original_run_uid': doc['uid'],
+                       'time': ttime.time()},
+                      doc)
+        # Emit the start document for anyone subscribed to our Dispatcher
+        self.emit(DocumentNames.start, dict(md))
+
+    def descriptor(self, doc):
+        """Receive a descriptor and store for later reference"""
+        self._raw_descriptors[doc['uid']] = doc
+        super().descriptor(doc)
+
+    def send_event(self, doc):
+        """
+        Receive an event document
+
+        If we have not released a description yet, we can view the event
+        document and the last description we received from the raw RunEngine
+        and create a new updated description document. The event document is
+        also modified to have a new sequence number and description source so
+        that it is not confused with the raw data stream being emitted from the
+        RunEngine
+        """
+        # If we haven't described this configuration
+        # Send a new document to our subscribers
+        if doc['descriptor'] not in self._described:
+            prior_desc = self._raw_descriptors[doc['descriptor']]
+            # Create a new description document for the output of the stream
+            data_keys = dict()
+            # Parse the event document creating a new description. If the key
+            # existed in the original source description, just assume that it
+            # is the same type, units and shape. Otherwise do some
+            # investigation
+            for key, val in doc['data'].items():
+                # Described priorly
+                if key in prior_desc['data_keys']:
+                    key_desc = prior_desc['data_keys'][key]
+                # String key
+                elif isinstance(val, str):
+                    key_desc = {'dtype': 'string',
+                                'shape': []}
+                # Iterable
+                elif isinstance(val, Iterable):
+                    key_desc = {'dtype': 'array',
+                                'shape': np.shape(val)}
+                # Number
+                else:
+                    key_desc = {'dtype': 'number',
+                                'shape': []}
+                # Modify the source
+                key_desc['source'] = 'Stream: {}'.format(self.out_node.name
+                                                         or 'Unnamed Stream')
+                # Store in our new descriptor
+                data_keys[key] = key_desc
+            # Create our complete description document
+            desc = ChainMap({'uid': new_uid(), 'time': ttime.time(),
+                             'run_start': self._stream_start_uid,
+                             'object_keys': {'stream':
+                                             list(data_keys.keys())}},
+                            prior_desc)
+            # Store information about our descriptors
+            self._last_descriptor = dict(desc)
+            self._described.append(doc['descriptor'])
+            # Emit the document to all subscribers
+            self.emit(DocumentNames.descriptor, self._last_descriptor)
+
+        # Clean the Event document produced by graph network. The data is left
+        # untouched, but the relevant uids, timestamps, seq_num are modified so
+        # that this event is not confused with the raw data stream
+        self.seq_count += 1
+        current_time = ttime.time()
+        evt = ChainMap({'uid': new_uid(),
+                        'descriptor': self._last_descriptor['uid'],
+                        'timestamps': dict((key, current_time)
+                                           for key in doc['data'].keys()),
+                        'seq_num': self.seq_count, 'time': current_time},
+                       doc)
+        # Emit the event document
+        self.emit(DocumentNames.event, dict(evt))
+
+    def stop(self, doc):
+        """Receive a stop document, re-emit it for this event stream"""
+        # Create a new stop document with a new_uid, pointing to the correct
+        # start document uid, and tally the number of events we have emitted.
+        # The rest of the stop information is passed on to the next callback
+        md = ChainMap(dict(run_start=self._stream_start_uid,
+                           time=ttime.time(), uid=new_uid(),
+                           num_events=self.seq_count),
+                      doc)
+        self.emit(DocumentNames.stop, dict(md))
+        # Clear the local caches for the run
+        self._raw_descriptors.clear()
+        self._described.clear()
+        self.seq_count = 0
+        self._last_descriptor = None
+        self._stream_start_uid = None
+
+    def emit(self, name, doc):
+        """Emit a document, first checking the schema"""
+        jsonschema.validate(doc, schemas[name])
+        self.dispatcher.process(name, doc)
+
+    def subscribe(self, func, name='all'):
+        """Convenience function for dispatcher subscription"""
+        return self.dispatcher.subscribe(func, name)
+
+    def unsubscribe(self, token):
+        """Convenience function for dispatcher un-subscription"""
+        self.dispatcher.unsubscribe(token)
+
+
+class AverageStream(LiveStream):
+    """Stream that averages data points together"""
+    def __init__(self, n):
+        self.n = n
+        # Define our nodes
+        in_node = streamz.Source(stream_name='Input')
+        self._averager = in_node.partition(n)
+
+        def average_events(cache):
+            average_evt = dict()
+            desc_id = cache[0]['descriptor']
+            # Check that all of our events came from the same configuration
+            if not all([desc_id == evt['descriptor'] for evt in cache]):
+                raise Exception('The events in this bundle are from '
+                                'different configurations!')
+            # Use the last descriptor to avoid strings and objects
+            data_keys = self._raw_descriptors[desc_id]['data_keys']
+            for key, info in data_keys.items():
+                # Information from non-number fields is dropped
+                if info['dtype'] in ('number', 'array'):
+                    # Average together
+                    average_evt[key] = np.mean([evt['data'][key]
+                                                for evt in cache], axis=0)
+            return {'data': average_evt, 'descriptor': desc_id}
+
+        out_node = self._averager.map(average_events)
+        out_node.name = 'Average %s'.format(self.n)
+        # Initialize the Stream
+        super().__init__(in_node=in_node, out_node=out_node)

--- a/bluesky/callbacks/stream.py
+++ b/bluesky/callbacks/stream.py
@@ -47,7 +47,7 @@ class LiveDispatcher(CallbackBase):
         self._descriptors = dict()  # Dictionary of sent descriptors
 
     def start(self, doc, _md=None):
-        """Receive a start document, re-emit it for this event stream"""
+        """Receive a raw start document, re-emit it for the modified stream"""
         self._stream_start_uid = new_uid()
         _md = _md or dict()
         # Create a new start document with a new uid, start time, and the uid
@@ -68,7 +68,7 @@ class LiveDispatcher(CallbackBase):
 
     def event(self, doc, **kwargs):
         """
-        Receive an event document from the original stream.
+        Receive an event document from the raw stream.
 
         This should be reimplemented by a subclass.
 
@@ -85,7 +85,7 @@ class LiveDispatcher(CallbackBase):
     def process_event(self, doc, stream_name='primary',
                       id_args=None, config=None):
         """
-        Process an event document before emitting
+        Process a modified event document then emit it for the modified stream
 
         This will pass an Event document to the dispatcher. If we have received
         a new event descriptor from the original stream, or we have recieved a
@@ -178,7 +178,7 @@ class LiveDispatcher(CallbackBase):
         self.emit(DocumentNames.event, dict(evt))
 
     def stop(self, doc, _md=None):
-        """Receive a stop document, re-emit it for this event stream"""
+        """Receive a raw stop document, re-emit it for the modified stream"""
         # Create a new stop document with a new_uid, pointing to the correct
         # start document uid, and tally the number of events we have emitted.
         # The rest of the stop information is passed on to the next callback

--- a/bluesky/callbacks/stream.py
+++ b/bluesky/callbacks/stream.py
@@ -126,7 +126,7 @@ class LiveStream(CallbackBase):
         # The rest of the stop information is passed on to the next callback
         md = ChainMap(dict(run_start=self._stream_start_uid,
                            time=ttime.time(), uid=new_uid(),
-                           num_events=self.seq_count),
+                           num_events={'primary': self.seq_count}),
                       doc)
         self.emit(DocumentNames.stop, dict(md))
         # Clear the local caches for the run

--- a/bluesky/tests/test_streams.py
+++ b/bluesky/tests/test_streams.py
@@ -30,7 +30,7 @@ class NegativeStream(LiveDispatcher):
         for key, val in doc['data'].items():
             modified['modified_{}'.format(key)] = -math.fabs(val)
         doc['data'] = modified
-        return self.process_event(doc)
+        return super().event(doc)
 
 
 class AverageStream(LiveDispatcher):
@@ -75,7 +75,7 @@ class AverageStream(LiveDispatcher):
             return {'data': average_evt, 'descriptor': desc_id}
 
         self.out_node = self.averager.map(average_events)
-        self.out_node.sink(self.process_event)
+        self.out_node.sink(super().event)
         super().start(doc)
 
     def event(self, doc):

--- a/bluesky/tests/test_streams.py
+++ b/bluesky/tests/test_streams.py
@@ -3,7 +3,6 @@ import pytest
 from bluesky.callbacks import CallbackCounter
 from bluesky.examples import stepscan
 from bluesky.tests.utils import DocCollector
-from bluesky.callbacks import LiveTable
 
 # Do not run these test if streamz is not installed
 try:
@@ -41,7 +40,6 @@ def test_average_stream(RE, hw):
     ls.subscribe(c)
     ls.subscribe(d.insert)
     # Run a basic plan
-    RE.subscribe(LiveTable(('motor', 'det')))
     RE(stepscan(hw.det, hw.motor), {'all': ls})
     assert c.value == 1 + 1 + 2  # events, descriptor, start and stop
     # See that we made sensible descriptor
@@ -56,3 +54,5 @@ def test_average_stream(RE, hw):
     # See that we returned the correct average
     assert evt['data']['motor'] == -0.5  # mean of range(-5, 5)
     assert evt['data']['motor_setpoint'] == -0.5  # mean of range(-5, 5)
+    assert start_uid in d.stop
+    assert d.stop[start_uid]['num_events'] == {'primary': 1}

--- a/bluesky/tests/test_streams.py
+++ b/bluesky/tests/test_streams.py
@@ -1,8 +1,12 @@
+import math
 import pytest
+
+import numpy as np
 
 from bluesky.callbacks import CallbackCounter
 from bluesky.examples import stepscan
 from bluesky.tests.utils import DocCollector
+from bluesky.callbacks.stream import LiveDispatcher
 
 # Do not run these test if streamz is not installed
 try:
@@ -10,37 +14,115 @@ try:
     has_streamz = True
 except ImportError:
     has_streamz = False
-else:
-    from bluesky.callbacks.stream import LiveStream, AverageStream
-
 
 requires_streamz = pytest.mark.skipif(not has_streamz,
                                       reason='Missing streamz library')
 
 
-@requires_streamz
+class NegativeStream(LiveDispatcher):
+    """Stream that only adds metadata to start document"""
+    def start(self, doc):
+        doc.update({"stream_level": "boring"})
+        super().start(doc)
+
+    def event(self, doc):
+        modified = dict()
+        for key, val in doc['data'].items():
+            modified['modified_{}'.format(key)] = -math.fabs(val)
+        doc['data'] = modified
+        return self.process_event(doc)
+
+
+class AverageStream(LiveDispatcher):
+    """Stream that averages data points together"""
+    def __init__(self, n=None):
+        self.n = n
+        self.in_node = None
+        self.out_node = None
+        self.averager = None
+        super().__init__()
+
+    def start(self, doc):
+        """
+        Create the stream after seeing the start document
+
+        The callback looks for the 'average' key in the start document to
+        configure itself.
+        """
+        # Grab the average key
+        self.n = doc.get('average', self.n)
+        # Define our nodes
+        if not self.in_node:
+            self.in_node = streamz.Source(stream_name='Input')
+
+        self.averager = self.in_node.partition(self.n)
+
+        def average_events(cache):
+            average_evt = dict()
+            desc_id = cache[0]['descriptor']
+            # Check that all of our events came from the same configuration
+            if not all([desc_id == evt['descriptor'] for evt in cache]):
+                raise Exception('The events in this bundle are from '
+                                'different configurations!')
+            # Use the last descriptor to avoid strings and objects
+            data_keys = self.raw_descriptors[desc_id]['data_keys']
+            for key, info in data_keys.items():
+                # Information from non-number fields is dropped
+                if info['dtype'] in ('number', 'array'):
+                    # Average together
+                    average_evt[key] = np.mean([evt['data'][key]
+                                                for evt in cache], axis=0)
+            return {'data': average_evt, 'descriptor': desc_id}
+
+        self.out_node = self.averager.map(average_events)
+        self.out_node.sink(self.process_event)
+        super().start(doc)
+
+    def event(self, doc):
+        """Send an Event through the stream"""
+        self.in_node.emit(doc)
+
+    def stop(self, doc):
+        """Delete the stream when run stops"""
+        self.in_node = None
+        self.out_node = None
+        self.averager = None
+        super().stop(doc)
+
+
 def test_straight_through_stream(RE, hw):
     # Just a stream that sinks the events it receives
-    s = streamz.Source()
+    ss = NegativeStream()
     # Create callback chain
-    ls = LiveStream(s)
     c = CallbackCounter()
-    ls.subscribe(c)
+    d = DocCollector()
+    ss.subscribe(c)
+    ss.subscribe(d.insert)
     # Run a basic plan
-    RE(stepscan(hw.det, hw.motor), {'all': ls})
+    RE(stepscan(hw.det, hw.motor), {'all': ss})
+    # Check that our metadata is there
     assert c.value == 10 + 1 + 2  # events, descriptor, start and stop
+    assert d.start[0]['stream_level'] == 'boring'
+    desc = d.descriptor[d.start[0]['uid']][0]
+    events = d.event[desc['uid']]
+    print(desc)
+    print([evt['data'] for evt in events])
+    assert all([evt['data'][key] <= 0
+                for evt in events
+                for key in evt['data'].keys()])
+    assert all([key in desc['data_keys'] for key in events[0]['data'].keys()])
 
 
 @requires_streamz
 def test_average_stream(RE, hw):
     # Create callback chain
-    ls = AverageStream(10)
+    avg = AverageStream(10)
     c = CallbackCounter()
     d = DocCollector()
-    ls.subscribe(c)
-    ls.subscribe(d.insert)
+    avg.subscribe(c)
+    avg.subscribe(d.insert)
     # Run a basic plan
-    RE(stepscan(hw.det, hw.motor), {'all': ls})
+    RE(stepscan(hw.det, hw.motor), {'all': avg})
     assert c.value == 1 + 1 + 2  # events, descriptor, start and stop
     # See that we made sensible descriptor
     start_uid = d.start[0]['uid']

--- a/bluesky/tests/test_streams.py
+++ b/bluesky/tests/test_streams.py
@@ -1,0 +1,58 @@
+import pytest
+
+from bluesky.callbacks import CallbackCounter
+from bluesky.examples import stepscan
+from bluesky.tests.utils import DocCollector
+from bluesky.callbacks import LiveTable
+
+# Do not run these test if streamz is not installed
+try:
+    import streamz
+    has_streamz = True
+except ImportError:
+    has_streamz = False
+else:
+    from bluesky.callbacks.stream import LiveStream, AverageStream
+
+
+requires_streamz = pytest.mark.skipif(not has_streamz,
+                                      reason='Missing streamz library')
+
+
+@requires_streamz
+def test_straight_through_stream(RE, hw):
+    # Just a stream that sinks the events it receives
+    s = streamz.Source()
+    # Create callback chain
+    ls = LiveStream(s)
+    c = CallbackCounter()
+    ls.subscribe(c)
+    # Run a basic plan
+    RE(stepscan(hw.det, hw.motor), {'all': ls})
+    assert c.value == 10 + 1 + 2  # events, descriptor, start and stop
+
+
+@requires_streamz
+def test_average_stream(RE, hw):
+    # Create callback chain
+    ls = AverageStream(10)
+    c = CallbackCounter()
+    d = DocCollector()
+    ls.subscribe(c)
+    ls.subscribe(d.insert)
+    # Run a basic plan
+    RE.subscribe(LiveTable(('motor', 'det')))
+    RE(stepscan(hw.det, hw.motor), {'all': ls})
+    assert c.value == 1 + 1 + 2  # events, descriptor, start and stop
+    # See that we made sensible descriptor
+    start_uid = d.start[0]['uid']
+    assert start_uid in d.descriptor
+    desc_uid = d.descriptor[start_uid][0]['uid']
+    assert desc_uid in d.event
+    evt = d.event[desc_uid][0]
+    assert evt['seq_num'] == 1
+    assert all([key in d.descriptor[start_uid][0]['data_keys']
+                for key in evt['data'].keys()])
+    # See that we returned the correct average
+    assert evt['data']['motor'] == -0.5  # mean of range(-5, 5)
+    assert evt['data']['motor_setpoint'] == -0.5  # mean of range(-5, 5)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -19,6 +19,7 @@ pyepics
 pytest
 pyyaml
 requests
+streamz
 sphinx
 sphinx_rtd_theme
 tifffile


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The goal of this addition is to provide an outline for doing streaming analysis and feed this information to other out of the box `bluesky` callbacks. The callback uses the `streamz` module to send the event documents through an arbitrary graph network. Each document is then repackaged and sent to subscribers. 

## Motivation and Context
This solves a number of problems we have at SLAC where we want to process data as it is emitted and not necessarily wait for those things to propagate through a databroker. In order to not confuse event streams, the `LiveStream` mimics the document creation in the `RunEngine`, it creates its own sequence numbering, descriptors e.t.c. Here is an example below of running `bluesky.examples.stepscan`, and having two plots; one averaging every two shots, one showing the raw data.
![stream_example](https://user-images.githubusercontent.com/25753048/34000875-82f94eea-e0bc-11e7-8b6b-5ac6dcef93c2.png)

Obviously this is a wonky example, but I think it shows the power of this solution. I can do arbitrary analysis in my graph network and send all this through the built-in bluesky callbacks. I could imagine the use case where you have two databroker instances, one subscribed to the raw data and one subscribed to the processed information. This could provide an interesting first pass at analysis for user groups. At SLAC, we would want to use this to only show processed information to our `LiveFit`. Because any` bluesky` callback can subscribe to the processed data stream we can also plot the actual information that our fit is seeing without duplicating logic in multiple callbacks.

### Implementations Details
* The `streamz` module isn't strictly necessary. I think it makes sense for now to force the users to fit their processing pipeline into this form, but if this is not flexible enough, or we don't want the dependency, we can find a way around it.
* Recreating the document structure was kind of painful. It will also be annoying if you change how the RunEngine structures these dictionaries that the same change has to be made in `LiveStream`. It however, seemed liked a necessary evil.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests to the bluesky and `dev-requirements` now includes streamz
<!--

