### PR TITLE
DOC: remove reference to relocated code

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1573,6 +1573,10 @@ def fly(flyers, *, md=None):
     msg : Msg
         'kickoff', 'wait', 'complete, 'wait', 'collect' messages
 
+    See Also
+    --------
+    :func:`bluesky.preprocessors.fly_during_wrapper`
+    :func:`bluesky.preprocessors.fly_during_decorator`
     """
     yield from bps.open_run(md)
     for flyer in flyers:

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1573,9 +1573,6 @@ def fly(flyers, *, md=None):
     msg : Msg
         'kickoff', 'wait', 'complete, 'wait', 'collect' messages
 
-    See Also
-    --------
-    :func:`bluesky.plans.fly_during`
     """
     yield from bps.open_run(md)
     for flyer in flyers:


### PR DESCRIPTION
Seems the `fly_during()` plan was dropped sometime in late March-early April of 2016.  It had moved from `plans.py` to `plan_tools.py` and later moved again in a code cleanup.  I just spent time looking for it.  Time to identify its new location.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
