### PR TITLE
FIX: clean up the internal state of the RE earlier in _save

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1560,6 +1560,17 @@ class RunEngine:
 
         # Event Descriptor documents
         desc_key = self._bundle_name
+
+        # This is a separate check because it can be reset on resume.
+        seq_num_key = desc_key
+        if seq_num_key not in self._sequence_counters:
+            counter = count(1)
+            counter_copy1, counter_copy2 = tee(counter)
+            self._sequence_counters[seq_num_key] = counter_copy1
+            self._teed_sequence_counters[seq_num_key] = counter_copy2
+        self._bundling = False
+        self._bundle_name = None
+
         d_objs, doc = self._descriptors.get(desc_key, (None, None))
         if d_objs is not None and d_objs != objs_read:
             raise RuntimeError("Mismatched objects read, expected {!s}, "
@@ -1587,25 +1598,15 @@ class RunEngine:
             descriptor_uid = new_uid()
             doc = dict(run_start=self._run_start_uid, time=ttime.time(),
                        data_keys=data_keys, uid=descriptor_uid,
-                       configuration=config, name=self._bundle_name,
+                       configuration=config, name=desc_key,
                        hints=hints, object_keys=object_keys)
             yield from self.emit(DocumentNames.descriptor, doc)
             self.log.debug("Emitted Event Descriptor with name %r containing "
-                           "data keys %r (uid=%r)", self._bundle_name,
+                           "data keys %r (uid=%r)", desc_key,
                            data_keys.keys(), descriptor_uid)
             self._descriptors[desc_key] = (objs_read, doc)
 
         descriptor_uid = doc['uid']
-
-        # This is a separate check because it can be reset on resume.
-        seq_num_key = desc_key
-        if seq_num_key not in self._sequence_counters:
-            counter = count(1)
-            counter_copy1, counter_copy2 = tee(counter)
-            self._sequence_counters[seq_num_key] = counter_copy1
-            self._teed_sequence_counters[seq_num_key] = counter_copy2
-        self._bundling = False
-        self._bundle_name = None
 
         # Resource and Datum documents
         for name, doc in self._asset_docs_cache:

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1369,3 +1369,31 @@ def test_drop(RE, hw):
     RE(plan(), collector)
 
     assert len(docs['event']) == 3
+
+
+def test_failing_describe_callback(RE, hw):
+    class TestException(Exception):
+        pass
+    det = hw.det
+    det2 = hw.det2
+
+    def evil_cb(name, doc):
+        if any(k in doc['data_keys'] for k in det.describe()):
+            raise TestException
+
+    RE.subscribe(evil_cb, 'descriptor')
+
+    def plan():
+        yield Msg('open_run')
+        try:
+            yield Msg('create')
+            yield Msg('read', det)
+            yield Msg('save')
+        finally:
+            yield Msg('create')
+            yield Msg('read', det2)
+            yield Msg('save')
+        yield Msg('close_run')
+
+    with pytest.raises(TestException):
+        RE(plan())


### PR DESCRIPTION
Move the logic to re-set the internal state of the RE to not bundling
to above where we do anything with descriptors.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
