### PR TITLE
Added magics

### DIFF
--- a/bluesky/magics.py
+++ b/bluesky/magics.py
@@ -14,7 +14,6 @@ import collections
 from operator import attrgetter
 from . import plans as bp
 from . import plan_stubs as bps
-from bluesky.utils import separate_devices
 
 try:
     # cytools is a drop-in replacement for toolz, implemented in Cython
@@ -117,7 +116,7 @@ class BlueskyMagics(Magics):
     def detectors(self, line):
         ''' List all available detectors.'''
         # also make sure it has a name for printing
-        label='detector'
+        label = 'detector'
         devices = _labeled_devices(user_ns=self.shell.user_ns)
         cols = ["Python name", "Ophyd Name"]
         print("{:20s} \t {:20s}".format(*cols))
@@ -129,7 +128,7 @@ class BlueskyMagics(Magics):
     def motors(self, line):
         ''' List all available motors.'''
         # also make sure it has a name for printing
-        label='motor'
+        label = 'motor'
         devices = _labeled_devices(user_ns=self.shell.user_ns)
         # ignore the first key
         positioners = [positioner[1] for positioner in devices[label]]
@@ -244,7 +243,7 @@ def _labeled_devices(user_ns=None, maxdepth=6):
             if is_parent(obj):
                 labels = getattr(obj, '_ophyd_labels_', set())
                 obj_list.update(_labeled_devices(user_ns=obj.__dict__,
-                                              maxdepth=maxdepth-1,))
+                                                 maxdepth=maxdepth-1,))
             else:
                 if hasattr(obj, '_ophyd_labels_'):
                     # inherit parent labels
@@ -262,12 +261,14 @@ def is_parent(dev):
     return (hasattr(dev, 'component_names') and len(dev.component_names) > 0
             and hasattr(dev, 'read_attrs'))
 
+
 def get_children(dev):
     children = list()
     if hasattr(dev, 'component_names') and len(dev.component_names) > 0:
         for comp_name in dev.component_names:
             children.append(getattr(dev, comp_name))
     return children
+
 
 def _ct_callback(name, doc):
     if name != 'event':

--- a/bluesky/magics.py
+++ b/bluesky/magics.py
@@ -15,6 +15,7 @@ from . import plans as bp
 from . import plan_stubs as bps
 
 from ophyd.areadetector.base import ADBase
+from ophyd.epics_motor import EpicsMotor
 
 try:
     # cytools is a drop-in replacement for toolz, implemented in Cython
@@ -123,6 +124,16 @@ class BlueskyMagics(Magics):
         for name, obj in devices:
             print("{:20s} \t {:20s}".format(name, obj.name))
 
+    @line_magic
+    def motors(self, line):
+        ''' List all available detectors.'''
+        devices = _which_devices(cls_whitelist=[EpicsMotor], cls_blacklist=None)
+        cols = ["Python name", "Ophyd Name"]
+        print("{:20s} \t {:20s}".format(*cols))
+        print("="*40)
+        for name, obj in devices:
+            print("{:20s} \t {:20s}".format(name, obj.name))
+
 
     @line_magic
     def wa(self, line):
@@ -180,7 +191,10 @@ def _which_devices(cls_whitelist=None, cls_blacklist=None):
         cls_whitelist : tuple or list, optional
             the class of PV's to search for
             defaults to [Device, Signal]
+
         cls_blacklist : tuple or list, optional
+            the class of PV's to ignore
+            this defaults to an empty list
 
         Examples
         --------
@@ -202,7 +216,7 @@ def _which_devices(cls_whitelist=None, cls_blacklist=None):
         # also check its a subclass of desired classes
         if not key.startswith("_") and \
                 isinstance(obj, tuple(cls_whitelist)) and \
-                not isinstance(tuple(cls_blacklist)):
+                not isinstance(obj, tuple(cls_blacklist)):
             obj_list.append((key, obj))
 
     return obj_list

--- a/bluesky/magics.py
+++ b/bluesky/magics.py
@@ -116,7 +116,8 @@ class BlueskyMagics(Magics):
         ''' List all available detectors.'''
         # also make sure it has a name for printing
         logic = lambda x : is_detector(x) and hasattr(x, 'name')
-        devices = _which_devices(cls_whitelist=logic, cls_blacklist=None)
+        devices = _which_devices(cls_whitelist=logic, cls_blacklist=None,
+                                 user_ns=self.shell.user_ns)
         cols = ["Python name", "Ophyd Name"]
         print("{:20s} \t {:20s}".format(*cols))
         print("="*40)
@@ -128,7 +129,8 @@ class BlueskyMagics(Magics):
         ''' List all available detectors.'''
         # also make sure it has a name for printing
         logic = lambda x : is_epics_motor(x) and hasattr(x, 'name')
-        devices = _which_devices(cls_whitelist=logic, cls_blacklist=None)
+        devices = _which_devices(cls_whitelist=logic, cls_blacklist=None,
+                                 user_ns=self.shell.user_ns)
         cols = ["Python name", "Ophyd Name"]
         print("{:20s} \t {:20s}".format(*cols))
         print("="*40)
@@ -184,7 +186,7 @@ class BlueskyMagics(Magics):
         print('\n'.join(lines))
 
 
-def _which_devices(cls_whitelist=None, cls_blacklist=None):
+def _which_devices(cls_whitelist=None, cls_blacklist=None, user_ns=None):
     ''' Returns list of all devices according to the classes listed.
 
         Parameters
@@ -212,7 +214,8 @@ def _which_devices(cls_whitelist=None, cls_blacklist=None):
     if cls_blacklist is None:
         cls_blacklist = lambda x : False
 
-    user_ns = get_ipython().user_ns
+    if user_ns is None:
+        user_ns = get_ipython().user_ns
 
     obj_list = list()
     for key, obj in user_ns.items():

--- a/bluesky/magics.py
+++ b/bluesky/magics.py
@@ -145,7 +145,7 @@ class BlueskyMagics(Magics):
             positioners = eval(line, self.shell.user_ns)
         else:
             positioners = self.positioners
-        _print_positioners(positioners)
+        _print_positioners(positioners, precision=self.FMT_PREC)
 
 
 def _print_positioners(positioners, sort=True, precision=6):


### PR DESCRIPTION
WIP : Adding some ipython magics for bluesky for better diagnostics.

## Description
This is a WIP adding a series of bluesky magics that will allow the user to find what Devices they have available.


## Motivation and Context
Users often need to see a list of defined ophyd devices. This will help with that.

## How Has This Been Tested?

Tested at PDF beamline so far:
```py3
In [1]: %detectors
Python name              Ophyd Name          
========================================
Test_Cam1                Test_Cam1           
Cam2                     Cam2                
camera                   Cam2                
stats_plugin             Cam2_stats5         
pe1                      pe1                 
```

## Discussion
This is currently just searching the user name space. It might be potentially useful to search all `Signals` (children of `Devices`).