### PR TITLE
DOC: Include matplotlib in list of packages to install in tutorial.

### DIFF
--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -44,14 +44,14 @@ Before You Begin
 
   .. code-block:: bash
 
-     python3 -m pip install --upgrade bluesky ophyd databroker ipython
+     python3 -m pip install --upgrade bluesky ophyd databroker ipython matplotlib
 
   Alternatively, if you are a conda user and you prefer conda packages, you can
   use:
 
   .. code-block:: bash
 
-    conda install -c lightsource2-tag bluesky ophyd databroker ipython
+    conda install -c lightsource2-tag bluesky ophyd databroker ipython matplotlib
 
 * Start IPython:
 


### PR DESCRIPTION
As noted in #1086, the tutorial instructs users to pip- or conda-install
a set of packages but omits matplotlib. Since matplotlib is only an
optional dependency of bluesky, it has to be explicitly installed.