### PR TITLE
FIX: catch tight_layout errors

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -344,8 +344,10 @@ class BestEffortCallback(CallbackBase):
         else:
             raise NotImplementedError("we do not support 3D+ in BEC yet "
                                       "(and it should have bailed above)")
-
-        fig.tight_layout()
+        try:
+            fig.tight_layout()
+        except ValueError:
+            pass
 
     def event(self, doc):
         descriptor = self._descriptors[doc['descriptor']]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

If over-constrained tight_layout may raise `ValueError`.  Catch that
and move on assuming that an ugly plot is better than blowing up.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://gitter.im/NSLS-II/DAMA?at=5b12a1ba4eaffb692d76db00