### PR TITLE
FIX: fix BEC LiveGrid plot for a motor with one step

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -299,7 +299,8 @@ class BestEffortCallback(CallbackBase):
                          "create LiveGrid.")
                 else:
                     data_range = np.array([float(np.diff(e)) for e in extents])
-                    y_step, x_step = data_range / [s - 1 for s in shape]
+                    shp = [(s + 1) if s == 1 else s for s in shape]
+                    y_step, x_step = data_range / [s - 1 for s in shp]
                     adjusted_extent = [extents[1][0] - x_step / 2,
                                        extents[1][1] + x_step / 2,
                                        extents[0][0] - y_step / 2,

--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -299,8 +299,7 @@ class BestEffortCallback(CallbackBase):
                          "create LiveGrid.")
                 else:
                     data_range = np.array([float(np.diff(e)) for e in extents])
-                    shp = [(s + 1) if s == 1 else s for s in shape]
-                    y_step, x_step = data_range / [s - 1 for s in shp]
+                    y_step, x_step = data_range / [max(1, s - 1) for s in shape]
                     adjusted_extent = [extents[1][0] - x_step / 2,
                                        extents[1][1] + x_step / 2,
                                        extents[0][0] - y_step / 2,

--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -1,5 +1,5 @@
 import ast
-from bluesky.plans import scan
+from bluesky.plans import scan, grid_scan
 import bluesky.preprocessors as bpp
 import bluesky.plan_stubs as bps
 from bluesky.preprocessors import SupplementalData
@@ -80,3 +80,9 @@ def test_underhinted_plan(RE, hw):
         yield from bps.trigger_and_read(dets)
 
     RE(broken_plan([hw.det]))
+
+
+def test_live_grid(RE, hw):
+    bec = BestEffortCallback()
+    RE.subscribe(bec)
+    RE(grid_scan([hw.det4], hw.motor1, 0, 1, 1, hw.motor2, 0, 1, 2, True))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR should fix the issue with a BestEffortCallback LiveGrid plot failing for the `grid_scan` plan for a motor with one step.

## Description
<!--- Describe your changes in detail -->
Steps to reproduce:
```python
import matplotlib.pyplot as plt
from bluesky.utils import install_qt_kicker
from bluesky.run_engine import RunEngine
from bluesky.callbacks.best_effort import BestEffortCallback
import bluesky.plans as bp
from ophyd.sim import det4, motor1, motor2

plt.ion()
install_qt_kicker()
RE = RunEngine({})
bec = BestEffortCallback()
RE.subscribe(bec)
RE(bp.grid_scan([det4], motor1, 0, 1, 1, motor2, 0, 1, 2, True))
```
This will fail with an error like:
```
In [26]: RE(bp.grid_scan([det4], motor1, 0, 1, 1, motor2, 0, 1, 2, True))
Transient Scan ID: 6     Time: 2018/04/07 00:48:56
Persistent Unique Scan ID: '23353b56-06cd-4827-abb6-79a472c29736'
New stream: 'primary'
+-----------+------------+------------+------------+------------+
|   seq_num |       time |     motor1 |     motor2 |       det4 |
+-----------+------------+------------+------------+------------+
/Users/mrakitin/src/mrakitin/DAMA/bluesky/bluesky/callbacks/best_effort.py:302: RuntimeWarning: divide by zero encountered in true_divide
  y_step, x_step = data_range / [s - 1 for s in shape]
+-----------+------------+------------+------------+------------+
generator grid_scan ['23353b56'] (scan num: 6)
```
The fix helps to eliminate the error and produce a plot with one "row" of data:

<img width="300" alt="image" src="https://user-images.githubusercontent.com/13209176/38451817-e64ad4f4-3a04-11e8-87ee-7eae0507e4df.png">

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
First this issue was observed at the [NSLS-II SMI beamline](https://github.com/NSLS-II-SMI/ipython_ophyd/blob/e847b3cf3d011121221424e0fe0b2243bc85166a/profile_collection/startup/30-user.py#L193), where the number of motors passed as arguments to the `grid_scan` plan varies from 1 to 3.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests passed locally.

<!--
## Screenshots (if appropriate):
-->
