### PR TITLE
BLD: Include more files in distribution.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,9 @@
-include versioneer.py
 include bluesky/_version.py
+recursive-include doc/source *
+include doc/Makefile doc/make.bat
+include LICENSE
+include MANIFEST.in
+include README.rst
+include requirements.txt
+include setup.py
+include versioneer.py


### PR DESCRIPTION
Most importantly, include requirements.txt, which is opened by
setup.py.

In current distribution, installing from a downloaded source tarball
does not work!

h/t @mrakitin for noticing the missing requirements.txt file.