### PR TITLE
MNT: stop using deprecated API in matplotlib

### DIFF
--- a/bluesky/callbacks/mpl_plotting.py
+++ b/bluesky/callbacks/mpl_plotting.py
@@ -95,7 +95,7 @@ class LivePlot(CallbackBase):
         self.current_line, = self.ax.plot([], [], **kwargs)
         self.lines.append(self.current_line)
         self.legend = self.ax.legend(
-            loc=0, title=self.legend_title).draggable()
+            loc=0, title=self.legend_title).set_draggable(True)
         super().start(doc)
 
     def event(self, doc):


### PR DESCRIPTION
This fails with AttributeError on Matplotlib master and will fail on
3.1 (coming next month).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->