### PR TITLE
DOC: add `%matplotlib notebook` to tutorials docs

### DIFF
--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -137,6 +137,8 @@ To start, let's use the all-purpose
 
 .. code-block:: python
 
+    %matplotlib notebook
+
     from bluesky.callbacks.best_effort import BestEffortCallback
     bec = BestEffortCallback()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Tutorials page is missing `%matplotlib notebook` directive. Fixing this issue here.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
