### PR TITLE
Customized scan_Id calculation method allowed 

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -91,8 +91,10 @@ _call_sig = Signature(
      Parameter('subs', Parameter.POSITIONAL_ONLY, default=None),
      Parameter('metadata_kw', Parameter.VAR_KEYWORD)])
 
+
 def default_scan_id_source(md):
     return md.get('scan_id', 0) + 1
+
 
 class RunEngine:
     """The Run Engine execute messages and emits Documents.

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -91,10 +91,8 @@ _call_sig = Signature(
      Parameter('subs', Parameter.POSITIONAL_ONLY, default=None),
      Parameter('metadata_kw', Parameter.VAR_KEYWORD)])
 
-#Default scan_id_source
 def default_scan_id_source(md):
-    scan_id = md.get('scan_id', 0) + 1
-    md['scan_id'] = scan_id
+    return md.get('scan_id', 0) + 1
 
 class RunEngine:
     """The Run Engine execute messages and emits Documents.
@@ -137,9 +135,11 @@ class RunEngine:
         ignored.
 
     scan_id_source : callable, optional
-        a function that will be use to calculate scan_id. Defaultis increment
-        scan_id 1 each time. However you could pass in a bespoken function to
-        get a complex scan_id
+        a function that will be used to calculate scan_id. Default is increment
+        scan_id 1 each time. However you could pass in a bespoke function to
+        get a scan_id from any source
+        Expected signature: f(md)
+        Expected return: updated scan_id value
 
     Attributes
     ----------
@@ -1353,7 +1353,7 @@ class RunEngine:
         self.log.debug("Starting new with uid %r", self._run_start_uid)
 
         # Run scan_id calculation method
-        self.scan_id_source(self.md)
+        self.md['scan_id'] = self.scan_id_source(self.md)
 
         # For metadata below, info about plan passed to self.__call__ for.
         plan_type = type(self._plan).__name__

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -135,9 +135,9 @@ class RunEngine:
         ignored.
 
     scan_id_source : callable, optional
-        a function that will be used to calculate scan_id. Default is increment
-        scan_id 1 each time. However you could pass in a bespoke function to
-        get a scan_id from any source
+        a function that will be used to calculate scan_id. Default is to 
+        increment scan_id by 1 each time. However you could pass in a 
+        customized function to get a scan_id from any source.
         Expected signature: f(md)
         Expected return: updated scan_id value
 

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -137,8 +137,8 @@ class RunEngine:
         ignored.
 
     scan_id_source : callable, optional
-        a function that will be used to calculate scan_id. Default is to 
-        increment scan_id by 1 each time. However you could pass in a 
+        a function that will be used to calculate scan_id. Default is to
+        increment scan_id by 1 each time. However you could pass in a
         customized function to get a scan_id from any source.
         Expected signature: f(md)
         Expected return: updated scan_id value
@@ -214,7 +214,7 @@ class RunEngine:
                              'remove_suspender']
 
     def __init__(self, md=None, *, loop=None, preprocessors=None,
-                 context_managers=None, md_validator=None, 
+                 context_managers=None, md_validator=None,
                  scan_id_source=default_scan_id_source):
         if loop is None:
             loop = asyncio.get_event_loop()


### PR DESCRIPTION
## Description
ENH: Allow RunEngine customize scan_id calculation

## Motivation and Context
Before the RunEngine will increase 1 each time for
scan_id. There isn't each way to change this scan_id
calculation method.
Since scan_id was created as a user-friendly number,
Now there is a callable argument scan_id_source to
allow user pass in a bespoken calculation method for
scan_id.

## How Has This Been Tested?
By pytest with /tests and bluesky tutorial example
The change is very limited and inside run_engine.py. It doesn't affects other code

## Screenshots (if appropriate):
====================================================== test session starts =======================================================
platform darwin -- Python 3.6.6, pytest-3.10.0, py-1.7.0, pluggy-0.8.0
rootdir: /Users/kz2249/bluesky, inifile:
collected 399 items                                                                                                              

test_bec.py .......                                                                                                        [  1%]
test_callbacks.py ........sss.....X..                                                                                      [  6%]
test_devices.py ..................                                                                                         [ 11%]
test_documents.py ..                                                                                                       [ 11%]
test_examples.py ......................................                                                                    [ 21%]
test_generators.py ...............                                                                                         [ 24%]
test_legacy_plans.py .                                                                                                     [ 25%]
test_magics.py ............                                                                                                [ 28%]
test_new_examples.py ..................................................................                                    [ 44%]
test_olog_cb.py ...                                                                                                        [ 45%]
test_plans.py ........                                                                                                     [ 47%]
test_progress_bar.py .....                                                                                                 [ 48%]
test_ramp_plan.py ..                                                                                                       [ 49%]
test_run_engine.py ........................................................................................                [ 71%]
test_scans.py .........................                                                                                    [ 77%]
test_scientific.py ..                                                                                                      [ 77%]
test_simple_api.py .................XXXXXXXXXXXXXXXX                                                                       [ 86%]
test_simulators.py ....                                                                                                    [ 87%]
test_snaking.py ...                                                                                                        [ 87%]
test_streams.py .s                                                                                                         [ 88%]
test_supplemental_data.py ........                                                                                         [ 90%]
test_suspenders.py ................                                                                                        [ 94%]
test_utils.py ...............                                                                                              [ 98%]
test_vertical_integration.py ...                                                                                           [ 98%]
test_zmq.py ....                                                                                                           [100%]

======================================================== warnings summary ========================================================
/Users/kz2249/bluesky/bluesky/examples.py:15
  /Users/kz2249/bluesky/bluesky/examples.py:15: UserWarning: 
  The simulated hardware objects in the bluesky.examples module have been
  moved to ophyd.sim. Update imports to suppress this warning.
      
    """)

/Users/kz2249/miniconda3/envs/py3/lib/python3.6/site-packages/IPython/lib/pretty.py:91
  /Users/kz2249/miniconda3/envs/py3/lib/python3.6/site-packages/IPython/lib/pretty.py:91: DeprecationWarning: IPython.utils.signatures backport for Python 2 is deprecated in IPython 6, which only supports Python 3
    from IPython.utils.signatures import signature

bluesky/tests/test_bec.py::test_live_grid
  /Users/kz2249/miniconda3/envs/py3/lib/python3.6/site-packages/matplotlib/axes/_base.py:1400: MatplotlibDeprecationWarning: The 'box-forced' keyword argument is deprecated since 2.2.
    " since 2.2.", cbook.mplDeprecation)

bluesky/tests/test_callbacks.py::test_table_external
  /Users/kz2249/miniconda3/envs/py3/lib/python3.6/site-packages/tifffile/tifffile.py:7685: UserWarning: No module named 'tifffile._tifffile'
    Functionality might be degraded or be slow.
  
    warnings.warn('%s%s' % (e, warn))

bluesky/tests/test_new_examples.py::test_caching_repeater
  /Users/kz2249/bluesky/bluesky/plan_stubs.py:883: UserWarning: The caching_repeater will be removed in a future version of bluesky.
    warnings.warn("The caching_repeater will be removed in a future version "

bluesky/tests/test_simple_api.py::test_plans[grid_scan-args12-kwargs12]
  /Users/kz2249/miniconda3/envs/py3/lib/python3.6/site-packages/matplotlib/axes/_base.py:1400: MatplotlibDeprecationWarning: The 'box-forced' keyword argument is deprecated since 2.2.
    " since 2.2.", cbook.mplDeprecation)

bluesky/tests/test_simple_api.py::test_plans_motors_no_hints[scan-args0-kwargs0]
  /Users/kz2249/miniconda3/envs/py3/lib/python3.6/site-packages/matplotlib/axes/_base.py:3124: UserWarning: Attempting to set identical left==right results
  in singular transformations; automatically expanding.
  left=1.0, right=1.0
    'left=%s, right=%s') % (left, right))
  /Users/kz2249/miniconda3/envs/py3/lib/python3.6/site-packages/matplotlib/axes/_base.py:3443: UserWarning: Attempting to set identical bottom==top results
  in singular transformations; automatically expanding.
  bottom=1.0, top=1.0
    'bottom=%s, top=%s') % (bottom, top))

bluesky/tests/test_simple_api.py::test_plans_motors_no_hints[inner_product_scan-args1-kwargs1]
  /Users/kz2249/miniconda3/envs/py3/lib/python3.6/site-packages/matplotlib/axes/_base.py:3124: UserWarning: Attempting to set identical left==right results
  in singular transformations; automatically expanding.
  left=1.0, right=1.0
    'left=%s, right=%s') % (left, right))
  /Users/kz2249/miniconda3/envs/py3/lib/python3.6/site-packages/matplotlib/axes/_base.py:3443: UserWarning: Attempting to set identical bottom==top results
  in singular transformations; automatically expanding.
  bottom=1.0, top=1.0
    'bottom=%s, top=%s') % (bottom, top))

bluesky/tests/test_simple_api.py::test_plans_motors_no_hints[relative_inner_product_scan-args2-kwargs2]
  /Users/kz2249/miniconda3/envs/py3/lib/python3.6/site-packages/matplotlib/axes/_base.py:3124: UserWarning: Attempting to set identical left==right results
  in singular transformations; automatically expanding.
  left=1.0, right=1.0
    'left=%s, right=%s') % (left, right))
  /Users/kz2249/miniconda3/envs/py3/lib/python3.6/site-packages/matplotlib/axes/_base.py:3443: UserWarning: Attempting to set identical bottom==top results
  in singular transformations; automatically expanding.
  bottom=1.0, top=1.0
    'bottom=%s, top=%s') % (bottom, top))

bluesky/tests/test_simple_api.py::test_plans_motor_empty_hints[scan-args0-kwargs0]
  /Users/kz2249/miniconda3/envs/py3/lib/python3.6/site-packages/matplotlib/axes/_base.py:3124: UserWarning: Attempting to set identical left==right results
  in singular transformations; automatically expanding.
  left=1.0, right=1.0
    'left=%s, right=%s') % (left, right))
  /Users/kz2249/miniconda3/envs/py3/lib/python3.6/site-packages/matplotlib/axes/_base.py:3443: UserWarning: Attempting to set identical bottom==top results
  in singular transformations; automatically expanding.
  bottom=1.0, top=1.0
    'bottom=%s, top=%s') % (bottom, top))

bluesky/tests/test_simple_api.py::test_plans_motor_empty_hints[inner_product_scan-args1-kwargs1]
  /Users/kz2249/miniconda3/envs/py3/lib/python3.6/site-packages/matplotlib/axes/_base.py:3124: UserWarning: Attempting to set identical left==right results
  in singular transformations; automatically expanding.
  left=1.0, right=1.0
    'left=%s, right=%s') % (left, right))
  /Users/kz2249/miniconda3/envs/py3/lib/python3.6/site-packages/matplotlib/axes/_base.py:3443: UserWarning: Attempting to set identical bottom==top results
  in singular transformations; automatically expanding.
  bottom=1.0, top=1.0
    'bottom=%s, top=%s') % (bottom, top))

bluesky/tests/test_simple_api.py::test_plans_motor_empty_hints[relative_inner_product_scan-args2-kwargs2]
  /Users/kz2249/miniconda3/envs/py3/lib/python3.6/site-packages/matplotlib/axes/_base.py:3124: UserWarning: Attempting to set identical left==right results
  in singular transformations; automatically expanding.
  left=1.0, right=1.0
    'left=%s, right=%s') % (left, right))
  /Users/kz2249/miniconda3/envs/py3/lib/python3.6/site-packages/matplotlib/axes/_base.py:3443: UserWarning: Attempting to set identical bottom==top results
  in singular transformations; automatically expanding.
  bottom=1.0, top=1.0
    'bottom=%s, top=%s') % (bottom, top))

bluesky/tests/test_suspenders.py::test_suspender[SuspendInBand-sc_args5-1-0-1-0.2]
  /Users/kz2249/bluesky/bluesky/suspenders.py:474: UserWarning: SuspendInBand has been renamed SuspendWhenOutsideBand to make its meaning more clear. Its behavior has not changed.
    warn("SuspendInBand has been renamed SuspendWhenOutsideBand to make "

bluesky/tests/test_suspenders.py::test_suspender[SuspendOutBand-sc_args6-0-1-0-0.2]
  /Users/kz2249/bluesky/bluesky/suspenders.py:506: UserWarning: bluesky.suspenders.SuspendOutBand is deprecated.
    warn("bluesky.suspenders.SuspendOutBand is deprecated.")

bluesky/tests/test_zmq.py::test_zmq_components
  /Users/kz2249/bluesky/bluesky/callbacks/zmq.py:227: DeprecationWarning: ZMQEventLoop and zmq.asyncio.install are deprecated in pyzmq 17. Special eventloop integration is no longer needed.
    loop = zmq_asyncio.ZMQEventLoop()

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================ 378 passed, 4 skipped, 17 xpassed, 21 warnings in 125.71 seconds ================================
