### PR TITLE
Make `CallbackBase` composable

### DIFF
--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -42,7 +42,13 @@ LiveMesh = _deprecate_import_name("LiveMesh")
 class CallbackBase:
     def __call__(self, name, doc):
         "Dispatch to methods expecting particular doc types."
-        return getattr(self, name)(doc)
+        # if callback returns it will return a new dict document
+        ret = getattr(self, name)(doc)
+        if ret:
+            return name, ret
+        # if the return is None (very likely for most callbacks)
+        # give back the original name, doc pair
+        return name, doc
 
     def event(self, doc):
         pass

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -456,11 +456,11 @@ def test_plotting_hints(RE, hw, db):
 
 
 def test_callback_return(RE, hw):
-    class c(CallbackBase):
+    class C(CallbackBase):
         def start(self, doc):
             doc.update({'hello': 'world'})
             return doc
     L = []
-    cc = c()
+    cc = C()
     RE(stepscan(hw.det, hw.motor), {'all': lambda *x: L.append(cc(*x))})
     assert L[0][1]['hello'] == 'world'

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -453,3 +453,14 @@ def test_plotting_hints(RE, hw, db):
     RE(grid_scan([hw.det], hw.motor1, -1, 1, 2, hw.motor2, -1, 1, 2,
                  True, hw.motor3, -2, 0, 2, True))
     assert dc.start[-1]['hints'] == hint
+
+
+def test_callback_return(RE, hw):
+    class c(CallbackBase):
+        def start(self, doc):
+            doc.update({'hello': 'world'})
+            return doc
+    L = []
+    cc = c()
+    RE(stepscan(hw.det, hw.motor), {'all': lambda *x: L.append(cc(*x))})
+    assert L[0][1]['hello'] == 'world'


### PR DESCRIPTION
The `CallbackBase` has returned to it's home repo of Bluesky...

This allows subclasses of `CallbackBase` to return mutated documents.
This could be very useful for things like live databroker exporting
which would mutate the resource and datum documents for the new
filepaths to the copied files.


This seems more flexable and has some nice usecases for very simple
pipelines/document mutation