### PR TITLE
Make BEC more tolerant of under-hinted plans.

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -144,6 +144,11 @@ class BestEffortCallback(CallbackBase):
             self._cleanup_motor_heuristic = False
             fixed_dim_fields = []
             for obj_name in self.dim_fields:
+                # Special case: 'time' can be a dim_field, but it's not an
+                # object name. Just add it directly to the list of fields.
+                if obj_name == 'time':
+                    fixed_dim_fields.append('time')
+                    continue
                 try:
                     fields = doc.get('hints', {}).get(obj_name, {})['fields']
                 except KeyError:

--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -1,5 +1,7 @@
 import ast
 from bluesky.plans import scan
+import bluesky.preprocessors as bpp
+import bluesky.plan_stubs as bps
 from bluesky.preprocessors import SupplementalData
 from bluesky.callbacks.best_effort import BestEffortCallback
 
@@ -67,3 +69,14 @@ def test_with_baseline(RE, hw):
     sd = SupplementalData(baseline=[hw.det])
     RE.preprocessors.append(sd)
     RE(scan([hw.ab_det], hw.motor, 1, 5, 5))
+
+
+def test_underhinted_plan(RE, hw):
+    bec = BestEffortCallback()
+    RE.subscribe(bec)
+
+    @bpp.run_decorator()
+    def broken_plan(dets):
+        yield from bps.trigger_and_read(dets)
+
+    RE(broken_plan([hw.det]))


### PR DESCRIPTION
Closes #955

Notice TDD commit history, verifying that the test hits this bug and the
next commit fixes it.