### PR TITLE
ENH: provide a way to exclude scan_id

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1353,7 +1353,11 @@ class RunEngine:
         self._run_start_uids.append(self._run_start_uid)
 
         # Run scan_id calculation method
-        self.md['scan_id'] = self.scan_id_source(self.md)
+        if self.scan_id_source is not None:
+            self.md['scan_id'] = self.scan_id_source(self.md)
+        else:
+            if 'scan_id' in self.md:
+                del self.md['scan_id']
 
         # For metadata below, info about plan passed to self.__call__ for.
         plan_type = type(self._plan).__name__


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Provides a way to exclude the `scan_id` field from metadata.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
@prjemian's [snapshot](https://aps-bluesky-tools.readthedocs.io/en/latest/snapshot.html) tool allows to get PV data into a Beamline's databroker, however, it's not aware of the latest `scan_id`, and starts from scratch (`scan_id=1`):
```py
In [8]: db[-1].start
Out[8]:
{'time': 1556900218.8359325,
 'uid': '<REDACTED>',
 'plan_description': 'archive snapshot of ophyd Signals (usually EPICS PVs)',
 'purpose': 'archive a set of EPICS PVs',
 'plan_type': 'generator',
 'plan_name': 'snapshot',
 'software_versions': {'python': '3.6.7 |Anaconda, Inc.| (default, Oct 23 2018, 19:16:44) \n[GCC 7.3.0]',
  'PyEpics': '3.3.3',
  'bluesky': '1.5.2',
  'ophyd': '1.3.3',
  'databroker': '0.12.2',
  'apstools': '1.1.0'},
 'hostname': '<REDACTED>',
 'username': 'mrakitin',
 'scan_id': 1,
 'login_id': '<REDACTED>',
 'iso8601': '2019-05-03 12:16:58.835718',
 'hints': {}}
```
This PR attempts to prepare a way for the tool (and not only for it) to not have the `scan_id` in such scans at all.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To be tested.

<!--
## Screenshots (if appropriate):
-->
