### PR TITLE
BUG: Suspenders now call .resume() upon resuming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ target/
 
 # sphinx
 doc/source/generated/*.rst
+.pytest_cache

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -256,7 +256,7 @@ class RunEngine:
         self._msg_cache = deque()  # history of processed msgs for rewinding
         self._rewindable_flag = True  # if the RE is allowed to replay msgs
         self._plan_stack = deque()  # stack of generators to work off of
-        self._response_stack = deque([None])  # resps to send into the plans
+        self._response_stack = deque()  # resps to send into the plans
         self._exit_status = 'success'  # optimistic default
         self._reason = ''  # reason for abort
         self._task = None  # asyncio.Task associated with call to self._run
@@ -420,7 +420,7 @@ class RunEngine:
         self._deferred_pause_requested = False
         self._plan_stack = deque()
         self._msg_cache = deque()
-        self._response_stack = deque([None])
+        self._response_stack = deque()
         self._exception = None
         self._run_start_uids.clear()
         self._exit_status = 'success'

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1008,15 +1008,15 @@ class RunEngine:
         """
         pending_cancel_exception = None
         self._reason = ''
-        # sentinal to decide if need to add to the response stack or not
-        sentinal = object()
+        # sentinel to decide if need to add to the response stack or not
+        sentinel = object()
         try:
             self.state = 'running'
             while True:
                 assert len(self._response_stack) == len(self._plan_stack)
-                # set resp to the sentinal so that if we fail in the sleep
+                # set resp to the sentinel so that if we fail in the sleep
                 # we do not add an extra response
-                resp = sentinal
+                resp = sentinel
                 try:
                     # the new response to be added
                     new_response = None
@@ -1052,7 +1052,7 @@ class RunEngine:
                             self._plan_stack.pop()
                             # we have killed the current plan, do not give
                             # it a new response
-                            resp = sentinal
+                            resp = sentinel
                             if len(self._plan_stack):
                                 self._exception = e
                                 continue
@@ -1074,7 +1074,7 @@ class RunEngine:
                             self._plan_stack.pop()
                             # we have killed the current plan, do not give
                             # it a new response
-                            resp = sentinal
+                            resp = sentinel
                             if len(self._plan_stack):
                                 continue
                             # or reraise to get out of the infinite loop
@@ -1087,7 +1087,7 @@ class RunEngine:
                             self._plan_stack.pop()
                             # we have killed the current plan, do not give
                             # it a new response
-                            resp = sentinal
+                            resp = sentinel
                             if len(self._plan_stack):
                                 self._exception = e
                                 continue
@@ -1161,7 +1161,7 @@ class RunEngine:
                 finally:
                     # if we poped a response and did not pop a plan, we need
                     # to put the new response back on the stack
-                    if resp is not sentinal:
+                    if resp is not sentinel:
                         self._response_stack.append(new_response)
 
         except (StopIteration, RequestStop):

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -892,8 +892,10 @@ class RunEngine:
                     post_plan = post_plan()
                 self._plan_stack.append(ensure_generator(post_plan))
                 self._response_stack.append(None)
-            # add the wait on the future to the stack
+            # tell the devices they are ready to go again
             self._plan_stack.append(single_gen(Msg('resume', None, )))
+            self._response_stack.append(None)
+            # add the wait on the future to the stack
             self._plan_stack.append(single_gen(Msg('wait_for', None, [fut, ])))
             self._response_stack.append(None)
             # if there is a pre plan add on top of the wait

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -475,14 +475,14 @@ def _make_unrewindable_suspender_marker():
                  motor,
                  UnReplayableSynGauss('det', motor, 'motor', center=0, Imax=1),
                  ['set', 'trigger', 'sleep',
-                  'rewindable', 'wait_for', 'rewindable',
+                  'rewindable', 'wait_for', 'resume', 'rewindable',
                   'set', 'trigger']))
 
     inps.append((test_plan,
                  motor,
                  SynGauss('det', motor, 'motor', center=0, Imax=1),
                  ['set', 'trigger', 'sleep',
-                  'rewindable', 'wait_for', 'rewindable',
+                  'rewindable', 'wait_for', 'resume', 'rewindable',
                   'set',
                   'trigger', 'sleep', 'set', 'trigger']))
 

--- a/bluesky/tests/test_suspenders.py
+++ b/bluesky/tests/test_suspenders.py
@@ -80,16 +80,19 @@ def test_pretripped(RE, hw):
 @pytest.mark.parametrize('pre_plan,post_plan,expected_list',
                          [([Msg('null')], None,
                            ['checkpoint', 'sleep', 'rewindable', 'null',
-                            'wait_for', 'rewindable', 'sleep']),
+                            'wait_for', 'resume', 'rewindable', 'sleep']),
                           (None, [Msg('null')],
                            ['checkpoint', 'sleep', 'rewindable',
-                            'wait_for', 'null', 'rewindable', 'sleep']),
+                            'wait_for', 'resume', 'null', 'rewindable',
+                            'sleep']),
                           ([Msg('null')], [Msg('null')],
                            ['checkpoint', 'sleep', 'rewindable', 'null',
-                            'wait_for', 'null', 'rewindable', 'sleep']),
+                            'wait_for', 'resume', 'null', 'rewindable',
+                            'sleep']),
                           (lambda: [Msg('null')], lambda: [Msg('null')],
                            ['checkpoint', 'sleep', 'rewindable', 'null',
-                            'wait_for', 'null', 'rewindable', 'sleep'])])
+                            'wait_for', 'resume', 'null', 'rewindable',
+                            'sleep'])])
 def test_pre_suspend_plan(RE, pre_plan, post_plan, expected_list, hw):
     sig = hw.bool_sig
     scan = [Msg('checkpoint'), Msg('sleep', None, .2)]


### PR DESCRIPTION
The suspenders where calling the obj.pause() upon being triggered, but were not calling the obj.resume() when they resumed.

## Description
Added a coroutine `_resume()` and then registered (And called) a `Msg` called `resume` to run it.

## Motivation and Context
The FastCCD detector on CSX turns off the HDF5 file capture when paused, and as resume is not being called on the suspender resume, the detector never starts writing data to a file again.  

For the Ctrl-C type pause/resume everything works as expected.

## How Has This Been Tested?
We (myself and @jrmlhermitte) ran numerous tests on the beamline to make sure this fixed the observed issue on CSX.  

