### PR TITLE
ENH: Add optional file param to ts_msg_hook.

### DIFF
--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -974,14 +974,14 @@ def ensure_uid(doc_or_uid):
         return doc_or_uid
 
 
-def ts_msg_hook(msg):
+def ts_msg_hook(msg, file=sys.stdout):
     t = '{:%H:%M:%S.%f}'.format(datetime.datetime.now())
     msg_fmt = '{: <17s} -> {!s: <15s} args: {}, kwargs: {}'.format(
         msg.command,
         msg.obj.name if hasattr(msg.obj, 'name') else msg.obj,
         msg.args,
         msg.kwargs)
-    print('{} {}'.format(t, msg_fmt))
+    print('{} {}'.format(t, msg_fmt), file=file)
 
 
 def make_decorator(wrapper):


### PR DESCRIPTION
This will be passed through to print, and it has the same default value
is as print.

This allows usages like:

```
file = open('my_log_file', 'a')
import functools
func = functools.partial(ts_msg_hook, file=file)
RE.msg_hook = func
```

Somewhat moot once we can do with via the logger proposed in #1116, but
still probably worth doing.