### PR TITLE
FIX: Show-stopping typo in flyer asset collection.

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1844,7 +1844,7 @@ class RunEngine:
 
         if hasattr(obj, 'collect_asset_docs'):
             # Resource and Datum documents
-            for name, doc in self.collect_asset_docs():
+            for name, doc in obj.collect_asset_docs():
                 # Add a 'run_start' field to the resource document on its way out.
                 if name == 'resource':
                     doc['run_start'] = self._run_start_uid


### PR DESCRIPTION
This typo is only hit if using a Flyer than implements `collect_asset_docs()`.

Are there any on the ring other than the one that @mrakitin are setting up with @dhidas
for HXN?