### PR TITLE
Moved suspenders into init, not class declaration

### DIFF
--- a/bluesky/suspenders.py
+++ b/bluesky/suspenders.py
@@ -502,7 +502,10 @@ class SuspendOutBand(_SuspendBandBase):
     post_plan : iterable or iterator, optional
             a generator, list, or similar containing `Msg` objects
     """
-    warn("bluesky.suspenders.SuspendOutBand is deprecated.")
+    def __init__(self, *args, **kwargs):
+        warn("bluesky.suspenders.SuspendOutBand is deprecated.")
+        super().__init__(*args, **kwargs)
+
     def _should_resume(self, value):
         return not (self._bot < value < self._top)
 


### PR DESCRIPTION
The `warning` for the suspender should be in the `__init__` not the class declaration, is that correct?

  Right now I get warnings whenever I import anything from `bluesky.suspenders`