### PR TITLE
MNT: fix invalid escape sequences in strings

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -215,7 +215,7 @@ class BestEffortCallback(CallbackBase):
             # If any open figure matches 'figname {number}', use it. If there
             # are multiple, the most recently touched one will be used.
             pat1 = re.compile('^' + fig_name + '$')
-            pat2 = re.compile('^' + fig_name + ' \d+$')
+            pat2 = re.compile('^' + fig_name + r' \d+$')
             for label in plt.get_figlabels():
                 if pat1.match(label) or pat2.match(label):
                     fig_name = label

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -528,7 +528,7 @@ def tune_centroid(
         step_factor=3.0,
         snake=False,
         *, md=None):
-    """
+    r"""
     plan: tune a motor to the centroid of signal(motor)
 
     Initially, traverse the range from start to stop with


### PR DESCRIPTION
Fix invalid escape-sequence warnings from Python 3.6.