### PR TITLE
MNT: add more helpful error message if obj.read returns None

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1488,9 +1488,10 @@ class RunEngine:
         ret = obj.read(*msg.args, **msg.kwargs)
 
         if ret is None:
-            raise RuntimeError(f"The read of {obj.name} returned None. "
-                               "This is a bug in your object implementation, "
-                               "`read` must return a dictionary ")
+            raise RuntimeError(
+                "The read of {nm} returned None. ".format(nm=obj.name) +
+                "This is a bug in your object implementation, "
+                "`read` must return a dictionary ")
 
         if self._bundling:
             # if the object is not in the _describe_cache, cache it

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1487,6 +1487,11 @@ class RunEngine:
         # actually _read_ the object
         ret = obj.read(*msg.args, **msg.kwargs)
 
+        if ret is None:
+            raise RuntimeError(f"The read of {obj.name} returned None. "
+                               "This is a bug in your object implementation, "
+                               "`read` must return a dictionary ")
+
         if self._bundling:
             # if the object is not in the _describe_cache, cache it
             if obj not in self._describe_cache:

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1467,6 +1467,7 @@ def test_failing_describe_callback(RE, hw):
     with pytest.raises(TestException):
         RE(plan())
 
+
 def test_print_commands(RE):
     ''' test the printing of commands available.
         NOTE : An error here likely just means that this interface has changed.
@@ -1494,3 +1495,25 @@ def test_print_commands(RE):
 
     print_command_reg2 = RE.print_command_registry()
     assert print_command_reg1 == print_command_reg2
+
+
+def test_broken_read_exception(RE):
+    class Dummy:
+        def __init__(self, name):
+            self.name = name
+
+        def read_configuration(self):
+            return {}
+
+        def describe_configuration(self):
+            return {}
+
+        def describe(self):
+            return {}
+
+        def read(self):
+            ...
+
+    obj = Dummy('broken read')
+    with pytest.raises(RuntimeError):
+        RE([Msg('read', obj)])


### PR DESCRIPTION
This would have lead to a much clearer traceback at a beamline.

Ran into this working with @EliotGann If `read` returned `None` you got an exception in `save` when we try to collate the results.  This moves the failure to much when it happens and provides better exception (I ended up doing a binary search on a long list of baseline devices to find the problem).

If other also think this is a good idea I'll throw a test onto it.