### PR TITLE
FIX: LiveDispatcher should work even if we do not see a start document

### DIFF
--- a/bluesky/callbacks/stream.py
+++ b/bluesky/callbacks/stream.py
@@ -54,7 +54,7 @@ class LiveDispatcher(CallbackBase):
         # of the original start document. Preserve the rest of the metadata
         # that we retrieved from the start document
         md = ChainMap({'uid': self._stream_start_uid,
-                       'original_run_uid': doc['uid'],
+                       'original_run_uid': doc.get('uid', None),
                        'time': ttime.time()},
                       _md, doc)
         # Dispatch the start document for anyone subscribed to our Dispatcher
@@ -115,6 +115,10 @@ class LiveDispatcher(CallbackBase):
         """
         id_args = id_args or (doc['descriptor'],)
         config = config or dict()
+        # If we haven't seen a start document make sure we at least give an
+        # metadata-less start document to our subscribers
+        if not self._stream_start_uid:
+            self.start({})
         # Determine the descriptor id
         desc_id = frozenset((tuple(doc['data'].keys()), stream_name, id_args))
         # If we haven't described this configuration


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Finally got around to playing with the `LiveDispatcher` and noticed this slightly annoying gotcha. If you subscribe a `LiveDispatcher` **after** the original start document, the secondary stream outputs an event document **before** ever outputting a start document. This is certainly confusing to subscribers and we also never perform any of the necessary start-up done in `LiveDispatcher.start`

This quick fix just checks right before we emit our first event that we emitted a start document, if not we force an `self.start()` with an empty dictionary. 
