### PR TITLE
Live grid image mirroring

### DIFF
--- a/bluesky/magics.py
+++ b/bluesky/magics.py
@@ -346,7 +346,7 @@ def get_labeled_devices(user_ns=None, maxdepth=6):
 
 
     # Convert from defaultdict to normal dict before returning.
-    return dict(obj_list)
+    return {k: sorted(v) for k, v in obj_list.items()}
 
 
 def is_parent(dev):


### PR DESCRIPTION


## Description
Add the kwarg 'axes_positive' which is a list in the form ['x_direction', y_direction']. x_direction can take the values 'right' or 'left' and y_direction can take the values 'up' or 'down'. These values define the positive direction of the corresponding x or y axis.

## Motivation and Context
At SRX they scan the sample in order to produce 'images'. This scanning process leads to the y axis being inverted, as the moving the sample 'up' moves the beam 'down' on the sample. This will allow them to flip the direction of y_axis in order to have LiveGrid display the image correctly.
