### PR TITLE
ENH: add a x2x_scan

### DIFF
--- a/bluesky/tests/test_scans.py
+++ b/bluesky/tests/test_scans.py
@@ -479,3 +479,22 @@ def test_relative_fermat_spiral(RE, hw):
     approx_multi_traj_checker(RE, scan,
                               _get_fermat_data(start_x, start_y),
                               decimal=2)
+
+
+def test_x2x_scan(RE,hw):
+    y_start = -1
+    y_stop = 4
+    y_num = 11
+    expected_traj = []
+
+    for i in range(y_num):
+        y_val = y_start + i * (y_stop - y_start) / (y_num - 1)
+        expected_traj.append({'motor1': y_val, 'det': 1.0, 'motor2': y_val / 2})
+
+    for d in expected_traj:
+        d.update({'motor1_setpoint': d['motor1']})
+        d.update({'motor2_setpoint': d['motor2']})
+
+    scan = bp.x2x_scan([hw.det], hw.motor1, hw.motor2, y_start, y_stop, y_num )
+
+    multi_traj_checker(RE, scan, expected_traj)

--- a/bluesky/tests/test_scans.py
+++ b/bluesky/tests/test_scans.py
@@ -481,7 +481,7 @@ def test_relative_fermat_spiral(RE, hw):
                               decimal=2)
 
 
-def test_x2x_scan(RE,hw):
+def test_x2x_scan(RE, hw):
     y_start = -1
     y_stop = 4
     y_num = 11


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a generic version of a theta-2theta scan.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Watching @ambarb do scans while testing the tardis at CSX she typed this signature into `relative_inner_product_scan` as a bit of wishful API.

@ambarb Did I understand this correctly and is this useful?  Do you have a better name?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Still needs test
<!--
## Screenshots (if appropriate):
-->
