### PR TITLE
CI: Add codecov config.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+# show coverage in CI status, not as a comment. 
+comment: off
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+    patch:
+      default:
+        target: auto


### PR DESCRIPTION
This configuration file, which we have recent adopted on several other
projects retains the codecov X/checkmark in the "merge" box but
suppresses the large comment.