### PR TITLE
ENH: Add suspender messages

### DIFF
--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -650,6 +650,48 @@ def unsubscribe(token):
     return (yield Msg('unsubscribe', token=token))
 
 
+def install_suspender(suspender):
+    """
+    Install a suspender during a plan.
+
+    Parameters
+    ----------
+    suspender : :class:`bluesky.suspenders.SuspenderBase`
+        The suspender to install
+
+    Yields
+    ------
+    msg : Msg
+        Msg('install_suspender', suspender)
+
+    See Also
+    --------
+    :func:`bluesky.plan_subs.remove_suspender`
+    """
+    return (yield Msg('install_suspender', suspender))
+
+
+def remove_suspender(suspender):
+    """
+    Remove a suspender during a plan.
+
+    Parameters
+    ----------
+    suspender : :class:`bluesky.suspenders.SuspenderBase`
+        The suspender to remove
+
+    Yields
+    ------
+    msg : Msg
+        Msg('remove_suspender', suspender)
+
+    See Also
+    --------
+    :func:`bluesky.plan_stubs.install_suspender`
+    """
+    return (yield Msg('remove_suspender', suspender))
+
+
 def open_run(md=None):
     """
     Mark the beginning of a new 'run'. Emit a RunStart document.

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -662,13 +662,13 @@ def install_suspender(suspender):
     Yields
     ------
     msg : Msg
-        Msg('install_suspender', suspender)
+        Msg('install_suspender', None, suspender)
 
     See Also
     --------
     :func:`bluesky.plan_subs.remove_suspender`
     """
-    return (yield Msg('install_suspender', suspender))
+    return (yield Msg('install_suspender', None, suspender))
 
 
 def remove_suspender(suspender):
@@ -683,13 +683,13 @@ def remove_suspender(suspender):
     Yields
     ------
     msg : Msg
-        Msg('remove_suspender', suspender)
+        Msg('remove_suspender', None, suspender)
 
     See Also
     --------
     :func:`bluesky.plan_stubs.install_suspender`
     """
-    return (yield Msg('remove_suspender', suspender))
+    return (yield Msg('remove_suspender', None, suspender))
 
 
 def open_run(md=None):

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -352,6 +352,42 @@ def subs_wrapper(plan, subs):
                                         _unsubscribe()))
 
 
+def suspend_wrapper(plan, suspenders):
+    """
+    Install suspenders to the RunEngine, and remove them at the end.
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        a generator, list, or similar containing `Msg` objects
+    suspenders : suspender or list of suspenders
+        Suspenders to use for the duration of the wrapper
+
+    Yields
+    ------
+    msg : Msg
+        messages from plan, with 'install_suspender' and 'remove_suspender'
+        messages inserted and appended
+    """
+    if not isinstance(suspenders, list):
+        suspenders = [suspenders]
+
+    def _install():
+        for susp in suspenders:
+            yield Msg('install_suspender', susp)
+
+    def _remove():
+        for susp in suspenders:
+            yield Msg('remove_suspender', susp)
+
+    def _inner_plan():
+        yield from _install()
+        return (yield from plan)
+
+    return (yield from finalize_wrapper(_inner_plan(),
+                                        _remove()))
+
+
 def configure_count_time_wrapper(plan, time):
     """
     Preprocessor that sets all devices with a `count_time` to the same time.
@@ -1097,6 +1133,7 @@ def baseline_wrapper(plan, devices, name='baseline'):
 # Make generator function decorator for each generator instance wrapper.
 baseline_decorator = make_decorator(baseline_wrapper)
 subs_decorator = make_decorator(subs_wrapper)
+suspend_decorator = make_decorator(suspend_wrapper)
 relative_set_decorator = make_decorator(relative_set_wrapper)
 reset_positions_decorator = make_decorator(reset_positions_wrapper)
 # finalize_decorator is custom-made since it takes a plan as its

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict, deque, ChainMap
+from collections import OrderedDict, deque, ChainMap, Iterable
 import uuid
 from .utils import (normalize_subs_input, root_ancestor,
                     separate_devices,
@@ -369,16 +369,16 @@ def suspend_wrapper(plan, suspenders):
         messages from plan, with 'install_suspender' and 'remove_suspender'
         messages inserted and appended
     """
-    if not isinstance(suspenders, list):
+    if not isinstance(suspenders, Iterable):
         suspenders = [suspenders]
 
     def _install():
         for susp in suspenders:
-            yield Msg('install_suspender', susp)
+            yield Msg('install_suspender', None, susp)
 
     def _remove():
         for susp in suspenders:
-            yield Msg('remove_suspender', susp)
+            yield Msg('remove_suspender', None, susp)
 
     def _inner_plan():
         yield from _install()

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -186,7 +186,8 @@ class RunEngine:
     state = LoggingPropertyMachine(RunEngineStateMachine)
     _UNCACHEABLE_COMMANDS = ['pause', 'subscribe', 'unsubscribe', 'stage',
                              'unstage', 'monitor', 'unmonitor', 'open_run',
-                             'close_run']
+                             'close_run', 'install_suspender',
+                             'remove_suspender']
 
     def __init__(self, md=None, *, loop=None, preprocessors=None,
                  md_validator=None):
@@ -290,7 +291,9 @@ class RunEngine:
             'open_run': self._open_run,
             'close_run': self._close_run,
             'wait_for': self._wait_for,
-            'input': self._input, }
+            'input': self._input,
+            'install_suspender': self._install_suspender,
+            'remove_suspender': self._remove_suspender, }
 
         # public dispatcher for callbacks
         # The Dispatcher's public methods are exposed through the
@@ -768,6 +771,18 @@ class RunEngine:
         self._suspenders.add(suspender)
         suspender.install(self)
 
+    @asyncio.coroutine
+    def _install_suspender(self, msg):
+        """
+        See :meth: `RunEngine.install_suspender`
+
+        Expected message object is:
+
+            Msg('install_suspender', suspender)
+        """
+        suspender = msg.obj
+        self.install_suspender(suspender)
+
     def remove_suspender(self, suspender):
         """
         Uninstall a suspender.
@@ -784,6 +799,18 @@ class RunEngine:
         if suspender in self._suspenders:
             suspender.remove()
         self._suspenders.discard(suspender)
+
+    @asyncio.coroutine
+    def _remove_suspender(self, msg):
+        """
+        See :meth: `RunEngine.remove_suspender`
+
+        Expected message object is:
+
+            Msg('remove_suspender', suspender)
+        """
+        suspender = msg.obj
+        self.remove_suspender(suspender)
 
     def clear_suspenders(self):
         """

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -778,9 +778,9 @@ class RunEngine:
 
         Expected message object is:
 
-            Msg('install_suspender', suspender)
+            Msg('install_suspender', None, suspender)
         """
-        suspender = msg.obj
+        suspender = msg.args[0]
         self.install_suspender(suspender)
 
     def remove_suspender(self, suspender):
@@ -807,9 +807,9 @@ class RunEngine:
 
         Expected message object is:
 
-            Msg('remove_suspender', suspender)
+            Msg('remove_suspender', None, suspender)
         """
-        suspender = msg.obj
+        suspender = msg.args[0]
         self.remove_suspender(suspender)
 
     def clear_suspenders(self):

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -105,8 +105,8 @@ from bluesky.utils import all_safe_rewind
                                                        'func_placeholder',
                                                        'all')]),
      (unsubscribe, (1,), {}, [Msg('unsubscribe', None, token=1)]),
-     (install_suspender, (1,), {}, [Msg('install_suspender', 1)]),
-     (remove_suspender, (1,), {}, [Msg('remove_suspender', 1)]),
+     (install_suspender, (1,), {}, [Msg('install_suspender', None, 1)]),
+     (remove_suspender, (1,), {}, [Msg('remove_suspender', None, 1)]),
      (open_run, (), {}, [Msg('open_run')]),
      (open_run, (), {'md': {'a': 1}}, [Msg('open_run', a=1)]),
      (close_run, (), {}, [Msg('close_run', reason=None, exit_status=None)]),
@@ -277,9 +277,9 @@ def test_suspend():
 
     processed_plan = list(suspend_wrapper(plan, 1))
 
-    expected = [Msg('install_suspender', 1),
+    expected = [Msg('install_suspender', None, 1),
                 Msg('null'),
-                Msg('remove_suspender', 1)]
+                Msg('remove_suspender', None, 1)]
 
     assert processed_plan == expected
 

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -25,6 +25,8 @@ from bluesky.plan_stubs import (
     unstage,
     subscribe,
     unsubscribe,
+    install_suspender,
+    remove_suspender,
     open_run,
     close_run,
     wait_for,
@@ -45,6 +47,7 @@ from bluesky.preprocessors import (
     lazily_stage_wrapper,
     relative_set_wrapper,
     subs_wrapper,
+    suspend_wrapper,
     fly_during_decorator,
     subs_decorator,
     monitor_during_decorator,
@@ -102,6 +105,8 @@ from bluesky.utils import all_safe_rewind
                                                        'func_placeholder',
                                                        'all')]),
      (unsubscribe, (1,), {}, [Msg('unsubscribe', None, token=1)]),
+     (install_suspender, (1,), {}, [Msg('install_suspender', 1)]),
+     (remove_suspender, (1,), {}, [Msg('remove_suspender', 1)]),
      (open_run, (), {}, [Msg('open_run')]),
      (open_run, (), {'md': {'a': 1}}, [Msg('open_run', a=1)]),
      (close_run, (), {}, [Msg('close_run', reason=None, exit_status=None)]),
@@ -264,6 +269,18 @@ def test_subs():
 
     processed_plan = list(subs_decorator({'all': cb})(plan)('test_arg',
                                                             test_kwarg='val'))
+    assert processed_plan == expected
+
+
+def test_suspend():
+    plan = [Msg('null')]
+
+    processed_plan = list(suspend_wrapper(plan, 1))
+
+    expected = [Msg('install_suspender', 1),
+                Msg('null'),
+                Msg('remove_suspender', 1)]
+
     assert processed_plan == expected
 
 

--- a/bluesky/tests/test_suspenders.py
+++ b/bluesky/tests/test_suspenders.py
@@ -198,14 +198,14 @@ def test_suspender_plans(RE, hw):
     putter(0)
 
     # Do the messages work?
-    RE([Msg('install_suspender', my_suspender)])
+    RE([Msg('install_suspender', None, my_suspender)])
     assert my_suspender in RE.suspenders
-    RE([Msg('remove_suspender', my_suspender)])
+    RE([Msg('remove_suspender', None, my_suspender)])
     assert my_suspender not in RE.suspenders
 
     # Can we call both in a plan?
-    RE([Msg('install_suspender', my_suspender),
-        Msg('remove_suspender', my_suspender)])
+    RE([Msg('install_suspender', None, my_suspender),
+        Msg('remove_suspender', None, my_suspender)])
 
     scan = [Msg('checkpoint'), Msg('sleep', None, .2)]
 

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -382,6 +382,8 @@ Plans that control the RunEngine:
     input_plan
     subscribe
     unsubscribe
+    install_suspender
+    remove_suspender
     wait
     wait_for
     null
@@ -525,6 +527,8 @@ a generator instance. The corresponding functions named
     stage_wrapper
     subs_decorator
     subs_wrapper
+    suspend_decorator
+    suspend_wrapper
 
 Custom Preprocessors
 --------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds messages and preprocessor to install and remove suspenders during a plan.
```
Msg('install_suspender', None, my_suspender)
Msg('remove_suspender', None, my_suspender)

suspend_wrapper(my_plan, my_suspender)
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We've found times where we would like to associate a suspender with a particular plan, rather than with the `RE` instance. These are the sort of things that we might want for only a subset of plans in a particular experiment, so switching between them is awkward. This seems like a logical extension of the existing API.

This seemed simple enough to implement in a very basic way, so I decided to hash it out.

closes #998 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've inserted the messages into the tests where it seemed appropriate and added a test for the preprocessor at the end of the suspender tests.