### PR TITLE
FIX: eliminate race condition in bec test

### DIFF
--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -91,15 +91,15 @@ def test_live_grid(RE, hw):
 
 def test_plot_ints(RE):
     from ophyd import Signal
-    from ophyd.utils import set_and_wait
     from bluesky.callbacks.best_effort import BestEffortCallback
     from bluesky.plans import count
+    import bluesky.plan_stubs as bps
 
     bec = BestEffortCallback()
     RE.subscribe(bec)
 
     s = Signal(name='s')
-    set_and_wait(s, int(0))
+    RE(bps.mov(s, int(0)))
     assert s.describe()['s']['dtype'] == 'integer'
     s.kind = 'hinted'
     with pytest.warns(None) as record:

--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -91,6 +91,7 @@ def test_live_grid(RE, hw):
 
 def test_plot_ints(RE):
     from ophyd import Signal
+    from ophyd.utils import set_and_wait
     from bluesky.callbacks.best_effort import BestEffortCallback
     from bluesky.plans import count
 
@@ -98,7 +99,7 @@ def test_plot_ints(RE):
     RE.subscribe(bec)
 
     s = Signal(name='s')
-    s.set(int(0))
+    set_and_wait(s, int(0))
     assert s.describe()['s']['dtype'] == 'integer'
     s.kind = 'hinted'
     with pytest.warns(None) as record:


### PR DESCRIPTION
The `set` method on Signal uses a background thread to actually set
the value.  This was leading to race conditions on travis where
sometimes the value would not actually be set before we check it.

Use set_and_wait instead.