### PR TITLE
FIX: Skip unfilled externally-stored data in LiveTable.

### DIFF
--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -298,7 +298,12 @@ class LiveTable(CallbackBase):
         data[self.ev_time_key] = fmt_time
         data['seq_num'] = doc['seq_num']
         cols = [f.format(**{k: data[k]})
-                if k in data else ' ' * self._format_info[k].width
+                # Show data[k] if k exists in this Event and is 'filled'.
+                # (The latter is only applicable if the data is
+                # externally-stored -- hence the fallback to `True`.)
+                if ((k in data) and doc.get('filled', {}).get(k, True))
+                # Otherwise use a placeholder of whitespace.
+                else ' ' * self._format_info[k].width
                 for k, f in self._data_formats.items()]
         self._print('|' + '|'.join(cols) + '|')
         super().event(doc)

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -161,6 +161,12 @@ def test_table(RE, hw):
             assert ln[26:] == kn[26:]
 
 
+def test_table_external(RE, hw, db):
+    RE.subscribe(db.insert)
+    hw.img.reg = db.reg
+    RE(count([hw.img]), LiveTable(['img']))
+
+
 KNOWN_TABLE = """+------------+--------------+----------------+----------------+
 |   seq_num  |        time  |           det  |         motor  |
 +------------+--------------+----------------+----------------+


### PR DESCRIPTION
Closes #914, related to #912 originally reported by @chiahaoliu.

The first commit adds a test demonstrating the problem: if a datum_id works its
way into LiveTable, LiveTable can fail in this confusing way:

```py
    cols = [f.format(**{k: data[k]})
            if k in data else ' ' * self._format_info[k].width
            >           for k, f in self._data_formats.items()]
            E   ValueError: Unknown format code 'f' for object of type 'str'
```

It's expecting a number -- the externally-stored data -- but it gets a string UUID.

The second commit fixes the problem by skipping any data that both externally
stored and unfilled. One can always fill the data first and _then_ send it
to LiveTable, in which case LiveTable will be satisfied.