### PR TITLE
ENH: use the ISO8601 delimiters for date

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -139,7 +139,7 @@ class BestEffortCallback(CallbackBase):
         if self._heading_enabled:
             print("Transient Scan ID: {0}     Time: {1}".format(
                 self._start_doc['scan_id'],
-                time.strftime("%Y/%m/%d %H:%M:%S", tt)))
+                time.strftime("%Y-%m-%d %H:%M:%S", tt)))
             print("Persistent Unique Scan ID: '{0}'".format(
                 self._start_doc['uid']))
 


### PR DESCRIPTION
ISO8601 date delimiter is "-", not "/"

space between date and time is now accepted as modification of ISO8601 standard so no change there

<!--- Provide a general summary of your changes in the Title above -->

## Description
Existing: `Transient Scan ID: 17     Time: 2019/02/22 14:22:52`

Revised: `Transient Scan ID: 17     Time: 2019-02-22 14:22:52`

## Motivation and Context
Cosmetics:  why not use ISO standard format here?

