### PR TITLE
DOC: Release notes v1.5.0

### DIFF
--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -2,6 +2,61 @@
  Release History
 =================
 
+v1.5.0 (2019-01-03)
+===================
+
+This release includes many documentation fixes and handful of new features,
+especially around improved logging.
+
+Features
+--------
+
+* Logging has been increased and improved.
+* A default handler is added to the ``'bluesky'`` logger at import time. A new
+  convenience function, :func:`~bluesky.set_handler`, addresses common cases
+  such as directing the log output to a file.
+* The ``bluesky-0MQ-proxy`` script now supports a ``-v, --verbose`` option,
+  which logs every start and stop document received and a ``-vvv`` ("very
+  verbose")` option, which logs every document of every type.
+* The prefix on messages sent by :class:`bluesky.callbacks.zmq.Publisher` can
+  be set to arbitrary bytes. (In previous versions, the prefix was hardcoded to
+  an encoded combination of the hostname, process ID, and the Python object ID
+  of a RunEngine intance.)
+* The RunEngine includes a human-readable, not-necessarily-unique ``scan_id``
+  key in the RunStart document. The source of the ``scan_id`` is now pluggable
+  via a new parameter, ``scan_id_source``. See :doc:`run_engine_api` for
+  details.
+* The convenience function, :func:`bluesky.utils.ts_msg_hook` accepts new
+  parameter ``file`` for directing the output to a file instead of the standard
+  out.
+* It is possible to use those callbacks that do not require matplotlib without
+  importing matplotlib.
+
+Bug Fixes
+---------
+
+* Fixed BestEffortCallback's handling of integer data in plots.
+* Fixed invalid escape sequence that produced a warning in Python 3.6.
+
+Breaking Changes
+----------------
+
+* The siganture of :class:`bluesky.callbacks.zmq.RemoteDispatcher` has been
+  changed in a non-backward-compatbile way. The parameters for filtering
+  messages by ``hostname``, ``pid``, and ``run_engine_id`` have been replaced
+  by one new parameter, ``prefix``.
+* The default value of ``RunEngine.verbose`` is now ``True``, meaning that the
+  ``RunEngine.log`` is *not* disabled by default.
+
+Deprecations
+------------
+
+* The :class:`bluesky.callbacks.zmq.Publisher` accepts an optional RunEngine
+  instance, which the Publisher subscribes to automatically. This parameter has
+  been deprecated; users are now encouraged to subscribe the publisher the
+  RunEngine manually, in the normal way (``RE.subscribe(publisher)``). The
+  parameter may be removed in a future release of bluesky.
+
 v1.4.1 (2018-09-24)
 ===================
 

--- a/doc/source/debugging.rst
+++ b/doc/source/debugging.rst
@@ -1,148 +1,53 @@
 Debugging and Logging
 =====================
 
-Message Hook
-------------
+Bluesky uses Python logging framework. See below for a list of the names of the
+loggers it publishes to.
+
+Useful Snippets
+---------------
 
 If the RunEngine is "hanging," running slowly, or repeatedly encountering an
 error, it is useful to know exactly where in the plan the problem is occurring.
-To follow the RunEngine's progress through the plan, use the message hook. You
-can set it to any callable, including the ``print`` function:
+To follow the RunEngine's progress through the plan, crank up the verbosity of
+the logging.
 
 .. code-block:: python
 
-    RE.msg_hook = print
+   RE.log.setLevel('DEBUG')
 
-or a small utility that formats a more readable message and includes a
-timestamp:
-
-.. code-block:: python
-
-    from bluesky.utils import ts_msg_hook
-
-    RE.msg_hook = ts_msg_hook
-
-Now the RunEngine will call ``ts_msg_hook(msg)`` before processing each ``msg``
-in the plan. Execute the plan that is causing the issue and watch the output.
-Suppose we are running a ``count`` that freezes up while triggering a detector.
-That would look like this:
-
-.. ipython::
-    :verbatim:
-
-    In [8]: RE(count([det]))
-    11:39:06.712560 stage             -> det             args: (), kwargs: {}
-    11:39:06.715281 open_run          -> None            args: (), kwargs:
-    {'detectors': ['det'], 'num_points': 1, 'num_intervals': 0, 'plan_args':
-    {'detectors': ["SynGauss(name='det', value=1.0, timestamp=1516379938.010617)"],
-    'num': 1}, 'plan_name': 'count', 'hints': {'dimensions': [(('time',),
-    'primary')]}}
-    11:39:06.717813 checkpoint        -> None            args: (), kwargs: {}
-    11:39:06.718076 trigger           -> det             args: (), kwargs:
-    {'group': 'trigger-0487d9'}
-    11:39:06.718659 wait              -> None            args: (), kwargs:
-    {'group': 'trigger-0487d9'}
-
-The last message is is a 'wait' message, and it waiting for the 'trigger' just
-above it to complete. If the plan freezes at this point, a likely culprit is
-the triggering mechanism of the detector. In this example, we can see the
-detector in question is a simulated detector, ``ophyd.sim.SynGauss``.
-From here we would investigate whether the hardware was behaving properly and
-whether its triggering behavior was programmed properly on the Python side.
-
-When finished troubleshooting, set ``RE.msg_hook = None``.
-
-Any user-defined function that accepts a ``bluesky.Msg`` namedtuple as its
-argument could also be used. For example, to write to a file:
+To direct the output to a file instead of to the screen:
 
 .. code-block:: python
 
-    from bluesky.utils import ts_msg_hook
+   from bluesky import set_handler
+   set_handler(file='debugging_bluesky.txt')
 
-    def append_to_file(msg):
-        with open('myfile.log', 'a') as file:
-            ts_msg_hook(msg, file=file)
+Logger Names
+------------
 
-    RE.msg_hook = append_to_file
+Here is the complete list of loggers used by bluesky.
 
-State Hook
-----------
+* ``'bluesky'`` --- the logger to which all bluesky log messages propagate
+* ``'bluesky.RE'`` --- Messages from a RunEngine. INFO-level notes state
+  changes. DEBUG-level notes when a each message from a plan is about to be
+  processed, when a document has been emitted to subscribed callbacks, and when
+  a status object has completed.
+* ``'bluesky.RE.<id>'`` --- Messages from a specific RunEngine instance,
+  disambiguating the (rare) case where there are multiple in the same process.
+  This is the logger than the accessor ``RE.log`` refers to.
+* ``'bluesky.RE.<id>.msg'`` --- DEBUG-level notes when each message from a plan
+  is about to be processed.
 
-The RunEngine can be in one of three states:
+Logging Handlers
+----------------
 
-* 'idle' (ready to accept a new plan)
-* 'running' (running the event loop and processing a plan)
-* 'paused' (not running the event loop, but holding onto state in preparation
-  for possibly resuming)
+By default, bluesky prints log messages to the standard out by adding a
+:class:`logging.StreamHandler` to the ``'bluesky'`` logger at import time. You
+can, of course, configure the handlers manually in the standard fashion
+supported by Python. But a convenience function :func:`bluesky.set_handler`,
+makes it easy to address to common cases.
 
-The state is exposed through the RunEngine's ``state`` attribute. To monitor
-changes in state, use the ``state_hook`` attribute. Like ``msg_hook`` above, it
-can be set to ``None`` (default) or a function. In this case, the function
-should accept two arguments: the new state and the previous state.
+See the Examples section below.
 
-Logging
--------
-
-The RunEngine integrates with Python's built-in logging framework. It provides
-a convenient attribute for configuring logging quickly.
-
-.. code-block:: python
-
-    # standard Python logging setup
-    import logging
-    logging.basicConfig()
-    
-    RE.log.disabled = False
-
-With this configuration, executing a plan prints log messages to the screen.
-
-The logger issues INFO-level messages whenever the RunEngine changes state
-(idle -> running, running -> paused, etc.) and DEBUG-level messages whenever a
-new Document is created and emitted to the subscriptions. Demo:
-
-.. code-block:: python
-
-    In [3]: RE(count([det]))
-    Out[3]: ['f015945c-7e9f-4d2c-9a83-d1db1b31fb43']
-
-    In [4]: RE.verbose = True
-
-    In [5]: RE(count([det]))
-    INFO:bluesky.run_engine_id4371931376:Change state on
-    <bluesky.run_engine.RunEngine object at 0x1049660f0> from 'idle' ->
-    'running'
-    DEBUG:bluesky.run_engine_id4371931376:Starting new with uid
-    '4f3e173f-3383-49a4-94bc-cac571144c4d'
-    DEBUG:bluesky.run_engine_id4371931376:Emitted RunStart
-    (uid='4f3e173f-3383-49a4-94bc-cac571144c4d')
-    DEBUG:bluesky.run_engine_id4371931376:The object reader: det reports
-    trigger is done with status True.
-    DEBUG:bluesky.run_engine_id4371931376:Emitted Event Descriptor with name
-    'primary' containing data keys dict_keys(['det'])
-    (uid='400f6d4a-db5d-454b-9b1c-5e759eb8511b')
-    DEBUG:bluesky.run_engine_id4371931376:Emitted Event with data keys
-    dict_keys(['det']) (uid='dd2dedba-4ac7-4761-a94a-2e65c1579aa8')
-    DEBUG:bluesky.run_engine_id4371931376:Stopping run
-    '4f3e173f-3383-49a4-94bc-cac571144c4d'
-    DEBUG:bluesky.run_engine_id4371931376:Emitted RunStop
-    (uid='654f4bfb-043f-4b81-9a8f-371ce276caf3')
-    INFO:bluesky.run_engine_id4371931376:Change state on
-    <bluesky.run_engine.RunEngine object at 0x1049660f0> from 'running' ->
-    'idle'
-    Out[5]: ['4f3e173f-3383-49a4-94bc-cac571144c4d']
-
-The log messages include the Python id of the RunEngine instance (``id(RE)``)
-in case logs from multiple instances end up in the same file.
-
-The ``RE.log`` attribute is a standard Python logger object. For example, to
-change the log level to skip DEBUG-level messages:
-
-.. code-block:: python
-
-    RE.log.setLevel(logging.INFO)
-
-.. note::
-
-    For back-compatibility with old versions of bluesky, there is also an
-    ``RE.verbose`` attribute. ``RE.verbose`` is a synonym for
-    ``not RE.log.disabled``.
+.. autofunction:: bluesky.set_handler


### PR DESCRIPTION
Includes an update to the logging documentation, reflecting the recent
changes to logging. Note that ``msg_hook`` and ``state_hook`` are
separately documented in the "Run Engine API" page, so that
documentation has been removed from the logging page now that we can get
the same information more easily and more readably from loggers.

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
-->