### PR TITLE
Rel warning

### DIFF
--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -948,6 +948,8 @@ def __read_and_stash_a_motor(obj, initial_positions, coupled_parents):
         reading = yield Msg('read', obj)
         if reading is None:
             # this plan may be being list-ified
+            print("*** all positions for {m.name} are "
+                  "relative to current position ***".format(m=obj))
             cur_pos = 0
         else:
             fields = getattr(obj, 'hints', {}).get('fields', [])

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -264,12 +264,11 @@ def print_summary_wrapper(plan):
             print('{motor.name} -> {args[0]}'.format(motor=msg.obj,
                                                      args=msg.args))
         elif cmd == 'create':
-            pass
+            read_cache = []
         elif cmd == 'read':
             read_cache.append(msg.obj.name)
         elif cmd == 'save':
             print('  Read {}'.format(read_cache))
-            read_cache = []
         yield msg
 
 

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -1051,19 +1051,6 @@ def reset_positions_wrapper(plan, devices=None):
     else:
         coupled_parents = set()
 
-    def read_and_stash_a_motor(obj):
-        try:
-            cur_pos = obj.position
-        except AttributeError:
-            reading = yield Msg('read', obj)
-            if reading is None:
-                # this plan may be being list-ified
-                cur_pos = 0
-            else:
-                k = list(reading.keys())[0]
-                cur_pos = reading[k]['value']
-        initial_positions[obj] = cur_pos
-
     def insert_reads(msg):
         eligible = devices is None or msg.obj in devices
         seen = msg.obj in initial_positions


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add a warning when the relative wrappers are used in 'simulation' mode and are assuming an initial position of `0` along with some clean up

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes quality of life issue / possibly dangerous situation they had at CSX.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
In [3]: import bluesky.plans as bp
   ...: from bluesky.simulators import print_summary
   ...: from ophyd.sim import motor1
   ...: from ophyd import Signal
   ...: 
   ...: motor1.set(5)
   ...: s = Signal(value=0, name='s')
   ...: print_summary(bp.rel_scan([], motor1, -1, 1, 10))
   ...: print_summary(bp.rel_scan([], s, -1, 1, 10))
=================================== Open Run ===================================
motor1 -> 4.0
  Read ['motor1']
motor1 -> 4.222222222222222
  Read ['motor1']
motor1 -> 4.444444444444445
  Read ['motor1']
motor1 -> 4.666666666666667
  Read ['motor1']
motor1 -> 4.888888888888889
  Read ['motor1']
motor1 -> 5.111111111111111
  Read ['motor1']
motor1 -> 5.333333333333333
  Read ['motor1']
motor1 -> 5.555555555555555
  Read ['motor1']
motor1 -> 5.777777777777778
  Read ['motor1']
motor1 -> 6.0
  Read ['motor1']
================================== Close Run ===================================
motor1 -> 5
=================================== Open Run ===================================
*** all positions for s are relative to current position ***
*** all positions for s are relative to current position ***
s -> -1.0
  Read ['s']
s -> -0.7777777777777778
  Read ['s']
s -> -0.5555555555555556
  Read ['s']
s -> -0.33333333333333337
  Read ['s']
s -> -0.11111111111111116
  Read ['s']
s -> 0.11111111111111116
  Read ['s']
s -> 0.33333333333333326
  Read ['s']
s -> 0.5555555555555554
  Read ['s']
s -> 0.7777777777777777
  Read ['s']
s -> 1.0
  Read ['s']
================================== Close Run ===================================
s -> 0

```
<!--
## Screenshots (if appropriate):
-->
