### PR TITLE
Bluesky proxy verbose

### DIFF
--- a/bluesky/log.py
+++ b/bluesky/log.py
@@ -144,7 +144,7 @@ def set_handler(file=sys.stdout, datefmt='%H:%M:%S', color=True):
 
     Parameters
     ----------
-    file : object with ``write`` method
+    file : object with ``write`` method or filename string
         Default is ``sys.stdout``.
     datefmt : string
         Date format. Default is ``'%H:%M:%S'``.
@@ -160,7 +160,7 @@ def set_handler(file=sys.stdout, datefmt='%H:%M:%S', color=True):
     --------
     Log to a file.
 
-    >>> set_handler(file=open('/tmp/what_is_happening.txt'))
+    >>> set_handler(file='/tmp/what_is_happening.txt')
 
     Include the date along with the time. (The log messages will always include
     microseconds, which are configured separately, not as part of 'datefmt'.)
@@ -172,7 +172,10 @@ def set_handler(file=sys.stdout, datefmt='%H:%M:%S', color=True):
     >>> set_handler(color=False)
     """
     global current_handler
-    handler = logging.StreamHandler(file)
+    if isinstance(file, str):
+        handler = logging.FileHandler(file)
+    else:
+        handler = logging.StreamHandler(file)
     if color:
         format = color_log_format
     else:

--- a/scripts/bluesky-0MQ-proxy
+++ b/scripts/bluesky-0MQ-proxy
@@ -7,6 +7,13 @@ import sys
 from bluesky.callbacks.zmq import RemoteDispatcher
 
 def start_dispatcher(logfile):
+    """The dispatcher function
+    Parameters
+    ----------
+    logfile : string
+        string come from user command. ex --logfile=temp.log
+        logfile will be "temp.log". logfile could be empty.
+    """
     d = RemoteDispatcher('localhost:'+str(out_port))
     if logfile:
         logger = logging.getLogger('logfile')
@@ -16,7 +23,14 @@ def start_dispatcher(logfile):
         logger.addHandler(hdlr)
         logger.setLevel(logging.INFO) #Only write to file with logger.info or worse
         def log_writer(name, doc):
+            """logger's wrapper function
+                This function will be use to fit .subscribe() method.
+                It has two arguments as .subscribe expect. Inside, it
+                call logger.info to write doc which is a dict as a str
+                into logfile
+            """
             logger.info(str(doc))
+            print("Log",name ,"doc to", logfile)
         d.subscribe(log_writer) # Subscribe log writer
     else:
         d.subscribe(print)
@@ -41,10 +55,10 @@ if __name__ == "__main__":
         print("in_port:", in_port)
         print("out_port:", out_port)
         if args.verbose > 2:
-            obj = threading.Thread(target=start_dispatcher,
-                                    args=(args.logfile,),
-                                    daemon = True).start()  # Set daemon to all ipython exit
-                                                            # kill all threads
+            threading.Thread(target=start_dispatcher,
+                                args=(args.logfile,),
+                                daemon = True).start()  # Set daemon to all ipython exit
+                                                        # kill all threads
     print("Loading...")
     from bluesky.callbacks.zmq import Proxy  # this takes a couple seconds
     print("Connecting...")

--- a/scripts/bluesky-0MQ-proxy
+++ b/scripts/bluesky-0MQ-proxy
@@ -7,6 +7,10 @@ import sys
 from bluesky.callbacks.zmq import RemoteDispatcher
 from bluesky.log import set_handler
 
+
+logger = logging.getLogger('bluesky')
+
+
 def start_dispatcher(logfile):
     """The dispatcher function
     Parameters
@@ -16,18 +20,19 @@ def start_dispatcher(logfile):
         logfile will be "temp.log". logfile could be empty.
     """
     d = RemoteDispatcher(f'localhost:{out_port}')
-    logger = logging.getLogger('bluesky')
     if logfile:
         set_handler(file=logfile)
     def log_writer(name, doc):
         """logger's wrapper function
             This function will be use to fit .subscribe() method.
             It has two arguments as .subscribe expect. Inside, it
-            call logger.info to write doc which is a dict as a str
+            call logger.* to write doc which is a dict as a str
             into logfile
         """
-        logger.info(str(doc))
-        print("Log",name ,"doc to", logfile)
+        if name in ('start', 'stop'):
+            logger.info(f'{name}: {doc}')
+        else:
+            logger.debug(f'{name}: {doc}')
     d.subscribe(log_writer) # Subscribe log writer
     d.start()
 
@@ -40,18 +45,21 @@ if __name__ == "__main__":
     parser.add_argument('out_port', type=int, nargs=1,
                         help='port that subscribers should subscribe to')
     parser.add_argument('--verbose', '-v', action='count',
-                        help="Show more log messages. (Use -vvv for even more.)")
+                        help=("Show 'start' and 'stop' documents. "
+                              "(Use -vvv show to all documents.)"))
     parser.add_argument('--logfile', type=str,
                         help="Write logfile")
     args = parser.parse_args()
     in_port = args.in_port[0]
     out_port = args.out_port[0]
     if args.verbose:
+        logger.setLevel('INFO')
         if args.verbose > 2:
-            threading.Thread(target=start_dispatcher,
-                                args=(args.logfile,),
-                                daemon=True).start()  # Set daemon to all ipython exit
-                                                      # kill all threads
+            logger.setLevel('DEBUG')
+        threading.Thread(target=start_dispatcher,
+                            args=(args.logfile,),
+                            daemon=True).start()  # Set daemon to all ipython exit
+                                                  # kill all threads
     print("Loading...")
     from bluesky.callbacks.zmq import Proxy  # this takes a couple seconds
     print("Connecting...")

--- a/scripts/bluesky-0MQ-proxy
+++ b/scripts/bluesky-0MQ-proxy
@@ -30,9 +30,9 @@ def start_dispatcher(logfile):
             into logfile
         """
         if name in ('start', 'stop'):
-            logger.info(f'{name}: {doc}')
+            logger.info("%s: %r", name, doc)
         else:
-            logger.debug(f'{name}: {doc}')
+            logger.debug("%s: %r", name, doc)
     dispatcher.subscribe(log_writer) # Subscribe log writer
     dispatcher.start()
 

--- a/scripts/bluesky-0MQ-proxy
+++ b/scripts/bluesky-0MQ-proxy
@@ -46,7 +46,7 @@ if __name__ == "__main__":
                         help='port that subscribers should subscribe to')
     parser.add_argument('--verbose', '-v', action='count',
                         help=("Show 'start' and 'stop' documents. "
-                              "(Use -vvv show to all documents.)"))
+                              "(Use -vvv to show to all documents.)"))
     parser.add_argument('--logfile', type=str,
                         help="Write logfile")
     args = parser.parse_args()

--- a/scripts/bluesky-0MQ-proxy
+++ b/scripts/bluesky-0MQ-proxy
@@ -46,7 +46,7 @@ if __name__ == "__main__":
                         help='port that subscribers should subscribe to')
     parser.add_argument('--verbose', '-v', action='count',
                         help=("Show 'start' and 'stop' documents. "
-                              "(Use -vvv to show to all documents.)"))
+                              "(Use -vvv to show all documents.)"))
     parser.add_argument('--logfile', type=str,
                         help="Write logfile")
     args = parser.parse_args()

--- a/scripts/bluesky-0MQ-proxy
+++ b/scripts/bluesky-0MQ-proxy
@@ -19,7 +19,7 @@ def start_dispatcher(logfile):
         string come from user command. ex --logfile=temp.log
         logfile will be "temp.log". logfile could be empty.
     """
-    d = RemoteDispatcher(f'localhost:{out_port}')
+    dispatcher = RemoteDispatcher(f'localhost:{out_port}')
     if logfile:
         set_handler(file=logfile)
     def log_writer(name, doc):
@@ -33,8 +33,8 @@ def start_dispatcher(logfile):
             logger.info(f'{name}: {doc}')
         else:
             logger.debug(f'{name}: {doc}')
-    d.subscribe(log_writer) # Subscribe log writer
-    d.start()
+    dispatcher.subscribe(log_writer) # Subscribe log writer
+    dispatcher.start()
 
 
 if __name__ == "__main__":

--- a/scripts/bluesky-0MQ-proxy
+++ b/scripts/bluesky-0MQ-proxy
@@ -1,12 +1,27 @@
 #!/usr/bin/env python3
-from bluesky.callbacks.zmq import RemoteDispatcher
 import threading
 import argparse
+import logging
+import sys
 
-def start_dispatcher():
+from bluesky.callbacks.zmq import RemoteDispatcher
+
+def start_dispatcher(logfile):
     d = RemoteDispatcher('localhost:'+str(out_port))
-    d.subscribe(print)
+    if logfile:
+        logger = logging.getLogger('logfile')
+        hdlr = logging.FileHandler(logfile)
+        formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
+        hdlr.setFormatter(formatter)
+        logger.addHandler(hdlr)
+        logger.setLevel(logging.INFO) #Only write to file with logger.info or worse
+        def log_writer(name, doc):
+            logger.info(str(doc))
+        d.subscribe(log_writer) # Subscribe log writer
+    else:
+        d.subscribe(print)
     d.start()
+
 
 if __name__ == "__main__":
     DESC = "Start a 0MQ proxy for publishing bluesky documents over a network."
@@ -17,7 +32,8 @@ if __name__ == "__main__":
                         help='port that subscribers should subscribe to')
     parser.add_argument('--verbose', '-v', action='count',
                         help="Show more log messages. (Use -vvv for even more.)")
-
+    parser.add_argument('--logfile', type=str,
+                        help="Write logfile ")
     args = parser.parse_args()
     in_port = args.in_port[0]
     out_port = args.out_port[0]

--- a/scripts/bluesky-0MQ-proxy
+++ b/scripts/bluesky-0MQ-proxy
@@ -14,8 +14,9 @@ def start_dispatcher(logfile):
         string come from user command. ex --logfile=temp.log
         logfile will be "temp.log". logfile could be empty.
     """
-    d = RemoteDispatcher('localhost:'+str(out_port))
+    d = RemoteDispatcher(f'localhost:{out_port}')
     if logfile:
+        print("inside log")
         logger = logging.getLogger('logfile')
         hdlr = logging.FileHandler(logfile)
         formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')

--- a/scripts/bluesky-0MQ-proxy
+++ b/scripts/bluesky-0MQ-proxy
@@ -25,7 +25,10 @@ if __name__ == "__main__":
         print("in_port:", in_port)
         print("out_port:", out_port)
         if args.verbose > 2:
-            threading.Thread(target=start_dispatcher).start()
+            obj = threading.Thread(target=start_dispatcher,
+                                    args=(args.logfile,),
+                                    daemon = True).start()  # Set daemon to all ipython exit
+                                                            # kill all threads
     print("Loading...")
     from bluesky.callbacks.zmq import Proxy  # this takes a couple seconds
     print("Connecting...")

--- a/scripts/bluesky-0MQ-proxy
+++ b/scripts/bluesky-0MQ-proxy
@@ -5,6 +5,7 @@ import logging
 import sys
 
 from bluesky.callbacks.zmq import RemoteDispatcher
+from bluesky.log import set_handler
 
 def start_dispatcher(logfile):
     """The dispatcher function
@@ -15,26 +16,19 @@ def start_dispatcher(logfile):
         logfile will be "temp.log". logfile could be empty.
     """
     d = RemoteDispatcher(f'localhost:{out_port}')
+    logger = logging.getLogger('bluesky')
     if logfile:
-        print("inside log")
-        logger = logging.getLogger('logfile')
-        hdlr = logging.FileHandler(logfile)
-        formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
-        hdlr.setFormatter(formatter)
-        logger.addHandler(hdlr)
-        logger.setLevel(logging.INFO) #Only write to file with logger.info or worse
-        def log_writer(name, doc):
-            """logger's wrapper function
-                This function will be use to fit .subscribe() method.
-                It has two arguments as .subscribe expect. Inside, it
-                call logger.info to write doc which is a dict as a str
-                into logfile
-            """
-            logger.info(str(doc))
-            print("Log",name ,"doc to", logfile)
-        d.subscribe(log_writer) # Subscribe log writer
-    else:
-        d.subscribe(print)
+        set_handler(file=logfile)
+    def log_writer(name, doc):
+        """logger's wrapper function
+            This function will be use to fit .subscribe() method.
+            It has two arguments as .subscribe expect. Inside, it
+            call logger.info to write doc which is a dict as a str
+            into logfile
+        """
+        logger.info(str(doc))
+        print("Log",name ,"doc to", logfile)
+    d.subscribe(log_writer) # Subscribe log writer
     d.start()
 
 
@@ -48,18 +42,16 @@ if __name__ == "__main__":
     parser.add_argument('--verbose', '-v', action='count',
                         help="Show more log messages. (Use -vvv for even more.)")
     parser.add_argument('--logfile', type=str,
-                        help="Write logfile ")
+                        help="Write logfile")
     args = parser.parse_args()
     in_port = args.in_port[0]
     out_port = args.out_port[0]
     if args.verbose:
-        print("in_port:", in_port)
-        print("out_port:", out_port)
         if args.verbose > 2:
             threading.Thread(target=start_dispatcher,
                                 args=(args.logfile,),
-                                daemon = True).start()  # Set daemon to all ipython exit
-                                                        # kill all threads
+                                daemon=True).start()  # Set daemon to all ipython exit
+                                                      # kill all threads
     print("Loading...")
     from bluesky.callbacks.zmq import Proxy  # this takes a couple seconds
     print("Connecting...")

--- a/scripts/bluesky-0MQ-proxy
+++ b/scripts/bluesky-0MQ-proxy
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
+from bluesky.callbacks.zmq import RemoteDispatcher
+import threading
 import argparse
 
+def start_dispatcher():
+    d = RemoteDispatcher('localhost:'+str(out_port))
+    d.subscribe(print)
+    d.start()
 
 if __name__ == "__main__":
     DESC = "Start a 0MQ proxy for publishing bluesky documents over a network."
@@ -9,10 +15,17 @@ if __name__ == "__main__":
                         help='port that RunEngines should broadcast to')
     parser.add_argument('out_port', type=int, nargs=1,
                         help='port that subscribers should subscribe to')
+    parser.add_argument('--verbose', '-v', action='count',
+                        help="Show more log messages. (Use -vvv for even more.)")
+
     args = parser.parse_args()
     in_port = args.in_port[0]
     out_port = args.out_port[0]
-
+    if args.verbose:
+        print("in_port:", in_port)
+        print("out_port:", out_port)
+        if args.verbose > 2:
+            threading.Thread(target=start_dispatcher).start()
     print("Loading...")
     from bluesky.callbacks.zmq import Proxy  # this takes a couple seconds
     print("Connecting...")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add --verbose and --logfile feature to bluesky-proxy
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
User friendly 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In terminal, run ipython
$ ipython --matplotlib=qt5
In ipython, run scirpts which will start proxy and RemoteDispatcher, in_port and out_port needed
%run -i bluesky-0MQ-proxy 5577 5578
If we add --verbose and --logfile=temp.log
%run -i bluesky-0MQ-proxy 5577 5578 --verbose --logfile=temp.log
<!--
## Screenshots (if appropriate):
-->
