### PR TITLE
ENH: Implement repeat plan

### DIFF
--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -922,7 +922,10 @@ def repeat(plan, num=1, delay=None):
         for i in iterator:
             now = time.time()  # Intercept the flow in its earliest moment.
             yield Msg('checkpoint')
-            yield from ensure_generator(plan())
+            if callable(plan):
+                yield from ensure_generator(plan())
+            else:
+                yield from ensure_generator(plan)
             try:
                 d = next(delay)
             except StopIteration:

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -14,7 +14,7 @@ except ImportError:
     from toolz import partition
 
 
-from .utils import (separate_devices, all_safe_rewind, Msg,
+from .utils import (separate_devices, all_safe_rewind, Msg, ensure_generator,
                     short_uid as _short_uid)
 
 
@@ -921,10 +921,8 @@ def repeat(plan, num=1, delay=None):
     def repeated_plan():
         for i in iterator:
             now = time.time()  # Intercept the flow in its earliest moment.
-            if isinstance(plan, list):
-                yield from plan
-            else:
-                yield from plan()
+            yield Msg('checkpoint')
+            yield from ensure_generator(plan())
             try:
                 d = next(delay)
             except StopIteration:

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -879,7 +879,12 @@ def one_nd_step(detectors, step, pos_cache):
 
 def repeat(plan, num=1, delay=None):
     """
-    Repeat a plan num times with delay between each repeat.
+    Repeat a plan num times with delay and checkpoint between each repeat.
+
+    This is different from ``repeater`` and ``caching_repeater`` in that it
+    adds ``checkpoint`` and optionally ``sleep`` messages if delay is provided.
+    This is intended for users who need the structure of ``count`` but do not
+    want to reimplement the control flow.
 
     Parameters
     ----------

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -924,13 +924,16 @@ def repeat(plan, num=1, delay=None):
         delay = iter(delay)
 
     def repeated_plan():
+        nonlocal plan
         for i in iterator:
             now = time.time()  # Intercept the flow in its earliest moment.
             yield Msg('checkpoint')
             if callable(plan):
                 yield from ensure_generator(plan())
             else:
-                yield from ensure_generator(plan)
+                # Stash plan for our next trip through the loop; use plan_copy.
+                plan, plan_copy = itertools.tee(ensure_generator(plan))
+                yield from plan_copy
             try:
                 d = next(delay)
             except StopIteration:

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1,5 +1,4 @@
 import sys
-# import itertools
 from itertools import chain
 
 from collections import defaultdict

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1,5 +1,6 @@
 import sys
 from itertools import chain
+from functools import partial
 
 from collections import defaultdict
 import time
@@ -56,14 +57,11 @@ def count(detectors, num=1, delay=None, *, md=None):
     _md.update(md or {})
     _md['hints'].setdefault('dimensions', [(('time',), 'primary')])
 
-    def take_data():
-        yield Msg('checkpoint')
-        return (yield from bps.trigger_and_read(detectors))
-
     @bpp.stage_decorator(detectors)
     @bpp.run_decorator(md=_md)
     def inner_count():
-        return (yield from bps.repeat(take_data, num=num, delay=delay))
+        return (yield from bps.repeat(partial(bps.trigger_and_read, detectors),
+                                      num=num, delay=delay))
 
     return (yield from inner_count())
 

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -56,18 +56,16 @@ def count(detectors, num=1, delay=None, *, md=None):
     _md.update(md or {})
     _md['hints'].setdefault('dimensions', [(('time',), 'primary')])
 
-    def outer():
-        def inner():
-            yield Msg('checkpoint')
-            yield from bps.trigger_and_read(detectors)
-        return (yield from inner())
+    def take_data():
+        yield Msg('checkpoint')
+        return (yield from bps.trigger_and_read(detectors))
 
     @bpp.stage_decorator(detectors)
     @bpp.run_decorator(md=_md)
-    def plan():
-        return (yield from bps.repeat(outer, num=num, delay=delay))
+    def inner_count():
+        return (yield from bps.repeat(take_data, num=num, delay=delay))
 
-    return (yield from plan())
+    return (yield from inner_count())
 
 
 def list_scan(detectors, motor, steps, *, per_step=None, md=None):

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1,8 +1,8 @@
 import sys
-import itertools
+# import itertools
 from itertools import chain
 
-from collections import (Iterable, defaultdict)
+from collections import defaultdict
 import time
 
 import numpy as np
@@ -57,59 +57,18 @@ def count(detectors, num=1, delay=None, *, md=None):
     _md.update(md or {})
     _md['hints'].setdefault('dimensions', [(('time',), 'primary')])
 
-    # If delay is a scalar, repeat it forever. If it is an iterable, leave it.
-    if not isinstance(delay, Iterable):
-        delay = itertools.repeat(delay)
-    else:
-        try:
-            num_delays = len(delay)
-        except TypeError:
-            # No way to tell in advance if we have enough delays.
-            pass
-        else:
-            if num - 1 > num_delays:
-                raise ValueError("num=%r but delays only provides %r "
-                                 "entries" % (num, num_delays))
-        delay = iter(delay)
+    def outer():
+        def inner():
+            yield Msg('checkpoint')
+            yield from bps.trigger_and_read(detectors)
+        return (yield from inner())
 
     @bpp.stage_decorator(detectors)
     @bpp.run_decorator(md=_md)
-    def finite_plan():
-        for i in range(num):
-            now = time.time()  # Intercept the flow in its earliest moment.
-            yield Msg('checkpoint')
-            yield from bps.trigger_and_read(detectors)
-            try:
-                d = next(delay)
-            except StopIteration:
-                if i + 1 == num:
-                    break
-                else:
-                    # num specifies a number of iterations less than delay
-                    raise ValueError("num=%r but delays only provides %r "
-                                     "entries" % (num, i))
-            if d is not None:
-                d = d - (time.time() - now)
-                if d > 0:  # Sleep if and only if time is left to do it.
-                    yield Msg('sleep', None, d)
+    def plan():
+        return (yield from bps.repeat(outer, num=num, delay=delay))
 
-    @bpp.stage_decorator(detectors)
-    @bpp.run_decorator(md=_md)
-    def infinite_plan():
-        while True:
-            yield Msg('checkpoint')
-            yield from bps.trigger_and_read(detectors)
-            try:
-                d = next(delay)
-            except StopIteration:
-                break
-            if d is not None:
-                yield Msg('sleep', None, d)
-
-    if num is None:
-        return (yield from infinite_plan())
-    else:
-        return (yield from finite_plan())
+    return (yield from plan())
 
 
 def list_scan(detectors, motor, steps, *, per_step=None, md=None):
@@ -614,7 +573,7 @@ def tune_centroid(
         number of points with each traversal, default = 10
     step_factor : float, optional
         used in calculating new range after each pass
-        
+
         note: step_factor > 1.0, default = 3
     snake : bool, optional
         if False (default), always scan from start to stop

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -519,6 +519,7 @@ def test_repeat():
     num = 3
     expected = [Msg('checkpoint'), 1, 2, 3] * num
     assert list(repeat(plan, num=num)) == expected
+    assert list(repeat(plan(), num=num)) == expected
     assert list(repeat(messages, num=num)) == expected
 
 

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -32,7 +32,8 @@ from bluesky.plan_stubs import (
     trigger_and_read,
     stop,
     repeater,
-    caching_repeater,)
+    caching_repeater,
+    repeat)
 from bluesky.preprocessors import (
     finalize_wrapper,
     fly_during_wrapper,
@@ -506,6 +507,19 @@ def test_caching_repeater():
     assert next(p) == 2
     assert next(p) == 3
     assert next(p) == 1
+
+
+def test_repeat():
+    # Check if lists and callables both work
+    messages = [1, 2, 3]
+
+    def plan():
+        yield from messages
+
+    num = 3
+    expected = [Msg('checkpoint'), 1, 2, 3] * num
+    assert list(repeat(plan, num=num)) == expected
+    assert list(repeat(messages, num=num)) == expected
 
 
 def test_trigger_and_read(hw):

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -1157,3 +1157,4 @@ These are useful utilities for defining custom plans and plan preprocessors.
     broadcast_msg
     repeater
     caching_repeater
+    repeat


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Quick implementation of the `repeat` plan previously described in #929, with a refactoring of `count` to use `repeat`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are cases where we want to have a repeatable plan where we can leverage the kind of looping and delaying from `count` without rewriting the control flow. The logic in that plan isn't just a trivial `for loop`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`count` still works after being reimplemented using `repeat`

## Misc Thoughts
- I'm not in love with this implementation because I feel like it's cleaner to make a new plan with a simple `for loop`
- This is better for the health of the library than implementing a `per_step` kwarg in `count`, and it accomplishes almost the same thing
- It is up to the user to define a descriptive metadata dict and provide `start` and `stop` documents because the `repeat` plan doesn't do anything without being handed a plan. Fundamentally, a plan like this is not a `count` and each case needs to be treated differently.
- I haven't pushed any docs updates related to this new stub plan