### PR TITLE
Add dev-requirements for test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,7 @@ jobs:
 
   - script: |
       pip install pytest
+      pip install -r dev-requirements.txt
       pytest bluesky/tests --doctest-modules --junitxml=junit/test-results.xml
     displayName: 'pytest'
 


### PR DESCRIPTION
The tests fail due do some packages not being installed.  As these are in the `dev-requirements.txt` I am just installing them here.  I am happy to trim down from this to specific packages if we want to explicitly state them.  But as the travis build just includes them all upfront anyway and doesn't differentiate, I'm not sure we care.