### PR TITLE
FIX: fix mpl callbacks

### DIFF
--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -12,34 +12,6 @@ from ..utils import ensure_uid
 logger = logging.getLogger(__name__)
 
 
-# deprecate callbacks moved to mpl_plotting ----------------------------------
-
-def _deprecate_import_name(name):
-    wmsg = (
-        "In a future version of bluesky, {} will not be importable from "
-        "bluesky.callbacks.core or bluesky.callbacks. Instead, import it from "
-        "bluesky.callbacks.mpl_plotting. This change allows other callbacks, "
-        "unrelated to matplotlib, to be imported and used without importing "
-        "matplotlib.pyplot or configuring a DISPLAY."
-    ).format(name)
-    def f(*args, **kwargs):
-        # per bluesky convention use UserWarning instead of DeprecationWarning
-        warnings.warn(wmsg, UserWarning)
-        from . import mpl_plotting
-        cls = getattr(mpl_plotting, name)
-        return cls(*args, **kwargs)
-    f.__name__ = name
-    return f
-
-LiveScatter = _deprecate_import_name("LiveScatter")
-LivePlot = _deprecate_import_name("LivePlot")
-LiveGrid = _deprecate_import_name("LiveGrid")
-LiveFitPlot = _deprecate_import_name("LiveFitPlot")
-LiveRaster = _deprecate_import_name("LiveRaster")
-LiveMesh = _deprecate_import_name("LiveMesh")
-
-# ----------------------------------------------------------------------------
-
 class CallbackBase:
     def __call__(self, name, doc):
         "Dispatch to methods expecting particular doc types."
@@ -142,6 +114,32 @@ def get_obj_fields(fields):
             string_fields.extend(field_list)
     return string_fields
 
+
+# deprecate callbacks moved to mpl_plotting ----------------------------------
+
+def _deprecate_import_name(name):
+    wmsg = (
+        "In a future version of bluesky, {} will not be importable from "
+        "bluesky.callbacks.core or bluesky.callbacks. Instead, import it from "
+        "bluesky.callbacks.mpl_plotting. This change allows other callbacks, "
+        "unrelated to matplotlib, to be imported and used without importing "
+        "matplotlib.pyplot or configuring a DISPLAY."
+    ).format(name)
+    # per bluesky convention use UserWarning instead of DeprecationWarning
+    warnings.warn(wmsg, UserWarning)
+    from . import mpl_plotting
+    cls = getattr(mpl_plotting, name)
+    cls.__name__ = name
+    return cls
+
+LiveScatter = _deprecate_import_name("LiveScatter")
+LivePlot = _deprecate_import_name("LivePlot")
+LiveGrid = _deprecate_import_name("LiveGrid")
+LiveFitPlot = _deprecate_import_name("LiveFitPlot")
+LiveRaster = _deprecate_import_name("LiveRaster")
+LiveMesh = _deprecate_import_name("LiveMesh")
+
+# ----------------------------------------------------------------------------
 
 class CollectThenCompute(CallbackBase):
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add backwards-compatibility when using the mpl callbacks the old way.
**Note**: the block of code in this PR had to be moved down after `CallbackBase` and `get_obj_fields` were defined, so that they are available when importing `mpl_plotting`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was observed at NSLS-II QAS with @lcdesilva when the `LivePlot` failed to be subclassed with the master bluesky ([link](https://github.com/NSLS-II-QAS/profile_collection/blob/e5bbfb1135c1e482b82f371b507ca1c63f66963c/startup/05-aux-classes.py#L2)).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Successfully tested locally.

<!--
## Screenshots (if appropriate):
-->
