### PR TITLE
API: Deprecate caching_repeater; limit 'repeat' plan to callables.

### DIFF
--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -6,6 +6,7 @@ import operator
 from functools import reduce
 from collections import Iterable
 import time
+import warnings
 
 try:
     # cytools is a drop-in replacement for toolz, implemented in Cython
@@ -837,6 +838,8 @@ def caching_repeater(n, plan):
     --------
     :func:`bluesky.plans.repeater`
     """
+    warnings.warn("The caching_repeater will be removed in a future version "
+                  "of bluesky.")
     it = range
     if n is None:
         n = 0
@@ -905,8 +908,8 @@ def repeat(plan, num=1, delay=None):
 
     Parameters
     ----------
-    plan: callable or list
-        Callable that returns a valid plan, or a list of Message objects
+    plan: callable
+        Callable that returns an iterable of Msg objects
     num : integer, optional
         number of readings to take; default is 1
 
@@ -941,16 +944,10 @@ def repeat(plan, num=1, delay=None):
         delay = iter(delay)
 
     def repeated_plan():
-        nonlocal plan
         for i in iterator:
             now = time.time()  # Intercept the flow in its earliest moment.
             yield Msg('checkpoint')
-            if callable(plan):
-                yield from ensure_generator(plan())
-            else:
-                # Stash plan for our next trip through the loop; use plan_copy.
-                plan, plan_copy = itertools.tee(plan)
-                yield from ensure_generator(plan_copy)
+            yield from ensure_generator(plan())
             try:
                 d = next(delay)
             except StopIteration:

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -521,15 +521,13 @@ def test_repeat(RE):
     num = 3
     expected = [Msg('checkpoint'), 1, 2, 3] * num
     assert list(repeat(plan, num=num)) == expected
-    assert list(repeat(plan(), num=num)) == expected
-    assert list(repeat(messages, num=num)) == expected
 
 
 def test_repeat_using_RE(RE):
     def plan():
         yield Msg('open_run')
         yield Msg('close_run')
-    RE(repeat(plan(), 2))
+    RE(repeat(plan, 2))
 
 
 def test_trigger_and_read(hw):

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -1,6 +1,24 @@
 Release History
 ===============
 
+v1.2.0 (in progress)
+--------------------
+
+Features
+^^^^^^^^
+
+* A new plan stub, :func:`~bluesky.plan_stubs.repeat`, repeats another plan N
+  times with optional interleaved delays --- a kind of customizable version of
+  :func:`~bluesky.plans.count`.
+
+Deprecations
+^^^^^^^^^^^^
+
+* The :func:`~bluesky.plan_stubs.caching_repeater` plan has been deprecated
+  because it is incompatible with some preprocessors. It will be removed in
+  a future release of bluesky. It was not documented in any previous releases
+  and rarely if ever used, so the impact of this removal is expected to be low.
+
 v1.1.0 (2017-12-19)
 -------------------
 

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -7,9 +7,27 @@ v1.2.0 (in progress)
 Features
 ^^^^^^^^
 
+* Refresh documentation with a new :doc:`tutorial` section.
+* Extend :func:`.scan` and :func:`.rel_scan` to
+  handle multiple motors, rendering :func:`.inner_product_scan` and
+  :func:`relative_inner_product_scan` redundant.
 * A new plan stub, :func:`~bluesky.plan_stubs.repeat`, repeats another plan N
   times with optional interleaved delays --- a kind of customizable version of
   :func:`~bluesky.plans.count`.
+
+Bug Fixes
+^^^^^^^^^
+
+* Fix axes orientation in :class:`.LiveRaster`.
+* Make :class:`.BestEffortCallback` display multi-motor scans properly.
+* Fix bug in :func:`.ts_msg_hook` where it conflated month and minute. Also,
+  include sub-second precision.
+* Avoid situation where plan without hints caused the
+  :class:`.BestEffortCallback` to error instead of do its best to guess useful
+  behavior.
+* Skip un-filled externally-stored data in :class:`.LiveTable`. This fixes a
+  bug where it is expecting array data but gets UUID (``datum_id``) and errors
+  out.
 
 Deprecations
 ^^^^^^^^^^^^

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -649,6 +649,4 @@ These are useful utilities for defining custom plans and plan preprocessors.
    :nosignatures:
 
     broadcast_msg
-    repeater
-    caching_repeater
     repeat


### PR DESCRIPTION
The notion of repeating a literal sequence of Msgs is problematic,
because some Msgs' contents depends on replies from the RunEngine.
For example, `Msg('unsubscribe', ...)` contains a ``token`` that
comes from the RunEngine's reply to `Msg('subscribe')`. Therefore,
it does not really make sense to support the usage, "Repeat this
literal sequence of Msgs." Repeater utilities should require
callables, so that adaptiveness can be fully supported.

attn @ZLLentz