### PR TITLE
ENH: prototype allow passing message prefixes to zmq

### DIFF
--- a/bluesky/callbacks/zmq.py
+++ b/bluesky/callbacks/zmq.py
@@ -35,8 +35,6 @@ class Publisher:
     >>> publisher = Publisher('localhost:5567', RE=RE)
     """
     def __init__(self, address, *, RE=None, zmq=None, prefix=''):
-        if prefix is None:
-            prefix = ''
         if zmq is None:
             import zmq
         if isinstance(address, str):

--- a/bluesky/callbacks/zmq.py
+++ b/bluesky/callbacks/zmq.py
@@ -24,6 +24,7 @@ class Publisher:
     zmq : object, optional
         By default, the 'zmq' module is imported and used. Anything else
         mocking its interface is accepted.
+    prefix : message prefix
 
     Example
     -------
@@ -33,7 +34,9 @@ class Publisher:
     >>> RE = RunEngine({})
     >>> publisher = Publisher('localhost:5567', RE=RE)
     """
-    def __init__(self, address, *, RE=None, zmq=None):
+    def __init__(self, address, *, RE=None, zmq=None, prefix=None):
+        if prefix is None:
+            prefix = ''
         if zmq is None:
             import zmq
         if isinstance(address, str):
@@ -43,8 +46,13 @@ class Publisher:
         self.hostname = socket.gethostname()
         self.pid = os.getpid()
         url = "tcp://%s:%d" % self.address
-        self._prefix = b'%s %d %d ' % (self.hostname.encode(),
-                                       self.pid, id(RE))
+        if prefix is not None:
+            self._prefix = b'%s %s %d %d ' % (prefix, self.hostname.encode(),
+                                              self.pid, id(RE))
+        else:
+            self._prefix = b'%s %s %d %d ' % (self.hostname.encode(), self.pid,
+                                              id(RE))
+
         self._context = zmq.Context()
         self._socket = self._context.socket(zmq.PUB)
         self._socket.connect(url)
@@ -204,7 +212,8 @@ class RemoteDispatcher(Dispatcher):
     >>> d.start()  # runs until interrupted
     """
     def __init__(self, address, *, hostname=None, pid=None, run_engine_id=None,
-                 loop=None, zmq=None, zmq_asyncio=None):
+                 loop=None, zmq=None, zmq_asyncio=None, prefix=None):
+        self._message_prefix = prefix
         if zmq is None:
             import zmq
         if zmq_asyncio is None:
@@ -227,13 +236,22 @@ class RemoteDispatcher(Dispatcher):
         self._socket.setsockopt_string(zmq.SUBSCRIBE, "")
         self._task = None
 
-        def is_our_message(_hostname, _pid, _RE_id):
+        def is_our_message(_hostname, _pid, _RE_id, message_prefix=None):
             # Close over filters and decide if this message applies to this
             # RemoteDispatcher.
-            return ((hostname is None or hostname == _hostname)
-                    and (pid is None or pid == _pid)
-                    and (run_engine_id is None or run_engine_id ==
-                         run_engine_id))
+            if message_prefix is not None:
+                return ((hostname is None or hostname == _hostname)
+                        and (pid is None or pid == _pid)
+                        and (run_engine_id is None or run_engine_id ==
+                            run_engine_id)
+                        and message_prefix == self._message_prefix
+                       )
+            else:
+                return ((hostname is None or hostname == _hostname)
+                        and (pid is None or pid == _pid)
+                        and (run_engine_id is None or run_engine_id ==
+                            run_engine_id))
+
         self._is_our_message = is_our_message
 
         super().__init__()
@@ -242,12 +260,16 @@ class RemoteDispatcher(Dispatcher):
     def _poll(self):
         while True:
             message = yield from self._socket.recv()
-            hostname, pid, RE_id, name, doc = message.split(b' ', 4)
+            if self.message_prefix is not None:
+                prefix, hostname, pid, RE_id, name, doc = message.split(b' ', 5)
+            else:
+                hostname, pid, RE_id, name, doc = message.split(b' ', 5)
+            prefix = prefix.decode()
             hostname = hostname.decode()
             pid = int(pid)
             RE_id = int(RE_id)
             name = name.decode()
-            if self._is_our_message(hostname, pid, RE_id):
+            if self._is_our_message(hostname, pid, RE_id, message_prefix=prefix):
                 doc = pickle.loads(doc)
                 self.loop.call_soon(self.process, DocumentNames[name], doc)
 

--- a/bluesky/callbacks/zmq.py
+++ b/bluesky/callbacks/zmq.py
@@ -44,7 +44,7 @@ class Publisher:
         self.hostname = socket.gethostname()
         self.pid = os.getpid()
         url = "tcp://%s:%d" % self.address
-        self._prefix = b'%s\x00%s\x00%d\x00%d\x00' % (prefix,
+        self._prefix = b'%s\x00%s\x00%d\x00%d\x00' % (prefix.encode(),
                                                       self.hostname.encode(),
                                                       self.pid, id(RE))
 
@@ -58,7 +58,7 @@ class Publisher:
         doc = copy.deepcopy(doc)
         apply_to_dict_recursively(doc, sanitize_np)
         message = bytes(self._prefix)  # making a copy
-        message += b' '.join([name.encode(), pickle.dumps(doc)])
+        message += b'\x00'.join([name.encode(), pickle.dumps(doc)])
         self._socket.send(message)
 
     def close(self):

--- a/bluesky/callbacks/zmq.py
+++ b/bluesky/callbacks/zmq.py
@@ -34,7 +34,7 @@ class Publisher:
     >>> RE = RunEngine({})
     >>> publisher = Publisher('localhost:5567', RE=RE)
     """
-    def __init__(self, address, *, RE=None, zmq=None, prefix=None):
+    def __init__(self, address, *, RE=None, zmq=None, prefix=''):
         if prefix is None:
             prefix = ''
         if zmq is None:
@@ -46,12 +46,9 @@ class Publisher:
         self.hostname = socket.gethostname()
         self.pid = os.getpid()
         url = "tcp://%s:%d" % self.address
-        if prefix is not None:
-            self._prefix = b'%s %s %d %d ' % (prefix, self.hostname.encode(),
-                                              self.pid, id(RE))
-        else:
-            self._prefix = b'%s %s %d %d ' % (self.hostname.encode(), self.pid,
-                                              id(RE))
+        self._prefix = b'%s\x00%s\x00%d\x00%d\x00' % (prefix,
+                                                      self.hostname.encode(),
+                                                      self.pid, id(RE))
 
         self._context = zmq.Context()
         self._socket = self._context.socket(zmq.PUB)
@@ -212,7 +209,7 @@ class RemoteDispatcher(Dispatcher):
     >>> d.start()  # runs until interrupted
     """
     def __init__(self, address, *, hostname=None, pid=None, run_engine_id=None,
-                 loop=None, zmq=None, zmq_asyncio=None, prefix=None):
+                 loop=None, zmq=None, zmq_asyncio=None, prefix=''):
         self._message_prefix = prefix
         if zmq is None:
             import zmq
@@ -236,21 +233,15 @@ class RemoteDispatcher(Dispatcher):
         self._socket.setsockopt_string(zmq.SUBSCRIBE, "")
         self._task = None
 
-        def is_our_message(_hostname, _pid, _RE_id, message_prefix=None):
+        def is_our_message(_hostname, _pid, _RE_id, message_prefix):
             # Close over filters and decide if this message applies to this
             # RemoteDispatcher.
-            if message_prefix is not None:
-                return ((hostname is None or hostname == _hostname)
-                        and (pid is None or pid == _pid)
-                        and (run_engine_id is None or run_engine_id ==
-                            run_engine_id)
-                        and message_prefix == self._message_prefix
-                       )
-            else:
-                return ((hostname is None or hostname == _hostname)
-                        and (pid is None or pid == _pid)
-                        and (run_engine_id is None or run_engine_id ==
-                            run_engine_id))
+            return ((hostname is None or hostname == _hostname)
+                     and (pid is None or pid == _pid)
+                     and (run_engine_id is None or run_engine_id ==
+                          run_engine_id)
+                     and message_prefix == self._message_prefix
+                    )
 
         self._is_our_message = is_our_message
 
@@ -260,10 +251,7 @@ class RemoteDispatcher(Dispatcher):
     def _poll(self):
         while True:
             message = yield from self._socket.recv()
-            if self.message_prefix is not None:
-                prefix, hostname, pid, RE_id, name, doc = message.split(b' ', 5)
-            else:
-                hostname, pid, RE_id, name, doc = message.split(b' ', 5)
+            prefix, hostname, pid, RE_id, name, doc = message.split(b'\x00', 5)
             prefix = prefix.decode()
             hostname = hostname.decode()
             pid = int(pid)


### PR DESCRIPTION
## Description
Give "topics" to zmq messages managed by the `RemoteDispatcher` and `Publisher`.

## Motivation and Context

From discussion with @CJ-Wright 
He would like to multiplex to multiple zeroMQ instances from the same RunEngine.
A first step to that would be to allow passing of arbitrary prefixes to ZMQ messages that can be filtered upon receipt. This is similar to the idea how we use topics with Kafka (this prefix is basically like a topic, although of course the implementation is much different)

I propose that we allow adding a prefix to the zmq messages.

I would have opened an issue, but I found writing it out was an issue starting point for discussion.

This needs to be tested if there is general consensus that this is a good idea.

thanks!

## Alternatives
The user would have to do the filtering themselves downstream.
It is assumed that all the data is going through to the same zmq proxy.
Note that **all** messages still go through to the subscriber.

There is no notion of recipient based filtering.

## How Has This Been Tested?
Not tested yet

