### PR TITLE
FIX/TST: Update RunEngine._create and tests for event-model 1.6.0.

### DIFF
--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -135,7 +135,7 @@ def conditional_pause(det, motor, defer, include_checkpoint):
 def simple_scan_saving(det, motor):
     "Set, trigger, read"
     yield Msg('open_run')
-    yield Msg('create')
+    yield Msg('create', name='primary')
     yield Msg('set', motor, 5)
     yield Msg('read', motor)
     yield Msg('trigger', det)
@@ -160,7 +160,7 @@ def cautious_stepscan(det, motor):
     yield Msg('open_run')
     for i in range(-5, 5):
         yield Msg('checkpoint')
-        yield Msg('create')
+        yield Msg('create', name='primary')
         yield Msg('set', motor, i)
         yield Msg('trigger', det)
         ret_m = yield Msg('read', motor)
@@ -191,7 +191,7 @@ def multi_sample_temperature_ramp(detector, sample_names, sample_positions,
                                   scan_motor, start, stop, step,
                                   temp_controller, tstart, tstop, tstep):
     def read_and_store_temp():
-        yield Msg('create')
+        yield Msg('create', name='primary')
         yield Msg('read', temp_controller)
         yield Msg('save')
 
@@ -219,7 +219,7 @@ def multi_sample_temperature_ramp(detector, sample_names, sample_positions,
                 # yield from read_and_store_temp()
                 yield Msg('trigger', detector)
                 # yield from read_and_store_temp()
-                yield Msg('create')
+                yield Msg('create', name='primary')
                 yield Msg('read', scan_motor)
                 yield Msg('read', detector)
                 yield Msg('read', temp_controller)

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -131,12 +131,16 @@ def test_table(RE, hw):
     with _print_redirect() as fout:
         hw.det.precision = 2
         hw.motor.precision = 2
+        hw.motor.setpoint.put(0.0)  # Make dtype 'number' not 'integer'.
+        hw.det.put(0.0)  # Make dtype 'number' not 'integer'.
         assert hw.det.describe()['det']['precision'] == 2
         assert hw.motor.describe()['motor']['precision'] == 2
+        assert hw.det.describe()['det']['dtype'] == 'number'
+        assert hw.motor.describe()['motor']['dtype'] == 'number'
 
         table = LiveTable(['det', 'motor'], min_width=16, extra_pad=2)
         ad_scan = bp.adaptive_scan([hw.det], 'det', hw.motor,
-                                   -15, 5, .01, 1, .05,
+                                   -15.0, 5., .01, 1, .05,
                                    True)
         # use lossless sub here because rows can get dropped
         token = RE.subscribe(table)

--- a/bluesky/tests/test_devices.py
+++ b/bluesky/tests/test_devices.py
@@ -10,11 +10,6 @@ from .utils import DocCollector
 
 if ophyd:
     from ophyd import Component as Cpt, Device, Signal
-    import epics
-    try:
-        ophyd.setup_ophyd()
-    except epics.ca.ChannelAccessException:
-        pass
 
     class A(Device):
         s1 = Cpt(Signal, value=0)

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -29,11 +29,11 @@ def test_msgs(RE, hw):
     assert m.args == tuple()
     assert m.kwargs == {}
 
-    m = Msg('create')
+    m = Msg('create', name='primary')
     assert m.command == 'create'
     assert m.obj is None
     assert m.args == tuple()
-    assert m.kwargs == {}
+    assert m.kwargs == {'name': 'primary'}
 
     m = Msg('sleep', None, 5)
     assert m.command == 'sleep'
@@ -268,7 +268,7 @@ def test_suspend(RE, hw):
         Msg('sleep', None, .2),
         Msg('set', hw.motor, 5),
         Msg('trigger', hw.det),
-        Msg('create'),
+        Msg('create', name='primary'),
         Msg('read', hw.motor),
         Msg('read', hw.det),
         Msg('save'),
@@ -408,17 +408,17 @@ def test_seqnum_nonrepeated(RE, hw):
 
     def gen():
         yield Msg('open_run')
-        yield Msg('create')
+        yield Msg('create', name='primary')
         yield Msg('set', hw.motor, 1)
         yield Msg('read', hw.motor)
         yield Msg('save')
         yield Msg('checkpoint')
-        yield Msg('create')
+        yield Msg('create', name='primary')
         yield Msg('set', hw.motor, 2)
         yield Msg('read', hw.motor)
         yield Msg('save')
         yield Msg('pause')
-        yield Msg('create')
+        yield Msg('create', name='primary')
         yield Msg('set', hw.motor, 3)
         yield Msg('read', hw.motor)
         yield Msg('save')
@@ -444,7 +444,7 @@ def test_duplicate_keys(RE, hw):
 
     def gen():
         yield(Msg('open_run'))
-        yield(Msg('create'))
+        yield(Msg('create', name='primary'))
         yield(Msg('trigger', hw.det))
         yield(Msg('trigger', hw.identical_det))
         yield(Msg('read', hw.det))
@@ -459,8 +459,8 @@ def test_illegal_sequences(RE, hw):
     def gen1():
         # two 'create' msgs in a row
         yield(Msg('open_run'))
-        yield(Msg('create'))
-        yield(Msg('create'))
+        yield(Msg('create', name='primary'))
+        yield(Msg('create', name='primary'))
         yield(Msg('close_run'))
 
     with pytest.raises(IllegalMessageSequence):
@@ -469,7 +469,7 @@ def test_illegal_sequences(RE, hw):
     def gen2():
         # two 'save' msgs in a row
         yield(Msg('open_run'))
-        yield(Msg('create'))
+        yield(Msg('create', name='primary'))
         yield(Msg('save'))
         yield(Msg('save'))
         yield(Msg('close_run'))
@@ -480,7 +480,7 @@ def test_illegal_sequences(RE, hw):
     def gen3():
         # 'configure' after 'create', before 'save'
         yield(Msg('open_run'))
-        yield(Msg('create'))
+        yield(Msg('create', name='primary'))
         yield(Msg('configure', hw.motor, {}))
 
     with pytest.raises(IllegalMessageSequence):
@@ -489,7 +489,7 @@ def test_illegal_sequences(RE, hw):
     def gen4():
         # two 'drop' msgs in a row
         yield(Msg('open_run'))
-        yield(Msg('create'))
+        yield(Msg('create', name='primary'))
         yield(Msg('drop'))
         yield(Msg('drop'))
         yield(Msg('close_run'))
@@ -507,11 +507,11 @@ def test_new_ev_desc(RE, hw):
     def gen1():
         # configure between two events -> two descs
         yield(Msg('open_run'))
-        yield(Msg('create'))
+        yield(Msg('create', name='primary'))
         yield(Msg('read', hw.motor))
         yield(Msg('save'))
         yield(Msg('configure', hw.motor, {}))
-        yield(Msg('create'))
+        yield(Msg('create', name='primary'))
         yield(Msg('read', hw.motor))
         yield(Msg('save'))
         yield(Msg('close_run'))
@@ -525,11 +525,11 @@ def test_new_ev_desc(RE, hw):
         # -> two descs
         yield(Msg('open_run'))
         yield(Msg('configure', hw.motor, {}))
-        yield(Msg('create'))
+        yield(Msg('create', name='primary'))
         yield(Msg('read', hw.motor))
         yield(Msg('save'))
         yield(Msg('configure', hw.motor, {}))
-        yield(Msg('create'))
+        yield(Msg('create', name='primary'))
         yield(Msg('read', hw.motor))
         yield(Msg('save'))
         yield(Msg('close_run'))
@@ -542,10 +542,10 @@ def test_new_ev_desc(RE, hw):
         # configure once before any events -> one desc
         yield(Msg('open_run'))
         yield(Msg('configure', hw.motor, {}))
-        yield(Msg('create'))
+        yield(Msg('create', name='primary'))
         yield(Msg('read', hw.motor))
         yield(Msg('save'))
-        yield(Msg('create'))
+        yield(Msg('create', name='primary'))
         yield(Msg('read', hw.motor))
         yield(Msg('save'))
         yield(Msg('close_run'))

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -35,7 +35,7 @@ def test_verbose(RE, hw):
     RE.verbose = True
     assert RE.verbose
     # Emit all four kinds of document, exercising the logging.
-    RE([Msg('open_run'), Msg('create'), Msg('read', hw.det), Msg('save'),
+    RE([Msg('open_run'), Msg('create', name='primary'), Msg('read', hw.det), Msg('save'),
         Msg('close_run')])
 
 
@@ -222,12 +222,12 @@ def test_dropping_without_an_open_bundle_is_illegal(RE):
 
 def test_opening_a_bundle_without_a_run_is_illegal(RE):
     with pytest.raises(IllegalMessageSequence):
-        RE([Msg('create')])
+        RE([Msg('create', name='primary')])
 
 
 def test_checkpoint_inside_a_bundle_is_illegal(RE):
     with pytest.raises(IllegalMessageSequence):
-        RE([Msg('open_run'), Msg('create'), Msg('checkpoint')])
+        RE([Msg('open_run'), Msg('create', name='primary'), Msg('checkpoint')])
 
 
 def test_redundant_monitors_are_illegal(RE):
@@ -308,14 +308,14 @@ def test_empty_bundle(RE, hw):
 
     # In this case, an Event should be emitted.
     mutable.clear()
-    RE([Msg('open_run'), Msg('create'), Msg('read', hw.det), Msg('save')],
+    RE([Msg('open_run'), Msg('create', name='primary'), Msg('read', hw.det), Msg('save')],
        {'event': cb})
     assert 'flag' in mutable
 
     # In this case, an Event should not be emitted because the bundle is
     # emtpy (i.e., there are no readings.)
     mutable.clear()
-    RE([Msg('open_run'), Msg('create'), Msg('save')], {'event': cb})
+    RE([Msg('open_run'), Msg('create', name='primary'), Msg('save')], {'event': cb})
     assert 'flag' not in mutable
 
 
@@ -1086,7 +1086,7 @@ def test_bad_from_idle_transitions(RE, change_func):
 def test_empty_cache_pause(RE):
     RE.rewindable = False
     pln = [Msg('open_run'),
-           Msg('create'),
+           Msg('create', name='primary'),
            Msg('pause'),
            Msg('save'),
            Msg('close_run')]
@@ -1406,7 +1406,7 @@ def test_drop(RE, hw):
     det = hw.det
 
     def inner(msg):
-        yield Msg('create')
+        yield Msg('create', name='primary')
         yield Msg('read', det)
         yield Msg(msg)
 
@@ -1445,11 +1445,11 @@ def test_failing_describe_callback(RE, hw):
     def plan():
         yield Msg('open_run')
         try:
-            yield Msg('create')
+            yield Msg('create', name='primary')
             yield Msg('read', det)
             yield Msg('save')
         finally:
-            yield Msg('create')
+            yield Msg('create', name='primary')
             yield Msg('read', det2)
             yield Msg('save')
         yield Msg('close_run')

--- a/bluesky/tests/test_streams.py
+++ b/bluesky/tests/test_streams.py
@@ -68,7 +68,7 @@ class AverageStream(LiveDispatcher):
             data_keys = self.raw_descriptors[desc_id]['data_keys']
             for key, info in data_keys.items():
                 # Information from non-number fields is dropped
-                if info['dtype'] in ('number', 'array'):
+                if info['dtype'] in ('number', 'array', 'integer'):
                     # Average together
                     average_evt[key] = np.mean([evt['data'][key]
                                                 for evt in cache], axis=0)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,7 +8,7 @@ ipython
 ipywidgets
 jinja2
 lmfit
-matplotlib
+matplotlib != 3.0.1  # bug in scatter method
 mongoquery
 networkx
 nose

--- a/doc/source/magics.rst
+++ b/doc/source/magics.rst
@@ -171,6 +171,7 @@ Previously, you could set a default list of detectors and them use ``%ct``
 without any parameters. This behaviour is deprecated. Do not use this:
 
 .. ipython:: python
+    :okwarning:
 
     BlueskyMagics.detectors = [area_detector, point_detector]
     %ct
@@ -183,6 +184,7 @@ Previously, it was possible to supply a list of motors. This feature is also
 deprecated. Do not use this:
 
 .. ipython:: python
+    :okwarning:
 
     BlueskyMagics.positioners = [motor1, motor2]
     %wa

--- a/fuzz/fuzz.py
+++ b/fuzz/fuzz.py
@@ -311,7 +311,7 @@ def run_fuzz():
     closerun_messages = [Msg('close_run')] * 10
     checkpoint_messages = [Msg('checkpoint')] * 10
     clear_checkpoint_messages = [Msg('clear_checkpoint')] * 10
-    create_messages = ([Msg('create')] * 5 +
+    create_messages = ([Msg('create', name='primary')] * 5 +
                        [Msg('create', name=unique_name()) for _ in range(5)])
     save_messages = [Msg('save')] * 10
     sleep_messages = [Msg('sleep', None, random.random() * 0.25) for _ in range(10)]


### PR DESCRIPTION
This should address the issue that has broken the bluesky CI since 29
August.

The "name" (i.e. stream name) item in Event Descriptors was introudced
in bluesky 0.4.x in February 2016. In the latest release of event-model,
1.6.0, we ensure that _if_ "name" is present its value must be a string.
This requirement breaks some old tests in bluesky, which generated Event
Descriptors with ``{'name': None, ...}``. We still allow name to be
absent, so that old data will still validate successfully.

It is not expected that much (or maybe any) production data has this
problem, because getting ``None`` requires manually spelling out
``Msg('create')``. The default name from ``bluesky.plan_stubs.create``
or high-level plans that call it is ``'primary'``.