### PR TITLE
Add Serializer to zmq callback

### DIFF
--- a/bluesky/callbacks/zmq.py
+++ b/bluesky/callbacks/zmq.py
@@ -33,7 +33,7 @@ class Publisher:
     >>> RE = RunEngine({})
     >>> publisher = Publisher('localhost:5567', RE=RE)
     """
-    def __init__(self, address, *, RE=None, zmq=None, serializer=None):
+    def __init__(self, address, *, RE=None, zmq=None, serializer=pickle.dumps):
         if zmq is None:
             import zmq
         if isinstance(address, str):
@@ -50,8 +50,6 @@ class Publisher:
         self._socket.connect(url)
         if RE:
             self._subscription_token = RE.subscribe(self)
-        if serializer is None:
-            serializer = pickle.dumps
         self._serializer = serializer
 
     def __call__(self, name, doc):
@@ -207,15 +205,14 @@ class RemoteDispatcher(Dispatcher):
     >>> d.start()  # runs until interrupted
     """
     def __init__(self, address, *, hostname=None, pid=None, run_engine_id=None,
-                 loop=None, zmq=None, zmq_asyncio=None, deserializer=None):
+                 loop=None, zmq=None, zmq_asyncio=None,
+                 deserializer=pickle.loads):
         if zmq is None:
             import zmq
         if zmq_asyncio is None:
             import zmq.asyncio as zmq_asyncio
         if isinstance(address, str):
             address = address.split(':', maxsplit=1)
-        if deserializer is None:
-            deserializer = pickle.loads
         self._deserializer = deserializer
         self.address = (address[0], int(address[1]))
         self.hostname = hostname

--- a/bluesky/callbacks/zmq.py
+++ b/bluesky/callbacks/zmq.py
@@ -24,6 +24,8 @@ class Publisher:
     zmq : object, optional
         By default, the 'zmq' module is imported and used. Anything else
         mocking its interface is accepted.
+    serializer: function, optional
+        optional function to serialize data. Default is pickle.dumps
 
     Example
     -------
@@ -194,6 +196,8 @@ class RemoteDispatcher(Dispatcher):
     zmq_asyncio : object, optional
         By default, the 'zmq.asyncio' module is imported and used. Anything
         else mocking its interface is accepted.
+    deserializer: function, optional
+        optional function to deserialize data. Default is pickle.loads
 
     Example
     -------

--- a/bluesky/callbacks/zmq.py
+++ b/bluesky/callbacks/zmq.py
@@ -50,8 +50,8 @@ class Publisher:
         self._socket.connect(url)
         if RE:
             self._subscription_token = RE.subscribe(self)
-        if serializer is None
-            serializer = pickel.dumps
+        if serializer is None:
+            serializer = pickle.dumps
         self._serializer = serializer
 
     def __call__(self, name, doc):

--- a/bluesky/tests/test_zmq.py
+++ b/bluesky/tests/test_zmq.py
@@ -8,6 +8,7 @@ import threading
 import time
 from bluesky.callbacks.zmq import Proxy, Publisher, RemoteDispatcher
 from bluesky.plans import count
+import cloudpickle
 
 
 def test_zmq(RE, hw):
@@ -144,6 +145,73 @@ def test_zmq_no_RE(RE):
             queue.put((name, doc))
 
         d = RemoteDispatcher('127.0.0.1:5568')
+        d.subscribe(put_in_queue)
+        print("REMOTE IS READY TO START")
+        d.loop.call_later(9, d.stop)
+        d.start()
+
+    queue = multiprocessing.Queue()
+    dispatcher_proc = multiprocessing.Process(target=make_and_start_dispatcher,
+                                              daemon=True, args=(queue,))
+    dispatcher_proc.start()
+    time.sleep(5)  # As above, give this plenty of time to start.
+
+    # Generate two documents. The Publisher will send them to the proxy
+    # device over 5567, and the proxy will send them to the
+    # RemoteDispatcher over 5568. The RemoteDispatcher will push them into
+    # the queue, where we can verify that they round-tripped.
+
+    local_accumulator = []
+
+    def local_cb(name, doc):
+        local_accumulator.append((name, doc))
+
+    RE([Msg('open_run'), Msg('close_run')], local_cb)
+
+    # This time the Publisher isn't attached to an RE. Send the documents
+    # manually. (The idea is, these might have come from a Broker instead...)
+    for name, doc in local_accumulator:
+        p(name, doc)
+    time.sleep(1)
+
+    # Get the two documents from the queue (or timeout --- test will fail)
+    remote_accumulator = []
+    for i in range(2):
+        remote_accumulator.append(queue.get(timeout=2))
+    p.close()
+    proxy_proc.terminate()
+    dispatcher_proc.terminate()
+    proxy_proc.join()
+    dispatcher_proc.join()
+    assert remote_accumulator == local_accumulator
+
+
+def test_zmq_no_RE_newserializer(RE):
+    # COMPONENT 1
+    # Run a 0MQ proxy on a separate process.
+    def start_proxy():
+        Proxy(5567, 5568).start()
+
+    proxy_proc = multiprocessing.Process(target=start_proxy, daemon=True)
+    proxy_proc.start()
+    time.sleep(5)  # Give this plenty of time to start up.
+
+    # COMPONENT 2
+    # Run a Publisher and a RunEngine in this main process.
+
+    p = Publisher('127.0.0.1:5567', serializer=cloudpickle.dumps)  # noqa
+
+    # COMPONENT 3
+    # Run a RemoteDispatcher on another separate process. Pass the documents
+    # it receives over a Queue to this process, so we can count them for our
+    # test.
+
+    def make_and_start_dispatcher(queue):
+        def put_in_queue(name, doc):
+            print('putting ', name, 'in queue')
+            queue.put((name, doc))
+
+        d = RemoteDispatcher('127.0.0.1:5568', deserializer=cloudpickle.loads)
         d.subscribe(put_in_queue)
         print("REMOTE IS READY TO START")
         d.loop.call_later(9, d.stop)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -24,3 +24,4 @@ streamz
 sphinx==1.6.4
 sphinx_rtd_theme
 tifffile
+cloudpickle

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 attrs
+cloudpickle
 coverage
 databroker
 doct
@@ -24,4 +25,3 @@ streamz
 sphinx==1.6.4
 sphinx_rtd_theme
 tifffile
-cloudpickle


### PR DESCRIPTION
For #1065 atn @CJ-Wright 

Note the prefix is not serialized using the serializer. This piece is interpreted internally by the zmq `Publisher` and `RemoteDispatcher`.